### PR TITLE
fix singleton.py

### DIFF
--- a/app/utils/singleton.py
+++ b/app/utils/singleton.py
@@ -9,9 +9,10 @@ class Singleton(abc.ABCMeta, type):
     _instances: dict = {}
 
     def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
-        return cls._instances[cls]
+        key = (cls, args, frozenset(kwargs.items()))
+        if key not in cls._instances:
+            cls._instances[key] = super().__call__(*args, **kwargs)
+        return cls._instances[key]
 
 
 class AbstractSingleton(abc.ABC, metaclass=Singleton):


### PR DESCRIPTION
方便插件创建多个下载器对象，用来的单例模式不管构造函数的参数是否不同，都是同一个对象，涉及多个下载器的插件编写不了。
改动后
![image](https://github.com/jxxghp/MoviePilot/assets/57806936/9de8a994-66dc-4ff2-951a-7f53b2b9ca92)
