### PR TITLE
fix torrent_cache ttl

### DIFF
--- a/app/chain/torrents.py
+++ b/app/chain/torrents.py
@@ -60,7 +60,7 @@ class TorrentsChain(ChainBase, metaclass=Singleton):
         else:
             return self.load_cache(self._rss_file) or {}
 
-    @cached(cache=TTLCache(maxsize=128, ttl=600))
+    @cached(cache=TTLCache(maxsize=128, ttl=595))
     def browse(self, domain: str) -> List[TorrentInfo]:
         """
         浏览站点首页内容，返回种子清单，TTL缓存10分钟
@@ -73,7 +73,7 @@ class TorrentsChain(ChainBase, metaclass=Singleton):
             return []
         return self.refresh_torrents(site=site)
 
-    @cached(cache=TTLCache(maxsize=128, ttl=300))
+    @cached(cache=TTLCache(maxsize=128, ttl=295))
     def rss(self, domain: str) -> List[TorrentInfo]:
         """
         获取站点RSS内容，返回种子清单，TTL缓存5分钟


### PR DESCRIPTION
当 rss 和 search interval 设置为min的时候，ttl最后一秒没过期，导致 min_interval*2 生效，受影响的有brush，和rss订阅。