### PR TITLE
fix 插件多次加载

### DIFF
--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -35,8 +35,6 @@ class PluginManager(metaclass=Singleton):
         self.siteshelper = SitesHelper()
         self.pluginhelper = PluginHelper()
         self.systemconfig = SystemConfigOper()
-        self.install_online_plugin()
-        self.init_config()
 
     def init_config(self):
         # 停止已有插件

--- a/app/main.py
+++ b/app/main.py
@@ -195,8 +195,10 @@ def start_module():
     ResourceHelper()
     # 加载模块
     ModuleManager()
+    # 安装在线插件
+    PluginManager().install_online_plugin()
     # 加载插件
-    PluginManager()
+    PluginManager().start()
     # 启动定时服务
     Scheduler()
     # 启动事件消费


### PR DESCRIPTION
没找到 啥原因，实测release没问题，dev就是加载了3遍。

start_module的时候调用一次安装在线插件和加载插件
不放PluginManager的init了 。


已放线上docker容器测试。