### PR TITLE
fix 集如果带有.会刮削错误

### DIFF
--- a/app/modules/themoviedb/scraper.py
+++ b/app/modules/themoviedb/scraper.py
@@ -135,7 +135,8 @@ class TmdbScraper:
                                                        file_path=file_path)
                     # 集的图片
                     episode_image = episodeinfo.get("still_path")
-                    image_path = file_path.with_name(file_path.stem + "-thumb").with_suffix(Path(episode_image).suffix)
+                    image_path = file_path.with_name(file_path.stem + "-thumb.jpg").with_suffix(
+                        Path(episode_image).suffix)
                     if episode_image and (self._force_img or not image_path.exists()):
                         self.__save_image(
                             f"https://{settings.TMDB_IMAGE_DOMAIN}/t/p/original{episode_image}",


### PR DESCRIPTION
迷宫饭 - S01E01 - 1080p - WEB-DL - X264 - DDP 5.1 - NF - ADWeb.mkv

![image](https://github.com/jxxghp/MoviePilot/assets/54088512/39e24b80-9a5b-45c5-9483-1dc9a196d4d1)

刮削集图片出错。

file_path.with_name(file_path.stem + "-thumb") 返回结果是

`迷宫饭 - S01E01 - 1080p - WEB-DL - X264 - DDP 5.1 - NF - ADWeb-thumb`

file_path.with_name(file_path.stem + "-thumb").with_suffix(Path(episode_image).suffix)时，会把`.1 - NF - ADWeb-thumb`当做后缀替换成`.jpg`

得到错误的集缩略图`迷宫饭 - S01E01 - 1080p - WEB-DL - X264 - DDP 5.jpg`

预先给他一个后缀名就OK，这个预先的后缀名会被替换成正确的后缀名

`.with_suffix(suffix) 添加后缀，会把最后一个.之后的内容作为后缀名，如果已经有后缀则替换`