### PR TITLE
NFO文件 无需 "添加时间"

### DIFF
--- a/app/modules/douban/scraper.py
+++ b/app/modules/douban/scraper.py
@@ -83,10 +83,6 @@ class DoubanScraper:
 
     @staticmethod
     def __gen_common_nfo(mediainfo: MediaInfo, doc, root):
-        # 添加时间
-        DomUtils.add_node(doc, root, "dateadded",
-                          time.strftime('%Y-%m-%d %H:%M:%S',
-                                        time.localtime(time.time())))
         # 简介
         xplot = DomUtils.add_node(doc, root, "plot")
         xplot.appendChild(doc.createCDATASection(mediainfo.overview or ""))
@@ -166,8 +162,6 @@ class DoubanScraper:
         logger.info(f"正在生成季NFO文件：{season_path.name}")
         doc = minidom.Document()
         root = DomUtils.add_node(doc, doc, "season")
-        # 添加时间
-        DomUtils.add_node(doc, root, "dateadded", time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())))
         # 简介
         xplot = DomUtils.add_node(doc, root, "plot")
         xplot.appendChild(doc.createCDATASection(mediainfo.overview or ""))

--- a/app/modules/themoviedb/scraper.py
+++ b/app/modules/themoviedb/scraper.py
@@ -151,10 +151,6 @@ class TmdbScraper:
         """
         生成公共NFO
         """
-        # 添加时间
-        DomUtils.add_node(doc, root, "dateadded",
-                          time.strftime('%Y-%m-%d %H:%M:%S',
-                                        time.localtime(time.time())))
         # TMDB
         DomUtils.add_node(doc, root, "tmdbid", mediainfo.tmdb_id or "")
         uniqueid_tmdb = DomUtils.add_node(doc, root, "uniqueid", mediainfo.tmdb_id or "")
@@ -267,9 +263,6 @@ class TmdbScraper:
         logger.info(f"正在生成季NFO文件：{season_path.name}")
         doc = minidom.Document()
         root = DomUtils.add_node(doc, doc, "season")
-        # 添加时间
-        DomUtils.add_node(doc, root, "dateadded",
-                          time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())))
         # 简介
         xplot = DomUtils.add_node(doc, root, "plot")
         xplot.appendChild(doc.createCDATASection(seasoninfo.get("overview") or ""))
@@ -306,8 +299,6 @@ class TmdbScraper:
         logger.info(f"正在生成剧集NFO文件：{file_path.name}")
         doc = minidom.Document()
         root = DomUtils.add_node(doc, doc, "episodedetails")
-        # 添加时间
-        DomUtils.add_node(doc, root, "dateadded", time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())))
         # TMDBID
         uniqueid = DomUtils.add_node(doc, root, "uniqueid", str(episodeinfo.get("id")))
         uniqueid.setAttribute("type", "tmdb")


### PR DESCRIPTION
处理媒体库的nfo文件，这里不需要”添加时间“

合理的设置应该是媒体文件的创建日期：
<img width="1294" alt="image" src="https://github.com/jxxghp/MoviePilot/assets/20323435/9194a415-e983-47e9-8f71-60f160ec95e5">

目前代码的这种写法会导致在覆写所有元数据后，各种入库时间发生混乱，进而影响媒体库首屏媒体展示

这里最合理的修改是现在这里直接删除 ”添加时间 “

若认为此方案修改有风险，可以写个插件专门删除或修正nfo文件的”添加时间“节点


