### PR TITLE
feat 电影电视剧下载一级目录

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ docker pull jxxghp/moviepilot:latest
 - **PROXY_HOST：** 网络代理（可选），访问themoviedb需要使用代理访问，格式为`http(s)://ip:port`
 - **TMDB_API_DOMAIN：** TMDB API地址，默认`api.themoviedb.org`，也可配置为`api.tmdb.org`或其它中转代理服务地址，能连通即可
 - **DOWNLOAD_PATH：** 下载保存目录，**注意：需要将`moviepilot`及`下载器`的映射路径与宿主机`真实路径`保持一致**，例如群晖中下载路程径为`/volume1/downloads`，则需要将`moviepilot`及`下载器`的映射路径均设置为`/volume1/downloads`，否则会导致下载文件无法转移
+- **DOWNLOAD_MOVIE_PATH：** 电影下载保存目录，**必须是DOWNLOAD_PATH的下级路径**，不设置则下载到DOWNLOAD_PATH
+- **DOWNLOAD_TV_PATH：** 电视剧下载保存目录，**必须是DOWNLOAD_PATH的下级路径**，不设置则下载到DOWNLOAD_PATH
 - **DOWNLOAD_CATEGORY：** 下载二级分类开关，`true`/`false`，默认`false`，开启后会根据配置`category.yaml`自动在下载目录下建立二级目录分类
 - **TORRENT_TAG：** 种子标签，默认为`MOVIEPILOT`，设置后只有MoviePilot添加的下载才会处理，留空所有下载器中的任务均会处理
 - **LIBRARY_PATH：** 媒体库目录，**注意：需要将`moviepilot`的映射路径与宿主机`真实路径`保持一致**，多个目录使用`,`分隔

--- a/app/chain/download.py
+++ b/app/chain/download.py
@@ -104,7 +104,15 @@ class DownloadChain(ChainBase):
                 return
         # 下载目录
         if settings.DOWNLOAD_CATEGORY and _media and _media.category:
-            download_dir = Path(settings.DOWNLOAD_PATH) / _media.category
+            if _media.type == MediaType.MOVIE:
+                download_dir = Path(settings.DOWNLOAD_MOVIE_PATH) / _media.category
+            else:
+                download_dir = Path(settings.DOWNLOAD_TV_PATH) / _media.category
+        elif _media:
+            if _media.type == MediaType.MOVIE:
+                download_dir = Path(settings.DOWNLOAD_MOVIE_PATH)
+            else:
+                download_dir = Path(settings.DOWNLOAD_TV_PATH)
         else:
             download_dir = Path(settings.DOWNLOAD_PATH)
         # 添加下载

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -109,6 +109,10 @@ class Settings(BaseSettings):
     TORRENT_TAG: str = "MOVIEPILOT"
     # 下载保存目录，容器内映射路径需要一致
     DOWNLOAD_PATH: str = "/downloads"
+    # 电影下载保存目录，容器内映射路径需要一致
+    DOWNLOAD_MOVIE_PATH: str = DOWNLOAD_PATH
+    # 电视剧下载保存目录，容器内映射路径需要一致
+    DOWNLOAD_TV_PATH: str = DOWNLOAD_PATH
     # 下载目录二级分类
     DOWNLOAD_CATEGORY: bool = False
     # 媒体服务器 emby/jellyfin/plex


### PR DESCRIPTION
![image](https://github.com/jxxghp/MoviePilot/assets/54088512/2aac1654-4f25-4eac-aab7-d7ad0bbf21fc)
    # 下载保存目录，容器内映射路径需要一致
    DOWNLOAD_PATH: str = "/downloads"
    # 电影下载保存目录，容器内映射路径需要一致
    DOWNLOAD_MOVIE_PATH: str = DOWNLOAD_PATH
    # 电视剧下载保存目录，容器内映射路径需要一致
    DOWNLOAD_TV_PATH: str = DOWNLOAD_PATH

不填默认用DOWNLOAD_PATH