### PR TITLE
fix:修复bearer auth请求头设置错误,导致github_token参数应用失败

### DIFF
--- a/update
+++ b/update
@@ -84,7 +84,7 @@ if [[ "${MOVIEPILOT_AUTO_UPDATE}" = "true" ]] || [[ "${MOVIEPILOT_AUTO_UPDATE}" 
         echo "不使用代理更新程序"
     fi
     if [ -n "${GITHUB_TOKEN}" ]; then
-        CURL_HEADERS="--header 'Authorization: Bearer ${GITHUB_TOKEN}'"
+        CURL_HEADERS="--oauth2-bearer ${GITHUB_TOKEN}"
     else
         CURL_HEADERS=""
     fi


### PR DESCRIPTION
之前通过`CURL_HEADERS="--header 'Authorization: Bearer ${GITHUB_TOKEN}'"`的方式设置认证请求头，命令实际执行的时候，会报错，导致`GITHUB_TOKEN`参数应用失败，具体错误如下所示：
```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5770  100  5770    0     0   8877      0 --:--:-- --:--:-- --:--:--  8945
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: Bearer
curl: (3) URL using bad/illegal format or missing URL
```