### PR TITLE
让自定义站点可自行设置: 搜索结果条数/请求超时

### DIFF
--- a/app/chain/torrents.py
+++ b/app/chain/torrents.py
@@ -98,7 +98,7 @@ class TorrentsChain(ChainBase, metaclass=Singleton):
         if not site.get("rss"):
             logger.error(f'站点 {domain} 未配置RSS地址！')
             return []
-        rss_items = self.rsshelper.parse(site.get("rss"), True if site.get("proxy") else False)
+        rss_items = self.rsshelper.parse(site.get("rss"), True if site.get("proxy") else False, timeout=int(site.get("timeout") or 30))
         if rss_items is None:
             # rss过期，尝试保留原配置生成新的rss
             self.__renew_rss_url(domain=domain, site=site)

--- a/app/helper/rss.py
+++ b/app/helper/rss.py
@@ -224,11 +224,12 @@ class RssHelper:
     }
 
     @staticmethod
-    def parse(url, proxy: bool = False) -> Union[List[dict], None]:
+    def parse(url, proxy: bool = False, timeout: int = 30) -> Union[List[dict], None]:
         """
         解析RSS订阅URL，获取RSS中的种子信息
         :param url: RSS地址
         :param proxy: 是否使用代理
+        :param timeout: 请求超时
         :return: 种子信息列表，如为None代表Rss过期
         """
         # 开始处理
@@ -236,7 +237,7 @@ class RssHelper:
         if not url:
             return []
         try:
-            ret = RequestUtils(proxies=settings.PROXY if proxy else None).get_res(url)
+            ret = RequestUtils(proxies=settings.PROXY if proxy else None, timeout=timeout).get_res(url)
             if not ret:
                 return []
         except Exception as err:

--- a/app/modules/indexer/spider.py
+++ b/app/modules/indexer/spider.py
@@ -56,12 +56,14 @@ class TorrentSpider:
     fields: dict = {}
     # 页码
     page: int = 0
-    # 搜索条数
+    # 搜索条数, 默认: 100条
     result_num: int = 100
     # 单个种子信息
     torrents_info: dict = {}
     # 种子列表
     torrents_info_array: list = []
+    # 搜索超时, 默认: 30秒
+    _timeout = 30
 
     def __init__(self,
                  indexer: CommentedMap,
@@ -91,6 +93,8 @@ class TorrentSpider:
         self.fields = indexer.get('torrents').get('fields')
         self.render = indexer.get('render')
         self.domain = indexer.get('domain')
+        self.result_num = int(indexer.get('result_num') or 100)
+        self._timeout = int(indexer.get('timeout') or 30)
         self.page = page
         if self.domain and not str(self.domain).endswith("/"):
             self.domain = self.domain + "/"
@@ -233,14 +237,15 @@ class TorrentSpider:
                 url=searchurl,
                 cookies=self.cookie,
                 ua=self.ua,
-                proxies=self.proxy_server
+                proxies=self.proxy_server,
+                timeout=self._timeout
             )
         else:
             # requests请求
             ret = RequestUtils(
                 ua=self.ua,
                 cookies=self.cookie,
-                timeout=30,
+                timeout=self._timeout,
                 referer=self.referer,
                 proxies=self.proxies
             ).get_res(searchurl, allow_redirects=True)


### PR DESCRIPTION
老大, 内置的100条和20到30秒的请求超时, 无法满足扩展部分自定义站点。
导致请求经常超时, 搜索结果几百条只提取前100条, 订阅不到部分旧资源。
修改后自定义站点增加两个参数可自行设定站点结果数量和请求超时
{
  "id": "xxxxxxxxx",
  "name": "xxxxxxxxx",
  "domain": f"http://{domain}/",
  "encoding": "UTF-8",
  "public": True,
###   "result_num": 500,
###  "timeout": self._timeout,
  "search": {
      "paths": [ ................