### PR TITLE
fix: 更新qbittorrent下载判断值

### DIFF
--- a/app/modules/qbittorrent/__init__.py
+++ b/app/modules/qbittorrent/__init__.py
@@ -206,7 +206,7 @@ class QbittorrentModule(_ModuleBase):
                     season_episode=meta.season_episode,
                     progress=torrent.get('progress') * 100,
                     size=torrent.get('total_size'),
-                    state="paused" if torrent.get('state') == "paused" else "downloading",
+                    state="paused" if torrent.get('state') == "pausedDL" else "downloading",
                     dlspeed=StringUtils.str_filesize(torrent.get('dlspeed')),
                     upspeed=StringUtils.str_filesize(torrent.get('upspeed')),
                     left_time=StringUtils.str_secends(


### PR DESCRIPTION
https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-list 

pausedDL	Torrent is paused and has NOT finished downloading

官网看到的值是pausedDL 而不是 paused