### PR TITLE
修复部分版本qt存在"下载任务添加成功，但获取Qbittorrent任务信息失败"的情况

### DIFF
--- a/app/modules/qbittorrent/__init__.py
+++ b/app/modules/qbittorrent/__init__.py
@@ -126,6 +126,11 @@ class QbittorrentModule(_ModuleBase):
                         return torrent_hash, f"下载任务已存在"
             return None, f"添加种子任务失败：{content}"
         else:
+            # 对于部分qt版本add_torrent会成功，但是标签打不上
+            # 测试发现上述“下载任务已存在”这部分的处理中可以成功打上标签
+            # 导致这里根据tags去获取就会获取不到就会报错
+            # 对add_torrent方法加了一个补丁
+            # 用的是上面“下载任务已经存在”加上标签的逻辑
             # 获取种子Hash
             torrent_hash = self.qbittorrent.get_torrent_id_by_tag(tags=tag)
             if not torrent_hash:


### PR DESCRIPTION
对于部分版本qt存在"下载任务添加成功，但获取Qbittorrent任务信息失败"的情况
因为设备原因较新的qb用着cpu占用会非常高，用的是旧版的qb，发现存在”下载任务添加成功，但获取Qbittorrent任务信息失败“的情况，
我进行测试发现：
1. 在qt中下载任务确实添加成功，但是没有打上对应的”MOVIEPILOT“标签
2. 日志中爆出了”下载任务添加成功，但获取Qbittorrent任务信息失败“的错误
3. 在1的基础上，继续重复下载，”下载器中已存在该种子任务“，但是这时”MOVIEPILOT“标签成功打上

在源码中发现，获取获取Qbittorrent任务信息的逻辑是根据标签来进行获取，于是下载任务那里给加了一个重复下载位置那里打标签方法的补丁

因为部署比较麻烦，代码没有经过测试，我对于这个依赖的部分并不太清楚，可能会存在问题，希望作者能多多包涵
