### PR TITLE
fix 播放剧集微信消息推送图片&语法问题

### DIFF
--- a/app/modules/emby/emby.py
+++ b/app/modules/emby/emby.py
@@ -465,11 +465,11 @@ class Emby:
         req_url = "%sItems/%s/Images/%s" % (self._playhost, item_id, image_type)
         try:
             res = RequestUtils().get_res(req_url)
-            if res or res.status_code == 404:
+            if res and res.status_code != 404:
                 logger.info("影片图片链接:{}".format(res.url))
                 return res.url
             else:
-                logger.info("Items/Id/Images 未获取到返回数据或无该影片{}图片".format(image_type))
+                logger.error("Items/Id/Images 未获取到返回数据或无该影片{}图片".format(image_type))
                 return None
         except Exception as e:
             logger.error(f"连接Items/Id/Images出错：" + str(e))

--- a/app/modules/emby/emby.py
+++ b/app/modules/emby/emby.py
@@ -452,11 +452,12 @@ class Emby:
             return None
         return None
 
-    def generate_external_image_link(self, item_id, image_type):
+    def generate_external_image_link(self, item_id: str, image_type: str) -> Optional[str]:
         """
         根据ItemId和imageType查询本地对应图片
         :param item_id: 在Emby中的ID
         :param image_type: 图片类型，如Backdrop、Primary
+        :return: 图片对应在外网播放器中的URL
         """
         if not self._playhost:
             logger.error("Emby外网播放地址未能获取或为空")

--- a/app/modules/jellyfin/jellyfin.py
+++ b/app/modules/jellyfin/jellyfin.py
@@ -450,11 +450,11 @@ class Jellyfin:
         req_url = "%sItems/%s/Images/%s" % (self._playhost, item_id, image_type)
         try:
             res = RequestUtils().get_res(req_url)
-            if res or res.status_code == 404:
+            if res and res.status_code != 404:
                 logger.info("影片图片链接:{}".format(res.url))
                 return res.url
             else:
-                logger.info("Items/Id/Images 未获取到返回数据或无该影片{}图片".format(image_type))
+                logger.error("Items/Id/Images 未获取到返回数据或无该影片{}图片".format(image_type))
                 return None
         except Exception as e:
             logger.error(f"连接Items/Id/Images出错：" + str(e))

--- a/app/modules/jellyfin/jellyfin.py
+++ b/app/modules/jellyfin/jellyfin.py
@@ -437,11 +437,12 @@ class Jellyfin:
             return None
         return None
 
-    def generate_external_image_link(self, item_id, image_type):
+    def generate_external_image_link(self, item_id: str, image_type: str) -> Optional[str]:
         """
         根据ItemId和imageType查询本地对应图片
         :param item_id: 在Jellyfin中的ID
         :param image_type: 图片类型，如Backdrop、Primary
+        :return: 图片对应在外网播放器中的URL
         """
         if not self._playhost:
             logger.error("Jellyfin外网播放地址未能获取或为空")
@@ -464,12 +465,13 @@ class Jellyfin:
             logger.error(f"连接Items/Id/Images出错：" + str(e))
             return None
 
-    def get_itemId_ancestors(self, item_id, index, key):
+    def get_itemId_ancestors(self, item_id: str, index: int, key: str) -> Optional[Union[str, list, int, dict, bool]]:
         """
         获得itemId的父item
         :param item_id: 在Jellyfin中剧集的ID (S01E02的E02的item_id)
         :param index: 第几个json对象
         :param key: 需要得到父item中的键值对
+        :return key对应类型的值
         """
         req_url = "%sItems/%s/Ancestors?api_key=%s" % (self._host, item_id, self._apikey)
         try:
@@ -478,10 +480,10 @@ class Jellyfin:
                 return res.json()[index].get(key)
             else:
                 logger.error(f"Items/Id/Ancestors 未获取到返回数据")
-                return False
+                return None
         except Exception as e:
             logger.error(f"连接Items/Id/Ancestors出错：" + str(e))
-            return False
+            return None
 
     def refresh_root_library(self) -> bool:
         """


### PR DESCRIPTION
jellyfin播放剧集时webhook消息的ItemId是当前集（如S01E02），接口items/{itemid}/images/{imagetype}请求剧集则是需要剧集的ItemId（剧集主页）。
所以先查询是否有父item。

emby一切正常。

---
![image](https://github.com/jxxghp/MoviePilot/assets/17330034/52c6e69c-d92f-4d7b-8db4-2ca3f694a4ab)
👇
![image](https://github.com/jxxghp/MoviePilot/assets/17330034/a2ddc6ae-6cad-4cb1-80f7-11b3b3efe521)
