### PR TITLE
fix 播放微信消息推送图片问题

### DIFF
--- a/app/modules/emby/emby.py
+++ b/app/modules/emby/emby.py
@@ -436,19 +436,44 @@ class Emby:
             return None
         req_url = "%semby/Items/%s/RemoteImages?api_key=%s" % (self._host, item_id, self._apikey)
         try:
-            res = RequestUtils().get_res(req_url)
+            res = RequestUtils(timeout=10).get_res(req_url)
             if res:
                 images = res.json().get("Images")
-                for image in images:
-                    if image.get("ProviderName") == "TheMovieDb" and image.get("Type") == image_type:
-                        return image.get("Url")
-            else:
-                logger.error(f"Items/RemoteImages 未获取到返回数据")
-                return None
+                if images:
+                    for image in images:
+                        logger.info(image)
+                        if image.get("ProviderName") == "TheMovieDb" and image.get("Type") == image_type:
+                            return image.get("Url")
+            # 数据为空
+            logger.info(f"Items/RemoteImages 未获取到返回数据，采用本地图片")
+            return self.generate_external_image_link(item_id, image_type)
         except Exception as e:
             logger.error(f"连接Items/Id/RemoteImages出错：" + str(e))
             return None
         return None
+
+    def generate_external_image_link(self, item_id, image_type):
+        """
+        根据ItemId和imageType查询本地对应图片
+        :param item_id: 在Emby中的ID
+        :param image_type: 图片类型，如Backdrop、Primary
+        """
+        if self._playhost is None or self._playhost == "":
+            logger.error("Emby外网播放地址未能获取或为空")
+            return None
+
+        req_url = "%sItems/%s/Images/%s" % (self._playhost, item_id, image_type)
+        try:
+            res = RequestUtils().get_res(req_url)
+            if res or res.status_code == 404:
+                logger.info("影片图片链接:{}".format(res.url))
+                return res.url
+            else:
+                logger.info("Items/Id/Images 未获取到返回数据或无该影片{}图片".format(image_type))
+                return None
+        except Exception as e:
+            logger.error(f"连接Items/Id/Images出错：" + str(e))
+            return None
 
     def __refresh_emby_library_by_id(self, item_id: str) -> bool:
         """

--- a/app/modules/emby/emby.py
+++ b/app/modules/emby/emby.py
@@ -458,7 +458,7 @@ class Emby:
         :param item_id: 在Emby中的ID
         :param image_type: 图片类型，如Backdrop、Primary
         """
-        if self._playhost is None or self._playhost == "":
+        if not self._playhost:
             logger.error("Emby外网播放地址未能获取或为空")
             return None
 

--- a/app/modules/jellyfin/jellyfin.py
+++ b/app/modules/jellyfin/jellyfin.py
@@ -422,19 +422,43 @@ class Jellyfin:
             return None
         req_url = "%sItems/%s/RemoteImages?api_key=%s" % (self._host, item_id, self._apikey)
         try:
-            res = RequestUtils().get_res(req_url)
+            res = RequestUtils(timeout=10).get_res(req_url)
             if res:
                 images = res.json().get("Images")
                 for image in images:
                     if image.get("ProviderName") == "TheMovieDb" and image.get("Type") == image_type:
                         return image.get("Url")
+                # return images[0].get("Url") # 首选无则返回第一张
             else:
-                logger.error(f"Items/RemoteImages 未获取到返回数据")
-                return None
+                logger.info(f"Items/RemoteImages 未获取到返回数据，采用本地图片")
+                return self.generate_external_image_link(item_id, image_type)
         except Exception as e:
             logger.error(f"连接Items/Id/RemoteImages出错：" + str(e))
             return None
         return None
+
+    def generate_external_image_link(self, item_id, image_type):
+        """
+        根据ItemId和imageType查询本地对应图片
+        :param item_id: 在Jellyfin中的ID
+        :param image_type: 图片类型，如Backdrop、Primary
+        """
+        if self._playhost is None or self._playhost == "":
+            logger.error("Jellyfin外网播放地址未能获取或为空")
+            return None
+
+        req_url = "%sItems/%s/Images/%s" % (self._playhost, item_id, image_type)
+        try:
+            res = RequestUtils().get_res(req_url)
+            if res or res.status_code == 404:
+                logger.info("影片图片链接:{}".format(res.url))
+                return res.url
+            else:
+                logger.info("Items/Id/Images 未获取到返回数据或无该影片{}图片".format(image_type))
+                return None
+        except Exception as e:
+            logger.error(f"连接Items/Id/Images出错：" + str(e))
+            return None
 
     def refresh_root_library(self) -> bool:
         """

--- a/app/modules/jellyfin/jellyfin.py
+++ b/app/modules/jellyfin/jellyfin.py
@@ -443,7 +443,7 @@ class Jellyfin:
         :param item_id: 在Jellyfin中的ID
         :param image_type: 图片类型，如Backdrop、Primary
         """
-        if self._playhost is None or self._playhost == "":
+        if not self._playhost:
             logger.error("Jellyfin外网播放地址未能获取或为空")
             return None
 


### PR DESCRIPTION
jellyfin
请求RemoteImages，ProviderName自带只有"TheMovieDb"、"The Open Movie Database"：
其中经个人测试"TheMovieDb"请求几乎无效（？）；
而"The Open Movie Database"只有"Primary"类型的图片（Score排序），普遍加载很久（超时）。
所以，使用本地图片作为备选。

emby
请求RemoteImages，可能是接口问题，导致返回
`{'Images': [], 'TotalRecordCount': 0, 'Providers': []}`
需要加上Images内容检测。
也加上使用本地图片作为备选。

两者使用本地图片都需要填写各自外网播放地址。

![image](https://github.com/jxxghp/MoviePilot/assets/17330034/e3a7a041-e3f5-46d7-90a8-d676d6d4569d)
![image](https://github.com/jxxghp/MoviePilot/assets/17330034/b0517c27-1232-4d1e-bab3-27a6b95e44b0)

#1520 