### PR TITLE
修复副标题包含【】的情况下无法匹配标题的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ config/sites/**
 *.pyc
 *.log
 .vscode
+venv

--- a/app/helper/torrent.py
+++ b/app/helper/torrent.py
@@ -497,7 +497,7 @@ class TorrentHelper(metaclass=Singleton):
                 return True
         # 在副标题中判断是否存在标题、原语种标题、别名、译名
         if torrent.description:
-            subtitles = {StringUtils.clear_upper(t) for t in re.split(r'[\s/|]+',
+            subtitles = {StringUtils.clear_upper(t) for t in re.split(r'[\s/【】|]+',
                                                                       torrent.description) if t}
             if media_titles.intersection(subtitles) or media_names.intersection(subtitles):
                 logger.info(f'{mediainfo.title} 通过副标题匹配到资源：{torrent.site_name} - {torrent.title}，'


### PR DESCRIPTION
TMDB: [真爱历险](https://www.themoviedb.org/movie/1285868) (2024)
在HDFANS搜索上述资源时，发现副标题种存在资源名称但无法正确匹配，检查后发现副标题分隔符中包含`【】`字符。
副标题: `真爱历险【4K EDR高码率+杜比音效】【导演：雪涛 | 主演：刘亭驿 | 董阿娇 | 梁作诗 | 文雯】QHstudIo小组作品`
副标题匹配代码原效果如下
```python 
>>> {StringUtils.clear_upper(t) for t in re.split(r'[\s/|]+', "真爱历险【4K EDR高码率+杜比音效】【导演：雪涛 | 主演：刘亭驿 | 董阿娇 | 梁作诗 | 文雯】QHstudIo小组作品") if t}
{'真爱历险4K', '主演刘亭驿', '梁作诗', '董阿娇', '文雯QHSTUDIO小组作品', 'EDR高码率杜比音效导演雪涛'}
```
其中真爱历险4K被匹配到了一个字符串中，无法正确完整匹配。
修复后效果如下：
```python 
>>> {StringUtils.clear_upper(t) for t in re.split(r'[\s/【】|]+', "真爱历险【4K EDR高码率+杜比音效】【导演：雪涛 | 主演：刘亭驿 | 董阿娇 | 梁作诗 | 文雯】QHstudIo小组作品") if t}
{'真爱历险', '4K', '主演刘亭驿', '导演雪涛', '梁作诗', 'EDR高码率杜比音效', '文雯', 'QHSTUDIO小组作品', '董阿娇'}
```

