### PR TITLE
fix 单例加锁，防止init方法时间过长导致多次init

### DIFF
--- a/app/utils/singleton.py
+++ b/app/utils/singleton.py
@@ -1,4 +1,5 @@
 import abc
+import threading
 
 
 class Singleton(abc.ABCMeta, type):
@@ -7,12 +8,14 @@ class Singleton(abc.ABCMeta, type):
     """
 
     _instances: dict = {}
+    _lock = threading.Lock()
 
     def __call__(cls, *args, **kwargs):
         key = (cls, args, frozenset(kwargs.items()))
-        if key not in cls._instances:
-            cls._instances[key] = super().__call__(*args, **kwargs)
-        return cls._instances[key]
+        with cls._lock:
+            if key not in cls._instances:
+                cls._instances[key] = super().__call__(*args, **kwargs)
+            return cls._instances[key]
 
 
 class AbstractSingleton(abc.ABC, metaclass=Singleton):


### PR DESCRIPTION
![image](https://github.com/jxxghp/MoviePilot/assets/54088512/6d758a86-fd1b-4004-9e1e-6de24c99d6b4)
docker启动时发现日志重复打印，推断是PluginManager()的时候PluginManager的__init__方法执行了多次。

可能install_online_plugin方法如果插件仓库配置的很多，导致init需要时间，没有第一时间生成实例。

但是单例模式没加锁，多次PluginManager()的情况下实际上导致init了多次。
<img width="380" alt="image" src="https://github.com/jxxghp/MoviePilot/assets/54088512/2d9345ed-7f4a-4531-908a-bce944366c6d">
经测试，init方法如果耗时的话，多线程场景下确实会多次init，加锁后只会执行一次。