### PR TITLE
fix: Plex刷新媒体库无用

### DIFF
--- a/app/modules/plex/plex.py
+++ b/app/modules/plex/plex.py
@@ -317,7 +317,7 @@ class Plex:
             # 否则一个一个刷新
             for path, lib_key in result_dict.items():
                 logger.info(f"刷新媒体库：{lib_key} - {path}")
-                self._plex.query(f'/library/sections/{lib_key}/refresh?path={quote_plus(path)}')
+                self._plex.query(f'/library/sections/{lib_key}/refresh?path={quote_plus(str(Path(path).parent))}')
 
     @staticmethod
     def __find_librarie(path: Path, libraries: List[Any]) -> Tuple[str, str]:


### PR DESCRIPTION
Plex部分刷新需要传入文件的`父目录路径`才能刷新，而不是传入`文件路径`

**fix前**的`mediaserverrefresh.log`:

```bash
【INFO】2024-05-28 00:56:33,879 - mediaserverrefresh - 延迟 0 秒后刷新媒体库... 
【INFO】2024-05-28 00:56:34,568 - plex.py - 刷新媒体库：3 - /home/Library/电视剧/国产剧/武庚纪之天启 (2017)/Season 1/武庚纪之天启 - S01E04.mp4
```



**fix前**的`Plex日志`:

```bash
May 28, 2024 00:56:34.573 [139442805287736] DEBUG - Activity: registered new activity 7bb6eb50-c873-4c28-8c4e-8ccba2b1e0de - "Scanning"
May 28, 2024 00:56:34.573 [139442805287736] DEBUG - Scanning section 3
May 28, 2024 00:56:34.573 [139442805287736] DEBUG - Activity: updated activity 7bb6eb50-c873-4c28-8c4e-8ccba2b1e0de - completed 0.0% - Scanning 国产剧
May 28, 2024 00:56:35.508 [139442805287736] DEBUG - Scanning 国产剧 using zh-CN(Plex TV Series) with 0 current media items and 1 section locations in the database.
May 28, 2024 00:56:35.508 [139442805287736] DEBUG - Performing a scan with 'Plex TV Series' (language: zh-CN virtual: 0).
May 28, 2024 00:56:35.508 [139442805287736] DEBUG -   * Scanning /home/Library/电视剧/国产剧/武庚纪之天启 (2017)/Season 1/武庚纪之天启 - S01E04.mp4
May 28, 2024 00:56:35.512 [139442805287736] DEBUG - Scanner: Processing directory /home/Library/电视剧/国产剧/武庚纪之天启 (2017)/Season 1/武庚纪之天启 - S01E04.mp4 (parent: yes)
May 28, 2024 00:56:35.516 [139442805287736] DEBUG - Activity: updated activity 7bb6eb50-c873-4c28-8c4e-8ccba2b1e0de - completed 0.0% - Scanning 国产剧
May 28, 2024 00:56:35.516 [139442805287736] DEBUG - Activity: updated activity 7bb6eb50-c873-4c28-8c4e-8ccba2b1e0de - completed 99.0% - Scanning 国产剧
May 28, 2024 00:56:35.516 [139442805287736] DEBUG - Scanner [Plex TV Series]: Idle and left with 0 media items.
May 28, 2024 00:56:36.208 [139442805287736] DEBUG - Activity: updated activity 7bb6eb50-c873-4c28-8c4e-8ccba2b1e0de - completed 100.0% - Scanning 国产剧
```

扫描后无新增

---

**fix后**的`Plex日志`:

```bash
May 28, 2024 00:57:10.680 [139442805287736] DEBUG - Activity: registered new activity bff3afc3-85c8-4c7f-9ebc-cb603e9a07ae - "Scanning"
May 28, 2024 00:57:10.680 [139442805287736] DEBUG - Scanning section 3
May 28, 2024 00:57:10.681 [139442805287736] DEBUG - Activity: updated activity bff3afc3-85c8-4c7f-9ebc-cb603e9a07ae - completed 0.0% - Scanning 国产剧
May 28, 2024 00:57:11.550 [139442805287736] DEBUG - Scanning 国产剧 using zh-CN(Plex TV Series) with 3 current media items and 1 section locations in the database.
May 28, 2024 00:57:11.550 [139442805287736] DEBUG - Performing a scan with 'Plex TV Series' (language: zh-CN virtual: 0).
May 28, 2024 00:57:11.550 [139442805287736] DEBUG -   * Scanning /home/Library/电视剧/国产剧/武庚纪之天启 (2017)/Season 1
May 28, 2024 00:57:13.272 [139442805287736] DEBUG - Scanner: Processing directory /home/Library/电视剧/国产剧/武庚纪之天启 (2017)/Season 1 (parent: yes)
May 28, 2024 00:57:13.285 [139442801093432] DEBUG - Native Scanner: Executed Local Metadata stage in 0.00 sec.
May 28, 2024 00:57:13.286 [139442805287736] DEBUG - Activity: updated activity bff3afc3-85c8-4c7f-9ebc-cb603e9a07ae - completed 0.0% - Scanning 国产剧
May 28, 2024 00:57:13.286 [139442805287736] DEBUG - Activity: updated activity bff3afc3-85c8-4c7f-9ebc-cb603e9a07ae - completed 99.0% - Scanning 国产剧
May 28, 2024 00:57:13.858 [139442801093432] DEBUG - Scanner [Plex TV Series]: found cloud match for file '/home/Library/电视剧/国产剧/武庚纪之天启 (2017)/Season 1/武庚纪之天启 - S01E01 - 武庚纪之天启.mp4': '武庚纪之天启'
May 28, 2024 00:57:13.858 [139442801093432] DEBUG - Native Scanner: Executed Cloud Match stage in 0.57 sec.
May 28, 2024 00:57:13.872 [139442939505464] DEBUG - [LibraryTimeline] Scanner activity on section 3: 1 added, 0 deleted
May 28, 2024 00:57:15.717 [139442801093432] DEBUG - Native Scanner: Executed Add to Database stage in 1.86 sec.
May 28, 2024 00:57:15.718 [139442788510520] DEBUG - [JobRunner] Job running: FFMPEG_EXTERNAL_LIBS='/config/Library/Application\ Support/Plex\ Media\ Server/Codecs/ad47460-4673-linux-x86_64/' X_PLEX_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx "/usr/lib/plexmediaserver/Plex Media Scanner" --analyze --log-file-suffix " Analysis" --no-thumbs --item 702662
May 28, 2024 00:57:16.910 [139443107277624] DEBUG - Jobs: '/usr/lib/plexmediaserver/Plex Media Scanner' exit code for process 6910 is 0 (success)
May 28, 2024 00:57:16.910 [139442801093432] DEBUG - Native Scanner: Executed Media Analysis stage in 1.19 sec.
May 28, 2024 00:57:16.910 [139442805287736] DEBUG - Scanner [Plex TV Series]: Idle and left with 0 media items.
May 28, 2024 00:57:17.287 [139442784316216] DEBUG - [JobRunner] Job running: FFMPEG_EXTERNAL_LIBS='/config/Library/Application\ Support/Plex\ Media\ Server/Codecs/ad47460-4673-linux-x86_64/' X_PLEX_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx "/usr/lib/plexmediaserver/Plex Media Scanner" --match --type 2 --log-file-suffix " Matcher" --item 702658
May 28, 2024 00:57:17.570 [139442805287736] DEBUG - Activity: updated activity bff3afc3-85c8-4c7f-9ebc-cb603e9a07ae - completed 100.0% - Scanning 国产剧
May 28, 2024 00:57:22.280 [139443107277624] DEBUG - Jobs: '/usr/lib/plexmediaserver/Plex Media Scanner' exit code for process 6917 is 0 (success)
May 28, 2024 00:57:22.337 [139442788510520] DEBUG - [JobRunner] Job running: FFMPEG_EXTERNAL_LIBS='/config/Library/Application\ Support/Plex\ Media\ Server/Codecs/ad47460-4673-linux-x86_64/' X_PLEX_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx "/usr/lib/plexmediaserver/Plex Media Scanner" --analyze --log-file-suffix " Analysis" --item 702662
May 28, 2024 00:57:22.557 [139443107277624] DEBUG - Jobs: '/usr/lib/plexmediaserver/Plex Media Scanner' exit code for process 6930 is 0 (success)
```



可见`fix后`Plex服务器立刻检测到了新入库的视频`May 28, 2024 00:57:13.872 [139442939505464] DEBUG - [LibraryTimeline] Scanner activity on section 3: 1 added, 0 deleted`

而`fix前`未成功扫描到新视频

具体表现就是新入库内容在plex中会立刻出现，而以前不行



> **电影**也试过没问题：
>
> 
> **fix前**的`mediaserverrefresh.log`:
>
> ```bash
> 
> 【INFO】2024-05-28 01:47:30,842 - mediaserverrefresh - 延迟 0 秒后刷新媒体库... 
> 【INFO】2024-05-28 01:47:30,864 - plex.py - 刷新媒体库：14 - /home/Library/电影/外语电影/成事在人 (2009)/成事在人 (2009) - 1080p - X264 - DTS.mkv
> ```
>
> **fix前**`Plex日志`:
>
> ```
> May 28, 2024 01:47:30.872 [139442897562424] DEBUG - Activity: registered new activity d77b7f05-542d-4bc0-b6cd-7c6644dce71a - "Scanning"
> May 28, 2024 01:47:30.872 [139442897562424] DEBUG - Scanning section 14
> May 28, 2024 01:47:30.873 [139442897562424] DEBUG - Activity: updated activity d77b7f05-542d-4bc0-b6cd-7c6644dce71a - completed 0.0% - Scanning 外语电影
> May 28, 2024 01:47:31.606 [139442897562424] DEBUG - Scanning 外语电影 using zh-CN(Plex Movie) with 0 current media items and 1 section locations in the database.
> May 28, 2024 01:47:31.606 [139442897562424] DEBUG - Performing a scan with 'Plex Movie' (language: zh-CN virtual: 0).
> May 28, 2024 01:47:31.606 [139442897562424] DEBUG -   * Scanning /home/Library/电影/外语电影/成事在人 (2009)/成事在人 (2009) - 1080p - X264 - DTS.mkv
> May 28, 2024 01:47:31.637 [139442897562424] DEBUG - Scanner: Processing directory /home/Library/电影/外语电影/成事在人 (2009)/成事在人 (2009) - 1080p - X264 - DTS.mkv (parent: yes)
> May 28, 2024 01:47:31.657 [139442897562424] DEBUG - Activity: updated activity d77b7f05-542d-4bc0-b6cd-7c6644dce71a - completed 0.0% - Scanning 外语电影
> May 28, 2024 01:47:31.658 [139442897562424] DEBUG - Activity: updated activity d77b7f05-542d-4bc0-b6cd-7c6644dce71a - completed 99.0% - Scanning 外语电影
> May 28, 2024 01:47:31.658 [139442897562424] DEBUG - Scanner [Plex Movie]: Idle and left with 0 media items.
> May 28, 2024 01:47:32.781 [139442897562424] DEBUG - Activity: updated activity d77b7f05-542d-4bc0-b6cd-7c6644dce71a - completed 100.0% - Scanning 外语电影
> ```
>
> ---
>
> **fix后**的`Plex日志`:
>
> ```bash
> May 28, 2024 01:49:50.857 [139442897562424] DEBUG - Activity: registered new activity f8f14f84-86f0-4800-bcbb-70acee109930 - "Scanning"
> May 28, 2024 01:49:50.857 [139442897562424] DEBUG - Scanning section 14
> May 28, 2024 01:49:50.857 [139442897562424] DEBUG - Activity: updated activity f8f14f84-86f0-4800-bcbb-70acee109930 - completed 0.0% - Scanning 外语电影
> May 28, 2024 01:49:51.540 [139442897562424] DEBUG - Scanning 外语电影 using zh-CN(Plex Movie) with 0 current media items and 1 section locations in the database.
> May 28, 2024 01:49:51.540 [139442897562424] DEBUG - Performing a scan with 'Plex Movie' (language: zh-CN virtual: 0).
> May 28, 2024 01:49:51.540 [139442897562424] DEBUG -   * Scanning /home/Library/电影/外语电影/成事在人 (2009)
> May 28, 2024 01:49:55.487 [139442897562424] DEBUG - Scanner: Processing directory /home/Library/电影/外语电影/成事在人 (2009) (parent: yes)
> May 28, 2024 01:49:55.539 [139442897562424] DEBUG - Activity: updated activity f8f14f84-86f0-4800-bcbb-70acee109930 - completed 0.0% - Scanning 外语电影
> May 28, 2024 01:49:55.540 [139442897562424] DEBUG - Activity: updated activity f8f14f84-86f0-4800-bcbb-70acee109930 - completed 99.0% - Scanning 外语电影
> May 28, 2024 01:49:55.597 [139442889173816] DEBUG - [JobRunner] Job running: FFMPEG_EXTERNAL_LIBS='/config/Library/Application\ Support/Plex\ Media\ Server/Codecs/ad47460-4673-linux-x86_64/' X_PLEX_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx "/usr/lib/plexmediaserver/Plex Media Scanner" --match --type 1 --log-file-suffix " Matcher" --files '/home/Library/电影/外语电影/成事在人 (2009)/成事在人 (2009) - 1080p - X264 - DTS.mkv'
> May 28, 2024 01:49:57.432 [139442889173816] DEBUG - Native Scanner: Executed Local Metadata stage in 1.89 sec.
> May 28, 2024 01:49:57.432 [139443107277624] DEBUG - Jobs: '/usr/lib/plexmediaserver/Plex Media Scanner' exit code for process 12958 is 0 (success)
> May 28, 2024 01:49:58.360 [139442889173816] DEBUG - Scanner [Plex Movie]: found cloud match for file '/home/Library/电影/外语电影/成事在人 (2009)/成事在人 (2009) - 1080p - X264 - DTS.mkv': '成事在人'
> May 28, 2024 01:49:58.361 [139442889173816] DEBUG - Native Scanner: Executed Cloud Match stage in 0.93 sec.
> May 28, 2024 01:49:58.403 [139442872396600] DEBUG - [LibraryTimeline] Scanner activity on section 14: 1 added, 0 deleted
> May 28, 2024 01:49:58.414 [139442889173816] DEBUG - Native Scanner: Executed Add to Database stage in 0.05 sec.
> May 28, 2024 01:49:58.414 [139442868202296] DEBUG - [JobRunner] Job running: FFMPEG_EXTERNAL_LIBS='/config/Library/Application\ Support/Plex\ Media\ Server/Codecs/ad47460-4673-linux-x86_64/' X_PLEX_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx "/usr/lib/plexmediaserver/Plex Media Scanner" --analyze --log-file-suffix " Analysis" --no-thumbs --item 702663
> May 28, 2024 01:50:01.160 [139443107277624] DEBUG - Jobs: '/usr/lib/plexmediaserver/Plex Media Scanner' exit code for process 12966 is 0 (success)
> May 28, 2024 01:50:01.160 [139442889173816] DEBUG - Native Scanner: Executed Media Analysis stage in 2.75 sec.
> May 28, 2024 01:50:01.160 [139442897562424] DEBUG - Scanner [Plex Movie]: Idle and left with 0 media items.
> May 28, 2024 01:50:01.400 [139442859813688] DEBUG - [JobRunner] Job running: FFMPEG_EXTERNAL_LIBS='/config/Library/Application\ Support/Plex\ Media\ Server/Codecs/ad47460-4673-linux-x86_64/' X_PLEX_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx "/usr/lib/plexmediaserver/Plex Media Scanner" --match --type 1 --log-file-suffix " Matcher" --item 702663
> May 28, 2024 01:50:01.458 [139442897562424] DEBUG - Activity: updated activity f8f14f84-86f0-4800-bcbb-70acee109930 - completed 100.0% - Scanning 外语电影
> May 28, 2024 01:50:01.739 [139443107277624] DEBUG - Jobs: '/usr/lib/plexmediaserver/Plex Media Scanner' exit code for process 12982 is 0 (success)
> ```
> fix后立刻入库，能立刻搜索
