### PR TITLE
fix #1761

### DIFF
--- a/app/core/module.py
+++ b/app/core/module.py
@@ -78,9 +78,12 @@ class ModuleManager(metaclass=Singleton):
         if not setting:
             return True
         switch, value = setting
-        if getattr(settings, switch) and value is True:
+        option = getattr(settings, switch)
+        if not option:
+            return False
+        if option and value is True:
             return True
-        if value in getattr(settings, switch):
+        if value in option:
             return True
         return False
 


### PR DESCRIPTION
问题根源在于关闭所有通知渠道后，与通知相关的模块在读取settings.MESSAGER选项时会抛出空值异常，导致后续模块无法加载，部分服务因此失效。

修复方案是访问前先判断空值

closes #1761 