### PR TITLE
fix 修改bangumi获取演职人员信息的接口

### DIFF
--- a/app/modules/bangumi/bangumi.py
+++ b/app/modules/bangumi/bangumi.py
@@ -15,7 +15,8 @@ class BangumiApi(object):
         "calendar": "calendar",
         "detail": "v0/subjects/%s",
         "persons": "v0/subjects/%s/persons",
-        "subjects": "v0/subjects/%s/subjects"
+        "subjects": "v0/subjects/%s/subjects",
+        "characters": "v0/subjects/%s/characters"
     }
     _base_url = "https://api.bgm.tv/"
     _req = RequestUtils(session=requests.Session())
@@ -145,7 +146,17 @@ class BangumiApi(object):
         """
         获取番剧人物
         """
-        return self.__invoke(self._urls["persons"] % bid, _ts=datetime.strftime(datetime.now(), '%Y%m%d'))
+        ret_list = []
+        result = self.__invoke(self._urls["characters"] % bid, _ts=datetime.strftime(datetime.now(), '%Y%m%d'))
+        if result:
+            for item in result:
+                character_id = item.get("id")
+                actors = item.get("actors")
+                if character_id and actors and actors[0]:
+                    actor_info = actors[0]
+                    actor_info.update({'career': [item.get('name')]})
+                    ret_list.append(actor_info)
+        return ret_list
 
     def subjects(self, bid: int):
         """


### PR DESCRIPTION
通过v0/subjects/%s/persons获取到的并非演员信息，而是制作组信息，例如音效、企划、动效等人员信息。这些是用户不怎么关注的。
before:
![before](https://github.com/jxxghp/MoviePilot/assets/66009942/d6dd0415-ae47-4417-ae54-6672e45773e8)
after:
![after](https://github.com/jxxghp/MoviePilot/assets/66009942/9474d6a1-c58e-44f8-84d2-dd8430442867)
