### PR TITLE
uvicorn server初始化，reload传参错误

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.analysis.typeCheckingMode": "basic"
+}

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -21,8 +21,8 @@ class Settings(BaseSettings):
     HOST: str = "0.0.0.0"
     # API监听端口
     PORT: int = 3001
-    # 是否调试模式
-    DEBUG: bool = False
+    # 日志级别: 'critical', 'error', 'warning', 'info', 'debug', 'trace', 默认为error, 如需调试可以设置为debug
+    DEBUG_LEVEL: str = "error"
     # 配置文件目录
     CONFIG_DIR: str = None
     # 超级管理员

--- a/app/main.py
+++ b/app/main.py
@@ -29,7 +29,7 @@ App.add_middleware(
 
 # uvicorn服务
 Server = uvicorn.Server(Config(App, host=settings.HOST, port=settings.PORT,
-                               reload=settings.DEBUG, workers=multiprocessing.cpu_count()))
+                               log_level=settings.DEBUG, workers=multiprocessing.cpu_count()))
 
 
 def init_routers():


### PR DESCRIPTION
如果需要启动debug日志，需要设置debug_level为debug，否则默认为info.