### PR TITLE
fix: 启动找不到模块roman与pypushdeer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -57,3 +57,5 @@ fast-bencode~=1.1.3
 pystray~=0.19.5
 pyotp~=2.9.0
 Pinyin2Hanzi~=0.1.1
+roman~=4.1
+pypushdeer~=0.0.3


### PR DESCRIPTION
[fix: 启动找不到模块roman与pypushdeer](https://github.com/jxxghp/MoviePilot/commit/97523f8a457134b4da7259ec32e10feffd28cce1)