### PR TITLE
fix: jellyfin webhook百分比数据有时为None引发报错

### DIFF
--- a/app/modules/jellyfin/jellyfin.py
+++ b/app/modules/jellyfin/jellyfin.py
@@ -613,7 +613,10 @@ class Jellyfin:
             eventItem.item_name = "%s %s" % (
                 message.get('Name'), "(" + str(message.get('Year')) + ")")
 
-        eventItem.percentage = message.get('PlaybackPositionTicks') / message.get('RunTimeTicks') * 100
+        playback_position_ticks = message.get('PlaybackPositionTicks')
+        runtime_ticks = message.get('RunTimeTicks')
+        if playback_position_ticks is not None and runtime_ticks is not None:
+            eventItem.percentage = playback_position_ticks / runtime_ticks * 100
 
         # 获取消息图片
         if eventItem.item_id:


### PR DESCRIPTION
jellyfin webhook插件返回的数据不固定，有时不含“PlaybackPositionTicks”与“RunTimeTicks”

![Snipaste_2024-05-20_23-20-31](https://github.com/jxxghp/MoviePilot/assets/17330034/7d7d5d3c-9999-4278-b2b4-3567b4aaea07)

![Snipaste_2024-05-20_23-20-57](https://github.com/jxxghp/MoviePilot/assets/17330034/9ffec151-c6b4-4fda-b7c3-8262f3d8034d)

