### PR TITLE
bump: python 3.11.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,10 +65,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Init Python 3.11.4
+      - name: Init Python 3.11.6
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11.4'
+          python-version: '3.11.6'
           cache: 'pip'
 
       - name: Install Dependent Packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.4-slim-bullseye
+FROM python:3.11.6-slim-bullseye
 ARG MOVIEPILOT_VERSION
 ENV LANG="C.UTF-8" \
     TZ="Asia/Shanghai" \


### PR DESCRIPTION
If you don’t want to upgrade, just close this PR.