### PR TITLE
修复无法入库消息发送到 Telegram 时格式异常

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -259,8 +259,8 @@ class TransferChain(ChainBase):
                     )
                     self.post_message(Notification(
                         mtype=NotificationType.Manual,
-                        title=f"{file_path.name} 未识别到媒体信息，无法入库！\n"
-                              f"回复：```\n/redo {his.id} [tmdbid]|[类型]\n``` 手动识别转移。"
+                        title=f"{file_path.name} 未识别到媒体信息，无法入库！",
+                        text=f"回复：```\n/redo {his.id} [tmdbid]|[类型]\n``` 手动识别转移。"
                     ))
                     # 计数
                     processed_num += 1


### PR DESCRIPTION
由于 Telegram 发送消息的实现将 title 包在了一个加粗的 tag 中 https://github.com/jxxghp/MoviePilot/blob/7d7539df4cae2ad47ec14852b6beca5875d7017a/app/modules/telegram/telegram.py#L83C26-L83C26

导致其中的代码块异常
![CleanShot 2023-12-11 at 17 53 35@2x](https://github.com/jxxghp/MoviePilot/assets/3138493/c51f1c23-06ba-4287-a3af-1c3771d78be0)

PR 将消息拆分成了 title 和 text，代码块放在了 text 中，显示就正常了
![CleanShot 2023-12-11 at 17 54 39@2x](https://github.com/jxxghp/MoviePilot/assets/3138493/5d286acb-3765-4b4c-81f7-b28e1564ff1d)

同时检查了，其他推送渠道都是将 title 和 text 拼接，应该是没有影响的