### PR TITLE
fix: TR远程控制插件限速问题 104

### DIFF
--- a/app/modules/transmission/transmission.py
+++ b/app/modules/transmission/transmission.py
@@ -289,6 +289,29 @@ class Transmission:
             logger.error(f"设置速度限制出错：{str(err)}")
             return False
 
+    def get_speed_limit(self):
+        """
+        获取TR速度
+        :return: download_limit 下载速度 默认是0
+                 upload_limit 上传速度   默认是0
+        """
+        if not self.trc:
+            return False
+
+        download_limit = 0
+        upload_limit = 0
+        try:
+            download_limit = self.trc.get_session().get(settings.TR_DOWN_LIMIT_FIELD_NAME)
+            upload_limit = self.trc.get_session().get(settings.TR_UP_LIMIT_FIELD_NAME)
+
+        except Exception as err:
+            logger.error(f"获取速度限制出错：{str(err)}")
+
+        return (
+            download_limit,
+            upload_limit
+        )
+
     def recheck_torrents(self, ids: Union[str, list]) -> bool:
         """
         重新校验种子


### PR DESCRIPTION
修复TR限速问题，同QB相同，关联
https://github.com/jxxghp/MoviePilot-Plugins/issues/104

代码在本地可被执行，功能验证正常，请求合并主分支。