### PR TITLE
fix 反向代理图片显示问题，url改为查询参数避免双斜杠的优化

### DIFF
--- a/app/api/endpoints/system.py
+++ b/app/api/endpoints/system.py
@@ -26,7 +26,7 @@ from version import APP_VERSION
 router = APIRouter()
 
 
-@router.get("/img/{proxy}/{imgurl:path}", summary="图片代理")
+@router.get("/img/{proxy}", summary="图片代理")
 def get_img(imgurl: str, proxy: bool = False) -> Any:
     """
     通过图片代理（使用代理服务器）


### PR DESCRIPTION
路径参数中有`http://`会被优化为`http:/`，把url改为查询参数。