### PR TITLE
fix 豆瓣榜单插件

### DIFF
--- a/app/plugins/doubanrank/__init__.py
+++ b/app/plugins/doubanrank/__init__.py
@@ -430,7 +430,7 @@ class DoubanRank(_PluginBase):
             "onlyonce": self._onlyonce,
             "vote": self._vote,
             "ranks": self._ranks,
-            "rss_addrs": self._rss_addrs,
+            "rss_addrs": '\n'.join(map(str, self._rss_addrs)),
             "clear": self._clear
         })
 


### PR DESCRIPTION
每次运行完保存配置list转str类型，字符串是,分隔 ，下次再运行时用\n分割 得不到正确的rss地址