### PR TITLE
fix 删除站点会导致其订阅的站点列表出现数字ID

### DIFF
--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -12,6 +12,7 @@ from app.chain.search import SearchChain
 from app.chain.torrents import TorrentsChain
 from app.core.config import settings
 from app.core.context import TorrentInfo, Context, MediaInfo
+from app.core.event import eventmanager, Event
 from app.core.meta import MetaBase
 from app.core.metainfo import MetaInfo
 from app.db.models.subscribe import Subscribe
@@ -21,7 +22,7 @@ from app.helper.message import MessageHelper
 from app.helper.torrent import TorrentHelper
 from app.log import logger
 from app.schemas import NotExistMediaInfo, Notification
-from app.schemas.types import MediaType, SystemConfigKey, MessageChannel, NotificationType
+from app.schemas.types import MediaType, SystemConfigKey, MessageChannel, NotificationType, EventType
 from app.utils.string import StringUtils
 
 
@@ -956,3 +957,33 @@ class SubscribeChain(ChainBase):
                     start_episode=start_episode
                 )
         return no_exists
+
+    @eventmanager.register(EventType.SiteDeleted)
+    def remove_site(self, event: Event):
+        """
+        从订阅中移除与站点相关的设置
+        """
+        if not event:
+            return
+        event_data = event.event_data or {}
+        site_id = event_data.get("site_id")
+        if not site_id:
+            return
+        # 从选中的rss站点中移除
+        selected_sites = SystemConfigOper().get(SystemConfigKey.RssSites) or []
+        if site_id in selected_sites:
+            selected_sites.remove(site_id)
+            SystemConfigOper().set(SystemConfigKey.RssSites, selected_sites)
+        # 查询所有订阅
+        subscribes = self.subscribeoper.list()
+        for subscribe in subscribes:
+            if not subscribe.sites:
+                continue
+            sites = json.loads(subscribe.sites) or []
+            if site_id not in sites:
+                continue
+            sites.remove(site_id)
+            sites = json.dumps(sites)
+            self.subscribeoper.update(subscribe.id, {
+                "sites": sites
+            })


### PR DESCRIPTION
当删除站点后，这个站点相关的订阅依旧会使用这个站点ID，导致站点列表中出现数字。
<img width="128" alt="image" src="https://github.com/jxxghp/MoviePilot/assets/802181/837629e1-aa3b-4294-abd1-8abd179b63d8">

这个bug还可能产生另一个副作用，删除后再新增一个其它站点，由于新站点会复用之前删除的ID，这个ID相关的订阅就会在这个新站点上继续订阅，这可能是用户预期外的行为。

目前我的修改方案是当删除站点时，从相关的订阅中移除这个站点，确保了不会残留无效ID在站点列表中。
对于已经残留了ID的旧数据，暂时没做处理。