### PR TITLE
fix 兽站签到bug

### DIFF
--- a/app/plugins/autosignin/sites/hd4fans.py
+++ b/app/plugins/autosignin/sites/hd4fans.py
@@ -57,7 +57,7 @@ class HD4fans(_ISiteSigninHandler):
             return False, '签到失败，cookie失效'
 
         # 判断是否已签到
-        if self._repeat_text in html_text:
+        if self._success_text in html_text:
             logger.info(f"{site} 今日已签到")
             return True, '今日已签到'
 


### PR DESCRIPTION
源代码中判断逻辑为
`_repeat_text = '<span id="checkedin">[签到成功]</span>' `
查看兽站网页源码应该为
`_repeat_text = '<span id="checkedin" style="display: none;">[签到成功]</span>' `
个人感觉 直接判断'签到成功'更为妥当
发现代码中已经定义 变量为
`_success_text='签到成功'`
不知道原开发者为何这样写 所以说明一下