### PR TITLE
fix 编码斜杠禁用的反代无法加载图片

### DIFF
--- a/app/api/endpoints/system.py
+++ b/app/api/endpoints/system.py
@@ -26,7 +26,7 @@ from version import APP_VERSION
 router = APIRouter()
 
 
-@router.get("/img/{imgurl:path}/{proxy}", summary="图片代理")
+@router.get("/img/{proxy}/{imgurl:path}", summary="图片代理")
 def get_img(imgurl: str, proxy: bool = False) -> Any:
     """
     通过图片代理（使用代理服务器）


### PR DESCRIPTION
修改后端api接口路由格式，proxy放前面确保正确解析，imgurl不再对斜杠编码，防止被反向代理拦截。