### PR TITLE
Fixed #1416

### DIFF
--- a/app/chain/search.py
+++ b/app/chain/search.py
@@ -425,7 +425,7 @@ class SearchChain(ChainBase):
                     size = movie_size
                 # 大小范围
                 begin_size, end_size = __get_size_range(size)
-                if begin_size and end_size:
+                if begin_size is not None and end_size is not None:
                     meta = MetaInfo(title=t.title, subtitle=t.description)
                     # 集数
                     if mediainfo.type == MediaType.TV:


### PR DESCRIPTION
如果限制的大小的最小值是 0或者不填时会出问题

```
a = 0

if a:
    print("ahh")
else:
    print("kljlkj")
```

会打印 kljlkj，在项目中就会当前没有 begin_size 处理，就会导致大小限制失效