### PR TITLE
fix PROXY_HOST变量设置后，仍无法访问tg、tmdb的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ docker pull jxxghp/moviepilot:latest
 - **SUPERUSER：** 超级管理员用户名，默认`admin`，安装后使用该用户登录后台管理界面
 - **SUPERUSER_PASSWORD：** 超级管理员初始密码，默认`password`，建议修改为复杂密码
 - **API_TOKEN：** API密钥，默认`moviepilot`，在媒体服务器Webhook、微信回调等地址配置中需要加上`?token=`该值，建议修改为复杂字符串
-- **PROXY_HOST：** 网络代理（可选），访问themoviedb需要使用代理访问，格式为`ip:port`
+- **PROXY_HOST：** 网络代理（可选），访问themoviedb需要使用代理访问，格式为`http(s)://ip:port`
 - **TMDB_API_DOMAIN：** TMDB API地址，默认`api.themoviedb.org`，也可配置为`api.tmdb.org`或其它中转代理服务地址，能连通即可
 - **DOWNLOAD_PATH：** 下载保存目录，**注意：需要将`moviepilot`及`下载器`的映射路径与宿主机`真实路径`保持一致**，例如群晖中下载路程径为`/volume1/downloads`，则需要将`moviepilot`及`下载器`的映射路径均设置为`/volume1/downloads`，否则会导致下载文件无法转移
 - **LIBRARY_PATH：** 媒体库目录，**注意：需要将`moviepilot`的映射路径与宿主机`真实路径`保持一致**，多个目录使用`,`分隔

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -183,8 +183,8 @@ class Settings(BaseSettings):
     def PROXY(self):
         if self.PROXY_HOST:
             return {
-                "http": f"http://{self.PROXY_HOST}",
-                "https": f"https://{self.PROXY_HOST}"
+                "http": {self.PROXY_HOST},
+                "https": {self.PROXY_HOST},
             }
         return None
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -183,8 +183,8 @@ class Settings(BaseSettings):
     def PROXY(self):
         if self.PROXY_HOST:
             return {
-                "http": {self.PROXY_HOST},
-                "https": {self.PROXY_HOST},
+                "http": self.PROXY_HOST,
+                "https": self.PROXY_HOST,
             }
         return None
 


### PR DESCRIPTION
如果 PROXY_HOST 填写 192.168.31.2:1081 的话

按照以前逻辑就是
  return {
                "http": "http://192.168.31.2:1081",
                "https": "https://192.168.31.2:1081"
            }

实际上 https://192.168.31.2:1081 访问不通，导致tg、tmdb都不法代理访问


不如让用户直接填写http(s)://ip:port