### PR TITLE
fix: 清空 MediaServerItem 表

### DIFF
--- a/app/chain/mediaserver.py
+++ b/app/chain/mediaserver.py
@@ -52,7 +52,7 @@ class MediaServerChain(ChainBase):
             # 汇总统计
             total_count = 0
             # 清空登记薄
-            self.dboper.empty(server=settings.MEDIASERVER)
+            self.dboper.empty()
             # 同步黑名单
             sync_blacklist = settings.MEDIASERVER_SYNC_BLACKLIST.split(
                 ",") if settings.MEDIASERVER_SYNC_BLACKLIST else []

--- a/app/db/mediaserver_oper.py
+++ b/app/db/mediaserver_oper.py
@@ -25,7 +25,7 @@ class MediaServerOper(DbOper):
             return True
         return False
 
-    def empty(self, server: str):
+    def empty(self, server: Optional[str] = None):
         """
         清空媒体服务器数据
         """

--- a/app/db/models/mediaserver.py
+++ b/app/db/models/mediaserver.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 
 from sqlalchemy import Column, Integer, String, Sequence
 from sqlalchemy.orm import Session
@@ -9,7 +10,7 @@ from app.db.models import Base, db_update
 
 class MediaServerItem(Base):
     """
-    站点表
+    媒体服务器媒体条目表
     """
     id = Column(Integer, Sequence('id'), primary_key=True, index=True)
     # 服务器类型
@@ -48,8 +49,11 @@ class MediaServerItem(Base):
 
     @staticmethod
     @db_update
-    def empty(db: Session, server: str):
-        db.query(MediaServerItem).filter(MediaServerItem.server == server).delete()
+    def empty(db: Session, server: Optional[str] = None):
+        if server is None:
+            db.query(MediaServerItem).delete()
+        else:
+            db.query(MediaServerItem).filter(MediaServerItem.server == server).delete()
 
     @staticmethod
     @db_query


### PR DESCRIPTION
`MediaServerItem` 以下情况出现残留：

1. 配置多类型 `MEDIASERVER`；
2. 之前配置了多个类型 `MEDIASERVER`，后减少一种类型

当前修改直接清空 MediaServerItem 表