### PR TITLE
格式化代码

### DIFF
--- a/app/api/endpoints/bangumi.py
+++ b/app/api/endpoints/bangumi.py
@@ -1,4 +1,4 @@
-from typing import List, Any
+from typing import Any
 
 from fastapi import APIRouter, Depends
 
@@ -10,7 +10,7 @@ from app.core.security import verify_token
 router = APIRouter()
 
 
-@router.get("/calendar", summary="Bangumi每日放送", response_model=List[schemas.MediaInfo])
+@router.get("/calendar", summary="Bangumi每日放送", response_model=list[schemas.MediaInfo])
 def calendar(page: int = 1,
              count: int = 30,
              _: schemas.TokenPayload = Depends(verify_token)) -> Any:
@@ -23,7 +23,7 @@ def calendar(page: int = 1,
     return []
 
 
-@router.get("/credits/{bangumiid}", summary="查询Bangumi演职员表", response_model=List[schemas.MediaPerson])
+@router.get("/credits/{bangumiid}", summary="查询Bangumi演职员表", response_model=list[schemas.MediaPerson])
 def bangumi_credits(bangumiid: int,
                     page: int = 1,
                     count: int = 20,
@@ -37,7 +37,7 @@ def bangumi_credits(bangumiid: int,
     return []
 
 
-@router.get("/recommend/{bangumiid}", summary="查询Bangumi推荐", response_model=List[schemas.MediaInfo])
+@router.get("/recommend/{bangumiid}", summary="查询Bangumi推荐", response_model=list[schemas.MediaInfo])
 def bangumi_recommend(bangumiid: int,
                       page: int = 1,
                       count: int = 20,
@@ -60,7 +60,7 @@ def bangumi_person(person_id: int,
     return BangumiChain().person_detail(person_id=person_id)
 
 
-@router.get("/person/credits/{person_id}", summary="人物参演作品", response_model=List[schemas.MediaInfo])
+@router.get("/person/credits/{person_id}", summary="人物参演作品", response_model=list[schemas.MediaInfo])
 def bangumi_person_credits(person_id: int,
                            page: int = 1,
                            _: schemas.TokenPayload = Depends(verify_token)) -> Any:

--- a/app/api/endpoints/dashboard.py
+++ b/app/api/endpoints/dashboard.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
@@ -21,7 +21,7 @@ def statistic(_: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
     查询媒体数量统计信息
     """
-    media_statistics: Optional[List[schemas.Statistic]] = DashboardChain().media_statistic()
+    media_statistics: Optional[list[schemas.Statistic]] = DashboardChain().media_statistic()
     if media_statistics:
         # 汇总各媒体库统计信息
         ret_statistic = schemas.Statistic()
@@ -64,7 +64,7 @@ def storage2(_: str = Depends(verify_uri_token)) -> Any:
     return storage()
 
 
-@router.get("/processes", summary="进程信息", response_model=List[schemas.ProcessInfo])
+@router.get("/processes", summary="进程信息", response_model=list[schemas.ProcessInfo])
 def processes(_: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
     查询进程信息
@@ -101,7 +101,7 @@ def downloader2(_: str = Depends(verify_uri_token)) -> Any:
     return downloader()
 
 
-@router.get("/schedule", summary="后台服务", response_model=List[schemas.ScheduleInfo])
+@router.get("/schedule", summary="后台服务", response_model=list[schemas.ScheduleInfo])
 def schedule(_: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
     查询后台服务信息
@@ -109,7 +109,7 @@ def schedule(_: schemas.TokenPayload = Depends(verify_token)) -> Any:
     return Scheduler().list()
 
 
-@router.get("/schedule2", summary="后台服务（API_TOKEN）", response_model=List[schemas.ScheduleInfo])
+@router.get("/schedule2", summary="后台服务（API_TOKEN）", response_model=list[schemas.ScheduleInfo])
 def schedule2(_: str = Depends(verify_uri_token)) -> Any:
     """
     查询下载器信息 API_TOKEN认证（?token=xxx）
@@ -117,7 +117,7 @@ def schedule2(_: str = Depends(verify_uri_token)) -> Any:
     return schedule()
 
 
-@router.get("/transfer", summary="文件整理统计", response_model=List[int])
+@router.get("/transfer", summary="文件整理统计", response_model=list[int])
 def transfer(days: int = 7, db: Session = Depends(get_db),
              _: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
@@ -143,7 +143,7 @@ def cpu2(_: str = Depends(verify_uri_token)) -> Any:
     return cpu()
 
 
-@router.get("/memory", summary="获取当前内存使用量和使用率", response_model=List[int])
+@router.get("/memory", summary="获取当前内存使用量和使用率", response_model=list[int])
 def memory(_: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
     获取当前内存使用率
@@ -151,7 +151,7 @@ def memory(_: schemas.TokenPayload = Depends(verify_token)) -> Any:
     return SystemUtils.memory_usage()
 
 
-@router.get("/memory2", summary="获取当前内存使用量和使用率（API_TOKEN）", response_model=List[int])
+@router.get("/memory2", summary="获取当前内存使用量和使用率（API_TOKEN）", response_model=list[int])
 def memory2(_: str = Depends(verify_uri_token)) -> Any:
     """
     获取当前内存使用率 API_TOKEN认证（?token=xxx）

--- a/app/api/endpoints/douban.py
+++ b/app/api/endpoints/douban.py
@@ -1,4 +1,4 @@
-from typing import List, Any
+from typing import Any
 
 from fastapi import APIRouter, Depends, Response
 
@@ -37,7 +37,7 @@ def douban_person(person_id: int,
     return DoubanChain().person_detail(person_id=person_id)
 
 
-@router.get("/person/credits/{person_id}", summary="人物参演作品", response_model=List[schemas.MediaInfo])
+@router.get("/person/credits/{person_id}", summary="人物参演作品", response_model=list[schemas.MediaInfo])
 def douban_person_credits(person_id: int,
                           page: int = 1,
                           _: schemas.TokenPayload = Depends(verify_token)) -> Any:
@@ -50,7 +50,7 @@ def douban_person_credits(person_id: int,
     return []
 
 
-@router.get("/showing", summary="豆瓣正在热映", response_model=List[schemas.MediaInfo])
+@router.get("/showing", summary="豆瓣正在热映", response_model=list[schemas.MediaInfo])
 def movie_showing(page: int = 1,
                   count: int = 30,
                   _: schemas.TokenPayload = Depends(verify_token)) -> Any:
@@ -63,7 +63,7 @@ def movie_showing(page: int = 1,
     return []
 
 
-@router.get("/movies", summary="豆瓣电影", response_model=List[schemas.MediaInfo])
+@router.get("/movies", summary="豆瓣电影", response_model=list[schemas.MediaInfo])
 def douban_movies(sort: str = "R",
                   tags: str = "",
                   page: int = 1,
@@ -79,7 +79,7 @@ def douban_movies(sort: str = "R",
     return []
 
 
-@router.get("/tvs", summary="豆瓣剧集", response_model=List[schemas.MediaInfo])
+@router.get("/tvs", summary="豆瓣剧集", response_model=list[schemas.MediaInfo])
 def douban_tvs(sort: str = "R",
                tags: str = "",
                page: int = 1,
@@ -95,7 +95,7 @@ def douban_tvs(sort: str = "R",
     return []
 
 
-@router.get("/movie_top250", summary="豆瓣电影TOP250", response_model=List[schemas.MediaInfo])
+@router.get("/movie_top250", summary="豆瓣电影TOP250", response_model=list[schemas.MediaInfo])
 def movie_top250(page: int = 1,
                  count: int = 30,
                  _: schemas.TokenPayload = Depends(verify_token)) -> Any:
@@ -108,7 +108,7 @@ def movie_top250(page: int = 1,
     return []
 
 
-@router.get("/tv_weekly_chinese", summary="豆瓣国产剧集周榜", response_model=List[schemas.MediaInfo])
+@router.get("/tv_weekly_chinese", summary="豆瓣国产剧集周榜", response_model=list[schemas.MediaInfo])
 def tv_weekly_chinese(page: int = 1,
                       count: int = 30,
                       _: schemas.TokenPayload = Depends(verify_token)) -> Any:
@@ -121,7 +121,7 @@ def tv_weekly_chinese(page: int = 1,
     return []
 
 
-@router.get("/tv_weekly_global", summary="豆瓣全球剧集周榜", response_model=List[schemas.MediaInfo])
+@router.get("/tv_weekly_global", summary="豆瓣全球剧集周榜", response_model=list[schemas.MediaInfo])
 def tv_weekly_global(page: int = 1,
                      count: int = 30,
                      _: schemas.TokenPayload = Depends(verify_token)) -> Any:
@@ -134,7 +134,7 @@ def tv_weekly_global(page: int = 1,
     return []
 
 
-@router.get("/tv_animation", summary="豆瓣动画剧集", response_model=List[schemas.MediaInfo])
+@router.get("/tv_animation", summary="豆瓣动画剧集", response_model=list[schemas.MediaInfo])
 def tv_animation(page: int = 1,
                  count: int = 30,
                  _: schemas.TokenPayload = Depends(verify_token)) -> Any:
@@ -147,7 +147,7 @@ def tv_animation(page: int = 1,
     return []
 
 
-@router.get("/movie_hot", summary="豆瓣热门电影", response_model=List[schemas.MediaInfo])
+@router.get("/movie_hot", summary="豆瓣热门电影", response_model=list[schemas.MediaInfo])
 def movie_hot(page: int = 1,
               count: int = 30,
               _: schemas.TokenPayload = Depends(verify_token)) -> Any:
@@ -160,7 +160,7 @@ def movie_hot(page: int = 1,
     return []
 
 
-@router.get("/tv_hot", summary="豆瓣热门电视剧", response_model=List[schemas.MediaInfo])
+@router.get("/tv_hot", summary="豆瓣热门电视剧", response_model=list[schemas.MediaInfo])
 def tv_hot(page: int = 1,
            count: int = 30,
            _: schemas.TokenPayload = Depends(verify_token)) -> Any:
@@ -173,7 +173,7 @@ def tv_hot(page: int = 1,
     return []
 
 
-@router.get("/credits/{doubanid}/{type_name}", summary="豆瓣演员阵容", response_model=List[schemas.MediaPerson])
+@router.get("/credits/{doubanid}/{type_name}", summary="豆瓣演员阵容", response_model=list[schemas.MediaPerson])
 def douban_credits(doubanid: str,
                    type_name: str,
                    page: int = 1,
@@ -189,7 +189,7 @@ def douban_credits(doubanid: str,
     return []
 
 
-@router.get("/recommend/{doubanid}/{type_name}", summary="豆瓣推荐电影/电视剧", response_model=List[schemas.MediaInfo])
+@router.get("/recommend/{doubanid}/{type_name}", summary="豆瓣推荐电影/电视剧", response_model=list[schemas.MediaInfo])
 def douban_recommend(doubanid: str,
                      type_name: str,
                      _: schemas.TokenPayload = Depends(verify_token)) -> Any:

--- a/app/api/endpoints/download.py
+++ b/app/api/endpoints/download.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any
 
 from fastapi import APIRouter, Depends
 
@@ -14,7 +14,7 @@ from app.db.userauth import get_current_active_user
 router = APIRouter()
 
 
-@router.get("/", summary="正在下载", response_model=List[schemas.DownloadingTorrent])
+@router.get("/", summary="正在下载", response_model=list[schemas.DownloadingTorrent])
 def read(
         _: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """

--- a/app/api/endpoints/filebrowser.py
+++ b/app/api/endpoints/filebrowser.py
@@ -1,6 +1,6 @@
 import shutil
 from pathlib import Path
-from typing import Any, List
+from typing import Any
 
 from fastapi import APIRouter, Depends
 from starlette.responses import FileResponse, Response
@@ -16,7 +16,7 @@ router = APIRouter()
 IMAGE_TYPES = [".jpg", ".png", ".gif", ".bmp", ".jpeg", ".webp"]
 
 
-@router.get("/list", summary="所有目录和文件", response_model=List[schemas.FileItem])
+@router.get("/list", summary="所有目录和文件", response_model=list[schemas.FileItem])
 def list_path(path: str,
               sort: str = 'time',
               _: schemas.TokenPayload = Depends(verify_token)) -> Any:

--- a/app/api/endpoints/history.py
+++ b/app/api/endpoints/history.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Any
+from typing import Any
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
@@ -18,7 +18,7 @@ from app.schemas.types import EventType
 router = APIRouter()
 
 
-@router.get("/download", summary="查询下载历史记录", response_model=List[schemas.DownloadHistory])
+@router.get("/download", summary="查询下载历史记录", response_model=list[schemas.DownloadHistory])
 def download_history(page: int = 1,
                      count: int = 30,
                      db: Session = Depends(get_db),

--- a/app/api/endpoints/media.py
+++ b/app/api/endpoints/media.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Any, Union
+from typing import Any, Union
 
 from fastapi import APIRouter, Depends
 
@@ -63,7 +63,7 @@ def recognize_file2(path: str,
     return recognize_file(path)
 
 
-@router.get("/search", summary="搜索媒体/人物信息", response_model=List[dict])
+@router.get("/search", summary="搜索媒体/人物信息", response_model=list[dict])
 def search(title: str,
            type: str = "media",
            page: int = 1,

--- a/app/api/endpoints/mediaserver.py
+++ b/app/api/endpoints/mediaserver.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Dict
+from typing import Any
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
@@ -69,7 +69,7 @@ def exists_local(title: str = None,
     })
 
 
-@router.post("/exists_remote", summary="查询已存在的剧集信息（媒体服务器）", response_model=Dict[int, list])
+@router.post("/exists_remote", summary="查询已存在的剧集信息（媒体服务器）", response_model=dict[int, list])
 def exists(media_in: schemas.MediaInfo,
            _: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
@@ -88,7 +88,7 @@ def exists(media_in: schemas.MediaInfo,
     return existsinfo.seasons
 
 
-@router.post("/notexists", summary="查询媒体库缺失信息（媒体服务器）", response_model=List[schemas.NotExistMediaInfo])
+@router.post("/notexists", summary="查询媒体库缺失信息（媒体服务器）", response_model=list[schemas.NotExistMediaInfo])
 def not_exists(media_in: schemas.MediaInfo,
                _: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
@@ -118,7 +118,7 @@ def not_exists(media_in: schemas.MediaInfo,
     return []
 
 
-@router.get("/latest", summary="最新入库条目", response_model=List[schemas.MediaServerPlayItem])
+@router.get("/latest", summary="最新入库条目", response_model=list[schemas.MediaServerPlayItem])
 def latest(count: int = 18,
            userinfo: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
@@ -127,7 +127,7 @@ def latest(count: int = 18,
     return MediaServerChain().latest(count=count, username=userinfo.username) or []
 
 
-@router.get("/playing", summary="正在播放条目", response_model=List[schemas.MediaServerPlayItem])
+@router.get("/playing", summary="正在播放条目", response_model=list[schemas.MediaServerPlayItem])
 def playing(count: int = 12,
             userinfo: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
@@ -136,7 +136,7 @@ def playing(count: int = 12,
     return MediaServerChain().playing(count=count, username=userinfo.username) or []
 
 
-@router.get("/library", summary="媒体库列表", response_model=List[schemas.MediaServerLibrary])
+@router.get("/library", summary="媒体库列表", response_model=list[schemas.MediaServerLibrary])
 def library(userinfo: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
     获取媒体服务器媒体库列表

--- a/app/api/endpoints/message.py
+++ b/app/api/endpoints/message.py
@@ -1,4 +1,4 @@
-from typing import Union, Any, List
+from typing import Union, Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends
 from fastapi import Request
@@ -55,7 +55,7 @@ def web_message(text: str, current_user: User = Depends(get_current_active_super
     return schemas.Response(success=True)
 
 
-@router.get("/web", summary="获取WEB消息", response_model=List[dict])
+@router.get("/web", summary="获取WEB消息", response_model=list[dict])
 def get_web_message(_: schemas.TokenPayload = Depends(verify_token),
                     db: Session = Depends(get_db),
                     page: int = 1,
@@ -118,7 +118,7 @@ def incoming_verify(token: str = None, echostr: str = None, msg_signature: str =
     return vocechat_verify(token)
 
 
-@router.get("/switchs", summary="查询通知消息渠道开关", response_model=List[NotificationSwitch])
+@router.get("/switchs", summary="查询通知消息渠道开关", response_model=list[NotificationSwitch])
 def read_switchs(_: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
     查询通知消息渠道开关
@@ -143,7 +143,7 @@ def read_switchs(_: schemas.TokenPayload = Depends(verify_token)) -> Any:
 
 
 @router.post("/switchs", summary="设置通知消息渠道开关", response_model=schemas.Response)
-def set_switchs(switchs: List[NotificationSwitch],
+def set_switchs(switchs: list[NotificationSwitch],
                 _: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
     设置通知消息渠道开关

--- a/app/api/endpoints/plugin.py
+++ b/app/api/endpoints/plugin.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Annotated
+from typing import Any, Annotated
 
 from fastapi import APIRouter, Depends, Header
 
@@ -36,8 +36,8 @@ def remove_plugin_api(plugin_id: str):
                 break
 
 
-@router.get("/", summary="所有插件", response_model=List[schemas.Plugin])
-def all_plugins(_: schemas.TokenPayload = Depends(verify_token), state: str = "all") -> List[schemas.Plugin]:
+@router.get("/", summary="所有插件", response_model=list[schemas.Plugin])
+def all_plugins(_: schemas.TokenPayload = Depends(verify_token), state: str = "all") -> list[schemas.Plugin]:
     """
     查询所有插件清单，包括本地插件和在线插件，插件状态：installed, market, all
     """
@@ -82,7 +82,7 @@ def all_plugins(_: schemas.TokenPayload = Depends(verify_token), state: str = "a
     return installed_plugins + market_plugins
 
 
-@router.get("/installed", summary="已安装插件", response_model=List[str])
+@router.get("/installed", summary="已安装插件", response_model=list[str])
 def installed(_: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
     查询用户已安装插件清单
@@ -143,7 +143,7 @@ def plugin_form(plugin_id: str,
 
 
 @router.get("/page/{plugin_id}", summary="获取插件数据页面")
-def plugin_page(plugin_id: str, _: schemas.TokenPayload = Depends(verify_token)) -> List[dict]:
+def plugin_page(plugin_id: str, _: schemas.TokenPayload = Depends(verify_token)) -> list[dict]:
     """
     根据插件ID获取插件数据页面
     """
@@ -151,7 +151,7 @@ def plugin_page(plugin_id: str, _: schemas.TokenPayload = Depends(verify_token))
 
 
 @router.get("/dashboard/meta", summary="获取所有插件仪表板元信息")
-def plugin_dashboard_meta(_: schemas.TokenPayload = Depends(verify_token)) -> List[dict]:
+def plugin_dashboard_meta(_: schemas.TokenPayload = Depends(verify_token)) -> list[dict]:
     """
     获取所有插件仪表板元信息
     """

--- a/app/api/endpoints/search.py
+++ b/app/api/endpoints/search.py
@@ -1,4 +1,4 @@
-from typing import List, Any
+from typing import Any
 
 from fastapi import APIRouter, Depends
 
@@ -12,7 +12,7 @@ from app.schemas.types import MediaType
 router = APIRouter()
 
 
-@router.get("/last", summary="查询搜索结果", response_model=List[schemas.Context])
+@router.get("/last", summary="查询搜索结果", response_model=list[schemas.Context])
 async def search_latest(_: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
     查询搜索结果
@@ -85,7 +85,7 @@ def search_by_id(mediaid: str,
         return schemas.Response(success=True, data=[torrent.to_dict() for torrent in torrents])
 
 
-@router.get("/title", summary="模糊搜索资源", response_model=List[schemas.TorrentInfo])
+@router.get("/title", summary="模糊搜索资源", response_model=list[schemas.TorrentInfo])
 async def search_by_title(keyword: str = None,
                           page: int = 0,
                           site: int = None,

--- a/app/api/endpoints/site.py
+++ b/app/api/endpoints/site.py
@@ -1,4 +1,4 @@
-from typing import List, Any
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
@@ -24,9 +24,9 @@ from app.utils.string import StringUtils
 router = APIRouter()
 
 
-@router.get("/", summary="所有站点", response_model=List[schemas.Site])
+@router.get("/", summary="所有站点", response_model=list[schemas.Site])
 def read_sites(db: Session = Depends(get_db),
-               _: schemas.TokenPayload = Depends(verify_token)) -> List[dict]:
+               _: schemas.TokenPayload = Depends(verify_token)) -> list[dict]:
     """
     获取站点列表
     """
@@ -125,7 +125,7 @@ def reset(db: Session = Depends(get_db),
 
 @router.post("/priorities", summary="批量更新站点优先级", response_model=schemas.Response)
 def update_sites_priority(
-        priorities: List[dict],
+        priorities: list[dict],
         db: Session = Depends(get_db),
         _: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
@@ -202,7 +202,7 @@ def site_icon(site_id: int,
     })
 
 
-@router.get("/resource/{site_id}", summary="站点资源", response_model=List[schemas.TorrentInfo])
+@router.get("/resource/{site_id}", summary="站点资源", response_model=list[schemas.TorrentInfo])
 def site_resource(site_id: int,
                   db: Session = Depends(get_db),
                   _: schemas.TokenPayload = Depends(verify_token)) -> Any:
@@ -256,8 +256,8 @@ def read_site_by_domain(
     return schemas.SiteStatistic(domain=domain)
 
 
-@router.get("/rss", summary="所有订阅站点", response_model=List[schemas.Site])
-def read_rss_sites(db: Session = Depends(get_db)) -> List[dict]:
+@router.get("/rss", summary="所有订阅站点", response_model=list[schemas.Site])
+def read_rss_sites(db: Session = Depends(get_db)) -> list[dict]:
     """
     获取站点列表
     """

--- a/app/api/endpoints/subscribe.py
+++ b/app/api/endpoints/subscribe.py
@@ -1,5 +1,5 @@
 import json
-from typing import List, Any
+from typing import Any
 
 import cn2an
 from fastapi import APIRouter, Request, BackgroundTasks, Depends, HTTPException, Header
@@ -32,7 +32,7 @@ def start_subscribe_add(title: str, year: str,
                          mtype=mtype, tmdbid=tmdbid, season=season, username=username)
 
 
-@router.get("/", summary="查询所有订阅", response_model=List[schemas.Subscribe])
+@router.get("/", summary="查询所有订阅", response_model=list[schemas.Subscribe])
 def read_subscribes(
         db: Session = Depends(get_db),
         _: schemas.TokenPayload = Depends(verify_token)) -> Any:
@@ -51,7 +51,7 @@ def read_subscribes(
     return subscribes
 
 
-@router.get("/list", summary="查询所有订阅（API_TOKEN）", response_model=List[schemas.Subscribe])
+@router.get("/list", summary="查询所有订阅（API_TOKEN）", response_model=list[schemas.Subscribe])
 def list_subscribes(_: str = Depends(verify_uri_token)) -> Any:
     """
     查询所有订阅 API_TOKEN认证（?token=xxx）
@@ -315,7 +315,7 @@ async def seerr_subscribe(request: Request, background_tasks: BackgroundTasks,
     return schemas.Response(success=True)
 
 
-@router.get("/history/{mtype}", summary="查询订阅历史", response_model=List[schemas.Subscribe])
+@router.get("/history/{mtype}", summary="查询订阅历史", response_model=list[schemas.Subscribe])
 def read_subscribe(
         mtype: str,
         page: int = 1,
@@ -348,7 +348,7 @@ def delete_subscribe(
     return schemas.Response(success=True)
 
 
-@router.get("/popular", summary="热门订阅（基于用户共享数据）", response_model=List[schemas.MediaInfo])
+@router.get("/popular", summary="热门订阅（基于用户共享数据）", response_model=list[schemas.MediaInfo])
 def popular_subscribes(
         stype: str,
         page: int = 1,

--- a/app/api/endpoints/system.py
+++ b/app/api/endpoints/system.py
@@ -215,7 +215,7 @@ def latest_version(_: schemas.TokenPayload = Depends(verify_token)):
     查询Github所有Release版本
     """
     version_res = RequestUtils(proxies=settings.PROXY, headers=settings.GITHUB_HEADERS).get_res(
-        f"https://api.github.com/repos/jxxghp/MoviePilot/releases")
+        "https://api.github.com/repos/jxxghp/MoviePilot/releases")
     if version_res:
         ver_json = version_res.json()
         if ver_json:

--- a/app/api/endpoints/tmdb.py
+++ b/app/api/endpoints/tmdb.py
@@ -1,4 +1,4 @@
-from typing import List, Any
+from typing import Any
 
 from fastapi import APIRouter, Depends
 
@@ -10,7 +10,7 @@ from app.schemas.types import MediaType
 router = APIRouter()
 
 
-@router.get("/seasons/{tmdbid}", summary="TMDB所有季", response_model=List[schemas.TmdbSeason])
+@router.get("/seasons/{tmdbid}", summary="TMDB所有季", response_model=list[schemas.TmdbSeason])
 def tmdb_seasons(tmdbid: int, _: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
     根据TMDBID查询themoviedb所有季信息
@@ -21,7 +21,7 @@ def tmdb_seasons(tmdbid: int, _: schemas.TokenPayload = Depends(verify_token)) -
     return []
 
 
-@router.get("/similar/{tmdbid}/{type_name}", summary="类似电影/电视剧", response_model=List[schemas.MediaInfo])
+@router.get("/similar/{tmdbid}/{type_name}", summary="类似电影/电视剧", response_model=list[schemas.MediaInfo])
 def tmdb_similar(tmdbid: int,
                  type_name: str,
                  _: schemas.TokenPayload = Depends(verify_token)) -> Any:
@@ -40,7 +40,7 @@ def tmdb_similar(tmdbid: int,
     return []
 
 
-@router.get("/recommend/{tmdbid}/{type_name}", summary="推荐电影/电视剧", response_model=List[schemas.MediaInfo])
+@router.get("/recommend/{tmdbid}/{type_name}", summary="推荐电影/电视剧", response_model=list[schemas.MediaInfo])
 def tmdb_recommend(tmdbid: int,
                    type_name: str,
                    _: schemas.TokenPayload = Depends(verify_token)) -> Any:
@@ -59,7 +59,7 @@ def tmdb_recommend(tmdbid: int,
     return []
 
 
-@router.get("/credits/{tmdbid}/{type_name}", summary="演员阵容", response_model=List[schemas.MediaPerson])
+@router.get("/credits/{tmdbid}/{type_name}", summary="演员阵容", response_model=list[schemas.MediaPerson])
 def tmdb_credits(tmdbid: int,
                  type_name: str,
                  page: int = 1,
@@ -86,7 +86,7 @@ def tmdb_person(person_id: int,
     return TmdbChain().person_detail(person_id=person_id)
 
 
-@router.get("/person/credits/{person_id}", summary="人物参演作品", response_model=List[schemas.MediaInfo])
+@router.get("/person/credits/{person_id}", summary="人物参演作品", response_model=list[schemas.MediaInfo])
 def tmdb_person_credits(person_id: int,
                         page: int = 1,
                         _: schemas.TokenPayload = Depends(verify_token)) -> Any:
@@ -99,7 +99,7 @@ def tmdb_person_credits(person_id: int,
     return []
 
 
-@router.get("/movies", summary="TMDB电影", response_model=List[schemas.MediaInfo])
+@router.get("/movies", summary="TMDB电影", response_model=list[schemas.MediaInfo])
 def tmdb_movies(sort_by: str = "popularity.desc",
                 with_genres: str = "",
                 with_original_language: str = "",
@@ -118,7 +118,7 @@ def tmdb_movies(sort_by: str = "popularity.desc",
     return [movie.to_dict() for movie in movies]
 
 
-@router.get("/tvs", summary="TMDB剧集", response_model=List[schemas.MediaInfo])
+@router.get("/tvs", summary="TMDB剧集", response_model=list[schemas.MediaInfo])
 def tmdb_tvs(sort_by: str = "popularity.desc",
              with_genres: str = "",
              with_original_language: str = "",
@@ -137,7 +137,7 @@ def tmdb_tvs(sort_by: str = "popularity.desc",
     return [tv.to_dict() for tv in tvs]
 
 
-@router.get("/trending", summary="TMDB流行趋势", response_model=List[schemas.MediaInfo])
+@router.get("/trending", summary="TMDB流行趋势", response_model=list[schemas.MediaInfo])
 def tmdb_trending(page: int = 1,
                   _: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
@@ -149,7 +149,7 @@ def tmdb_trending(page: int = 1,
     return [info.to_dict() for info in infos]
 
 
-@router.get("/{tmdbid}/{season}", summary="TMDB季所有集", response_model=List[schemas.TmdbEpisode])
+@router.get("/{tmdbid}/{season}", summary="TMDB季所有集", response_model=list[schemas.TmdbEpisode])
 def tmdb_season_episodes(tmdbid: int, season: int,
                          _: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """

--- a/app/api/endpoints/transfer.py
+++ b/app/api/endpoints/transfer.py
@@ -73,7 +73,7 @@ def manual_transfer(path: str = None,
     elif path:
         in_path = Path(path)
     else:
-        return schemas.Response(success=False, message=f"缺少参数：path/logid")
+        return schemas.Response(success=False, message="缺少参数：path/logid")
 
     # 类型
     mtype = MediaType(type_name) if type_name else None

--- a/app/api/endpoints/user.py
+++ b/app/api/endpoints/user.py
@@ -1,6 +1,6 @@
 import base64
 import re
-from typing import Any, List, Union
+from typing import Any, Union
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
 from sqlalchemy.orm import Session
@@ -16,7 +16,7 @@ from app.utils.otp import OtpUtils
 router = APIRouter()
 
 
-@router.get("/", summary="所有用户", response_model=List[schemas.User])
+@router.get("/", summary="所有用户", response_model=list[schemas.User])
 def read_users(
         db: Session = Depends(get_db),
         current_user: User = Depends(get_current_active_superuser),

--- a/app/api/servarr.py
+++ b/app/api/servarr.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any
 
 from fastapi import APIRouter, HTTPException, Depends
 from sqlalchemy.orm import Session
@@ -167,7 +167,7 @@ def arr_languageprofile(_: str = Depends(verify_uri_apikey)) -> Any:
     }]
 
 
-@arr_router.get("/movie", summary="所有订阅电影", response_model=List[schemas.RadarrMovie])
+@arr_router.get("/movie", summary="所有订阅电影", response_model=list[schemas.RadarrMovie])
 def arr_movies(_: str = Depends(verify_uri_apikey), db: Session = Depends(get_db)) -> Any:
     """
     查询Rardar电影
@@ -258,7 +258,7 @@ def arr_movies(_: str = Depends(verify_uri_apikey), db: Session = Depends(get_db
     return result
 
 
-@arr_router.get("/movie/lookup", summary="查询电影", response_model=List[schemas.RadarrMovie])
+@arr_router.get("/movie/lookup", summary="查询电影", response_model=list[schemas.RadarrMovie])
 def arr_movie_lookup(term: str, db: Session = Depends(get_db), _: str = Depends(verify_uri_apikey)) -> Any:
     """
     查询Rardar电影 term: `tmdb:${id}`
@@ -377,7 +377,7 @@ def arr_remove_movie(mid: int, db: Session = Depends(get_db), _: str = Depends(v
         )
 
 
-@arr_router.get("/series", summary="所有剧集", response_model=List[schemas.SonarrSeries])
+@arr_router.get("/series", summary="所有剧集", response_model=list[schemas.SonarrSeries])
 def arr_series(_: str = Depends(verify_uri_apikey), db: Session = Depends(get_db)) -> Any:
     """
     查询Sonarr剧集
@@ -537,7 +537,7 @@ def arr_series_lookup(term: str, db: Session = Depends(get_db), _: str = Depends
         return [SonarrSeries()]
 
     # 季信息
-    seas: List[int] = []
+    seas: list[int] = []
     sea_num = tvdbinfo.get('season')
     if sea_num:
         seas = list(range(1, int(sea_num) + 1))
@@ -555,7 +555,7 @@ def arr_series_lookup(term: str, db: Session = Depends(get_db), _: str = Depends
         hasfile = False
 
     # 查询订阅信息
-    seasons: List[dict] = []
+    seasons: list[dict] = []
     subscribes = Subscribe.get_by_tmdbid(db, mediainfo.tmdb_id)
     if subscribes:
         # 已监控

--- a/app/api/servcookie.py
+++ b/app/api/servcookie.py
@@ -1,8 +1,9 @@
 import gzip
 import json
 from hashlib import md5
-from typing import Annotated, Callable
-from typing import Any, Dict, Optional
+from typing import Annotated
+from collections.abc import Callable
+from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response
 from fastapi.responses import PlainTextResponse
@@ -78,7 +79,7 @@ async def update_cookie(req: schemas.CookieData):
         return {"action": "error"}
 
 
-def load_encrypt_data(uuid: str) -> Dict[str, Any]:
+def load_encrypt_data(uuid: str) -> dict[str, Any]:
     """
     加载本地加密原始数据
     """
@@ -96,7 +97,7 @@ def load_encrypt_data(uuid: str) -> Dict[str, Any]:
 
 
 def get_decrypted_cookie_data(uuid: str, password: str,
-                              encrypted: str) -> Optional[Dict[str, Any]]:
+                              encrypted: str) -> Optional[dict[str, Any]]:
     """
     加载本地加密数据并解密为Cookie
     """

--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -272,7 +272,7 @@ class ChainBase(metaclass=ABCMeta):
         """
         return self.run_module("webhook_parser", body=body, form=form, args=args)
 
-    def search_medias(self, meta: MetaBase) -> Optional[List[MediaInfo]]:
+    def search_medias(self, meta: MetaBase) -> Optional[list[MediaInfo]]:
         """
         搜索媒体信息
         :param meta:  识别的元数据
@@ -280,7 +280,7 @@ class ChainBase(metaclass=ABCMeta):
         """
         return self.run_module("search_medias", meta=meta)
 
-    def search_persons(self, name: str) -> Optional[List[MediaPerson]]:
+    def search_persons(self, name: str) -> Optional[list[MediaPerson]]:
         """
         搜索人物信息
         :param name:  人物名称
@@ -288,9 +288,9 @@ class ChainBase(metaclass=ABCMeta):
         return self.run_module("search_persons", name=name)
 
     def search_torrents(self, site: CommentedMap,
-                        keywords: List[str],
+                        keywords: list[str],
                         mtype: MediaType = None,
-                        page: int = 0) -> List[TorrentInfo]:
+                        page: int = 0) -> list[TorrentInfo]:
         """
         搜索一个站点的种子资源
         :param site:  站点
@@ -302,7 +302,7 @@ class ChainBase(metaclass=ABCMeta):
         return self.run_module("search_torrents", site=site, keywords=keywords,
                                mtype=mtype, page=page)
 
-    def refresh_torrents(self, site: CommentedMap) -> List[TorrentInfo]:
+    def refresh_torrents(self, site: CommentedMap) -> list[TorrentInfo]:
         """
         获取站点最新一页的种子，多个站点需要多线程处理
         :param site:  站点
@@ -311,9 +311,9 @@ class ChainBase(metaclass=ABCMeta):
         return self.run_module("refresh_torrents", site=site)
 
     def filter_torrents(self, rule_string: str,
-                        torrent_list: List[TorrentInfo],
-                        season_episodes: Dict[int, list] = None,
-                        mediainfo: MediaInfo = None) -> List[TorrentInfo]:
+                        torrent_list: list[TorrentInfo],
+                        season_episodes: dict[int, list] = None,
+                        mediainfo: MediaInfo = None) -> list[TorrentInfo]:
         """
         过滤种子资源
         :param rule_string:  过滤规则
@@ -327,9 +327,9 @@ class ChainBase(metaclass=ABCMeta):
                                mediainfo=mediainfo)
 
     def download(self, content: Union[Path, str], download_dir: Path, cookie: str,
-                 episodes: Set[int] = None, category: str = None,
+                 episodes: set[int] = None, category: str = None,
                  downloader: str = settings.DEFAULT_DOWNLOADER
-                 ) -> Optional[Tuple[Optional[str], str]]:
+                 ) -> Optional[tuple[Optional[str], str]]:
         """
         根据种子文件，选择并添加下载任务
         :param content:  种子文件地址或者磁力链接
@@ -358,7 +358,7 @@ class ChainBase(metaclass=ABCMeta):
     def list_torrents(self, status: TorrentStatus = None,
                       hashs: Union[list, str] = None,
                       downloader: str = settings.DEFAULT_DOWNLOADER
-                      ) -> Optional[List[Union[TransferTorrent, DownloadingTorrent]]]:
+                      ) -> Optional[list[Union[TransferTorrent, DownloadingTorrent]]]:
         """
         获取下载器种子列表
         :param status:  种子状态
@@ -370,7 +370,7 @@ class ChainBase(metaclass=ABCMeta):
 
     def transfer(self, path: Path, meta: MetaBase, mediainfo: MediaInfo,
                  transfer_type: str, target: Path = None,
-                 episodes_info: List[TmdbEpisode] = None,
+                 episodes_info: list[TmdbEpisode] = None,
                  scrape: bool = None) -> Optional[TransferInfo]:
         """
         文件转移
@@ -427,7 +427,7 @@ class ChainBase(metaclass=ABCMeta):
         return self.run_module("stop_torrents", hashs=hashs, downloader=downloader)
 
     def torrent_files(self, tid: str,
-                      downloader: str = settings.DEFAULT_DOWNLOADER) -> Optional[Union[TorrentFilesList, List[File]]]:
+                      downloader: str = settings.DEFAULT_DOWNLOADER) -> Optional[Union[TorrentFilesList, list[File]]]:
         """
         获取种子文件
         :param tid:  种子Hash
@@ -474,7 +474,7 @@ class ChainBase(metaclass=ABCMeta):
         # 发送
         self.run_module("post_message", message=message)
 
-    def post_medias_message(self, message: Notification, medias: List[MediaInfo]) -> Optional[bool]:
+    def post_medias_message(self, message: Notification, medias: list[MediaInfo]) -> Optional[bool]:
         """
         发送媒体信息选择列表
         :param message:  消息体
@@ -490,7 +490,7 @@ class ChainBase(metaclass=ABCMeta):
                              note=note_list)
         return self.run_module("post_medias_message", message=message, medias=medias)
 
-    def post_torrents_message(self, message: Notification, torrents: List[Context]) -> Optional[bool]:
+    def post_torrents_message(self, message: Notification, torrents: list[Context]) -> Optional[bool]:
         """
         发送种子信息选择列表
         :param message:  消息体
@@ -521,14 +521,14 @@ class ChainBase(metaclass=ABCMeta):
         self.run_module("scrape_metadata", path=path, mediainfo=mediainfo, metainfo=metainfo,
                         transfer_type=transfer_type, force_nfo=force_nfo, force_img=force_img)
 
-    def media_category(self) -> Optional[Dict[str, list]]:
+    def media_category(self) -> Optional[dict[str, list]]:
         """
         获取媒体分类
         :return: 获取二级分类配置字典项，需包括电影、电视剧
         """
         return self.run_module("media_category")
 
-    def register_commands(self, commands: Dict[str, dict]) -> None:
+    def register_commands(self, commands: dict[str, dict]) -> None:
         """
         注册菜单命令
         """

--- a/app/chain/bangumi.py
+++ b/app/chain/bangumi.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional
 
 from app import schemas
 from app.chain import ChainBase
@@ -11,7 +11,7 @@ class BangumiChain(ChainBase, metaclass=Singleton):
     Bangumi处理链，单例运行
     """
 
-    def calendar(self) -> Optional[List[MediaInfo]]:
+    def calendar(self) -> Optional[list[MediaInfo]]:
         """
         获取Bangumi每日放送
         """
@@ -25,14 +25,14 @@ class BangumiChain(ChainBase, metaclass=Singleton):
         """
         return self.run_module("bangumi_info", bangumiid=bangumiid)
 
-    def bangumi_credits(self, bangumiid: int) -> List[schemas.MediaPerson]:
+    def bangumi_credits(self, bangumiid: int) -> list[schemas.MediaPerson]:
         """
         根据BangumiID查询电影演职员表
         :param bangumiid:  BangumiID
         """
         return self.run_module("bangumi_credits", bangumiid=bangumiid)
 
-    def bangumi_recommend(self, bangumiid: int) -> Optional[List[MediaInfo]]:
+    def bangumi_recommend(self, bangumiid: int) -> Optional[list[MediaInfo]]:
         """
         根据BangumiID查询推荐电影
         :param bangumiid:  BangumiID
@@ -46,7 +46,7 @@ class BangumiChain(ChainBase, metaclass=Singleton):
         """
         return self.run_module("bangumi_person_detail", person_id=person_id)
 
-    def person_credits(self, person_id: int) -> Optional[List[MediaInfo]]:
+    def person_credits(self, person_id: int) -> Optional[list[MediaInfo]]:
         """
         根据人物ID查询人物参演作品
         :param person_id:  人物ID

--- a/app/chain/dashboard.py
+++ b/app/chain/dashboard.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional
 
 from app import schemas
 from app.chain import ChainBase
@@ -9,13 +9,13 @@ class DashboardChain(ChainBase, metaclass=Singleton):
     """
     各类仪表板统计处理链
     """
-    def media_statistic(self) -> Optional[List[schemas.Statistic]]:
+    def media_statistic(self) -> Optional[list[schemas.Statistic]]:
         """
         媒体数量统计
         """
         return self.run_module("media_statistic")
 
-    def downloader_info(self) -> Optional[List[schemas.DownloaderInfo]]:
+    def downloader_info(self) -> Optional[list[schemas.DownloaderInfo]]:
         """
         下载器信息
         """

--- a/app/chain/douban.py
+++ b/app/chain/douban.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional
 
 from app import schemas
 from app.chain import ChainBase
@@ -19,7 +19,7 @@ class DoubanChain(ChainBase, metaclass=Singleton):
         """
         return self.run_module("douban_person_detail", person_id=person_id)
 
-    def person_credits(self, person_id: int, page: int = 1) -> List[MediaInfo]:
+    def person_credits(self, person_id: int, page: int = 1) -> list[MediaInfo]:
         """
         根据人物ID查询人物参演作品
         :param person_id:  人物ID
@@ -27,7 +27,7 @@ class DoubanChain(ChainBase, metaclass=Singleton):
         """
         return self.run_module("douban_person_credits", person_id=person_id, page=page)
 
-    def movie_top250(self, page: int = 1, count: int = 30) -> Optional[List[MediaInfo]]:
+    def movie_top250(self, page: int = 1, count: int = 30) -> Optional[list[MediaInfo]]:
         """
         获取豆瓣电影TOP250
         :param page:  页码
@@ -35,26 +35,26 @@ class DoubanChain(ChainBase, metaclass=Singleton):
         """
         return self.run_module("movie_top250", page=page, count=count)
 
-    def movie_showing(self, page: int = 1, count: int = 30) -> Optional[List[MediaInfo]]:
+    def movie_showing(self, page: int = 1, count: int = 30) -> Optional[list[MediaInfo]]:
         """
         获取正在上映的电影
         """
         return self.run_module("movie_showing", page=page, count=count)
 
-    def tv_weekly_chinese(self, page: int = 1, count: int = 30) -> Optional[List[MediaInfo]]:
+    def tv_weekly_chinese(self, page: int = 1, count: int = 30) -> Optional[list[MediaInfo]]:
         """
         获取本周中国剧集榜
         """
         return self.run_module("tv_weekly_chinese", page=page, count=count)
 
-    def tv_weekly_global(self, page: int = 1, count: int = 30) -> Optional[List[MediaInfo]]:
+    def tv_weekly_global(self, page: int = 1, count: int = 30) -> Optional[list[MediaInfo]]:
         """
         获取本周全球剧集榜
         """
         return self.run_module("tv_weekly_global", page=page, count=count)
 
     def douban_discover(self, mtype: MediaType, sort: str, tags: str,
-                        page: int = 0, count: int = 30) -> Optional[List[MediaInfo]]:
+                        page: int = 0, count: int = 30) -> Optional[list[MediaInfo]]:
         """
         发现豆瓣电影、剧集
         :param mtype:  媒体类型
@@ -67,46 +67,46 @@ class DoubanChain(ChainBase, metaclass=Singleton):
         return self.run_module("douban_discover", mtype=mtype, sort=sort, tags=tags,
                                page=page, count=count)
 
-    def tv_animation(self, page: int = 1, count: int = 30) -> Optional[List[MediaInfo]]:
+    def tv_animation(self, page: int = 1, count: int = 30) -> Optional[list[MediaInfo]]:
         """
         获取动画剧集
         """
         return self.run_module("tv_animation", page=page, count=count)
 
-    def movie_hot(self, page: int = 1, count: int = 30) -> Optional[List[MediaInfo]]:
+    def movie_hot(self, page: int = 1, count: int = 30) -> Optional[list[MediaInfo]]:
         """
         获取热门电影
         """
         return self.run_module("movie_hot", page=page, count=count)
 
-    def tv_hot(self, page: int = 1, count: int = 30) -> Optional[List[MediaInfo]]:
+    def tv_hot(self, page: int = 1, count: int = 30) -> Optional[list[MediaInfo]]:
         """
         获取热门剧集
         """
         return self.run_module("tv_hot", page=page, count=count)
 
-    def movie_credits(self, doubanid: str) -> Optional[List[schemas.MediaPerson]]:
+    def movie_credits(self, doubanid: str) -> Optional[list[schemas.MediaPerson]]:
         """
         根据TMDBID查询电影演职人员
         :param doubanid:  豆瓣ID
         """
         return self.run_module("douban_movie_credits", doubanid=doubanid)
 
-    def tv_credits(self, doubanid: str) -> Optional[List[schemas.MediaPerson]]:
+    def tv_credits(self, doubanid: str) -> Optional[list[schemas.MediaPerson]]:
         """
         根据TMDBID查询电视剧演职人员
         :param doubanid:  豆瓣ID
         """
         return self.run_module("douban_tv_credits", doubanid=doubanid)
 
-    def movie_recommend(self, doubanid: str) -> List[MediaInfo]:
+    def movie_recommend(self, doubanid: str) -> list[MediaInfo]:
         """
         根据豆瓣ID查询推荐电影
         :param doubanid:  豆瓣ID
         """
         return self.run_module("douban_movie_recommend", doubanid=doubanid)
 
-    def tv_recommend(self, doubanid: str) -> List[MediaInfo]:
+    def tv_recommend(self, doubanid: str) -> list[MediaInfo]:
         """
         根据豆瓣ID查询推荐电视剧
         :param doubanid:  豆瓣ID

--- a/app/chain/download.py
+++ b/app/chain/download.py
@@ -4,7 +4,7 @@ import json
 import re
 import time
 from pathlib import Path
-from typing import List, Optional, Tuple, Set, Dict, Union
+from typing import Optional, Union
 
 from app.chain import ChainBase
 from app.core.config import settings
@@ -93,7 +93,7 @@ class DownloadChain(ChainBase):
     def download_torrent(self, torrent: TorrentInfo,
                          channel: MessageChannel = None,
                          userid: Union[str, int] = None
-                         ) -> Tuple[Optional[Union[Path, str]], str, list]:
+                         ) -> tuple[Optional[Union[Path, str]], str, list]:
         """
         下载种子文件，如果是磁力链，会返回磁力链接本身
         :return: 种子路径，种子目录名，种子文件清单
@@ -114,7 +114,7 @@ class DownloadChain(ChainBase):
                     return url
                 # 解码参数
                 req_str = base64.b64decode(base64_str.encode('utf-8')).decode('utf-8')
-                req_params: Dict[str, dict] = json.loads(req_str)
+                req_params: dict[str, dict] = json.loads(req_str)
                 # 是否使用cookie
                 if not req_params.get('cookie'):
                     cookie = None
@@ -195,7 +195,7 @@ class DownloadChain(ChainBase):
         return torrent_file, download_folder, files
 
     def download_single(self, context: Context, torrent_file: Path = None,
-                        episodes: Set[int] = None,
+                        episodes: set[int] = None,
                         channel: MessageChannel = None,
                         save_path: str = None,
                         userid: Union[str, int] = None,
@@ -354,13 +354,13 @@ class DownloadChain(ChainBase):
         return _hash
 
     def batch_download(self,
-                       contexts: List[Context],
-                       no_exists: Dict[Union[int, str], Dict[int, NotExistMediaInfo]] = None,
+                       contexts: list[Context],
+                       no_exists: dict[Union[int, str], dict[int, NotExistMediaInfo]] = None,
                        save_path: str = None,
                        channel: MessageChannel = None,
                        userid: str = None,
                        username: str = None
-                       ) -> Tuple[List[Context], Dict[Union[int, str], Dict[int, NotExistMediaInfo]]]:
+                       ) -> tuple[list[Context], dict[Union[int, str], dict[int, NotExistMediaInfo]]]:
         """
         根据缺失数据，自动种子列表中组合择优下载
         :param contexts:  资源上下文列表
@@ -372,7 +372,7 @@ class DownloadChain(ChainBase):
         :return: 已经下载的资源列表、剩余未下载到的剧集 no_exists[tmdb_id/douban_id] = {season: NotExistMediaInfo}
         """
         # 已下载的项目
-        downloaded_list: List[Context] = []
+        downloaded_list: list[Context] = []
 
         def __update_seasons(_mid: Union[int, str], _need: list, _current: list) -> list:
             """
@@ -446,7 +446,7 @@ class DownloadChain(ChainBase):
         logger.info(f"开始匹配电视剧整季：{no_exists}")
         if no_exists:
             # 先把整季缺失的拿出来，看是否刚好有所有季都满足的种子 {tmdbid: [seasons]}
-            need_seasons: Dict[int, list] = {}
+            need_seasons: dict[int, list] = {}
             for need_mid, need_tv in no_exists.items():
                 for tv in need_tv.values():
                     if not tv:
@@ -702,9 +702,9 @@ class DownloadChain(ChainBase):
 
     def get_no_exists_info(self, meta: MetaBase,
                            mediainfo: MediaInfo,
-                           no_exists: Dict[int, Dict[int, NotExistMediaInfo]] = None,
-                           totals: Dict[int, int] = None
-                           ) -> Tuple[bool, Dict[Union[int, str], Dict[int, NotExistMediaInfo]]]:
+                           no_exists: dict[int, dict[int, NotExistMediaInfo]] = None,
+                           totals: dict[int, int] = None
+                           ) -> tuple[bool, dict[Union[int, str], dict[int, NotExistMediaInfo]]]:
         """
         检查媒体库，查询是否存在，对于剧集同时返回不存在的季集信息
         :param meta: 元数据
@@ -765,7 +765,7 @@ class DownloadChain(ChainBase):
                                                             tmdbid=mediainfo.tmdb_id,
                                                             doubanid=mediainfo.douban_id)
                 if not mediainfo:
-                    logger.error(f"媒体信息识别失败！")
+                    logger.error("媒体信息识别失败！")
                     return False, {}
                 if not mediainfo.seasons:
                     logger.error(f"媒体信息中没有季集信息：{mediainfo.title_year}")
@@ -855,7 +855,7 @@ class DownloadChain(ChainBase):
             channel=channel, mtype=NotificationType.Download,
             title=title, text="\n".join(messages), userid=userid))
 
-    def downloading(self) -> List[DownloadingTorrent]:
+    def downloading(self) -> list[DownloadingTorrent]:
         """
         查询正在下载的任务
         """

--- a/app/chain/media.py
+++ b/app/chain/media.py
@@ -2,7 +2,7 @@ import copy
 import time
 from pathlib import Path
 from threading import Lock
-from typing import Optional, List, Tuple
+from typing import Optional
 
 from app.chain import ChainBase
 from app.core.context import Context, MediaInfo
@@ -80,9 +80,9 @@ class MediaChain(ChainBase, metaclass=Singleton):
             meta_dict = copy.deepcopy(self.recognize_temp)
         logger.info(f'获取到辅助识别结果：{meta_dict}')
         if meta_dict.get("name") == org_meta.name and meta_dict.get("year") == org_meta.year:
-            logger.info(f'辅助识别结果与原始识别结果一致')
+            logger.info('辅助识别结果与原始识别结果一致')
         else:
-            logger.info(f'辅助识别结果与原始识别结果不一致，重新匹配媒体信息 ...')
+            logger.info('辅助识别结果与原始识别结果不一致，重新匹配媒体信息 ...')
             org_meta.name = meta_dict.get("name")
             org_meta.year = meta_dict.get("year")
             org_meta.begin_season = meta_dict.get("season")
@@ -156,7 +156,7 @@ class MediaChain(ChainBase, metaclass=Singleton):
         # 返回上下文
         return Context(meta_info=file_meta, media_info=mediainfo)
 
-    def search(self, title: str) -> Tuple[Optional[MetaBase], List[MediaInfo]]:
+    def search(self, title: str) -> tuple[Optional[MetaBase], list[MediaInfo]]:
         """
         搜索媒体/人物信息
         :param title: 搜索内容
@@ -179,7 +179,7 @@ class MediaChain(ChainBase, metaclass=Singleton):
             meta.year = year
         # 开始搜索
         logger.info(f"开始搜索媒体信息：{meta.name}")
-        medias: Optional[List[MediaInfo]] = self.search_medias(meta=meta)
+        medias: Optional[list[MediaInfo]] = self.search_medias(meta=meta)
         if not medias:
             logger.warn(f"{meta.name} 没有找到对应的媒体信息！")
             return meta, []

--- a/app/chain/mediaserver.py
+++ b/app/chain/mediaserver.py
@@ -1,6 +1,6 @@
 import json
 import threading
-from typing import List, Union, Optional
+from typing import Union, Optional
 
 from app import schemas
 from app.chain import ChainBase
@@ -20,13 +20,13 @@ class MediaServerChain(ChainBase):
         super().__init__()
         self.dboper = MediaServerOper()
 
-    def librarys(self, server: str = None, username: str = None) -> List[schemas.MediaServerLibrary]:
+    def librarys(self, server: str = None, username: str = None) -> list[schemas.MediaServerLibrary]:
         """
         获取媒体服务器所有媒体库
         """
         return self.run_module("mediaserver_librarys", server=server, username=username)
 
-    def items(self, server: str, library_id: Union[str, int]) -> List[schemas.MediaServerItem]:
+    def items(self, server: str, library_id: Union[str, int]) -> list[schemas.MediaServerItem]:
         """
         获取媒体服务器所有项目
         """
@@ -38,19 +38,19 @@ class MediaServerChain(ChainBase):
         """
         return self.run_module("mediaserver_iteminfo", server=server, item_id=item_id)
 
-    def episodes(self, server: str, item_id: Union[str, int]) -> List[schemas.MediaServerSeasonInfo]:
+    def episodes(self, server: str, item_id: Union[str, int]) -> list[schemas.MediaServerSeasonInfo]:
         """
         获取媒体服务器剧集信息
         """
         return self.run_module("mediaserver_tv_episodes", server=server, item_id=item_id)
 
-    def playing(self, count: int = 20, server: str = None, username: str = None) -> List[schemas.MediaServerPlayItem]:
+    def playing(self, count: int = 20, server: str = None, username: str = None) -> list[schemas.MediaServerPlayItem]:
         """
         获取媒体服务器正在播放信息
         """
         return self.run_module("mediaserver_playing", count=count, server=server, username=username)
 
-    def latest(self, count: int = 20, server: str = None, username: str = None) -> List[schemas.MediaServerPlayItem]:
+    def latest(self, count: int = 20, server: str = None, username: str = None) -> list[schemas.MediaServerPlayItem]:
         """
         获取媒体服务器最新入库条目
         """

--- a/app/chain/message.py
+++ b/app/chain/message.py
@@ -1,7 +1,7 @@
 import copy
 import json
 import re
-from typing import Any, Optional, Dict, Union
+from typing import Any, Optional, Union
 
 from app.chain import ChainBase
 from app.chain.download import DownloadChain
@@ -51,7 +51,7 @@ class MessageChain(ChainBase):
     def __get_noexits_info(
             self,
             _meta: MetaBase,
-            _mediainfo: MediaInfo) -> Dict[Union[int, str], Dict[int, NotExistMediaInfo]]:
+            _mediainfo: MediaInfo) -> dict[Union[int, str], dict[int, NotExistMediaInfo]]:
         """
         获取缺失的媒体信息
         """
@@ -134,7 +134,7 @@ class MessageChain(ChainBase):
         # 申明全局变量
         global _current_page, _current_meta, _current_media
         # 加载缓存
-        user_cache: Dict[str, dict] = self.load_cache(self._cache_file) or {}
+        user_cache: dict[str, dict] = self.load_cache(self._cache_file) or {}
         # 处理消息
         logger.info(f'收到用户消息内容，用户：{userid}，内容：{text}')
         # 保存消息
@@ -448,7 +448,7 @@ class MessageChain(ChainBase):
 
     def __auto_download(self, channel: MessageChannel, cache_list: list[Context],
                         userid: Union[str, int], username: str,
-                        no_exists: Optional[Dict[Union[int, str], Dict[int, NotExistMediaInfo]]] = None):
+                        no_exists: Optional[dict[Union[int, str], dict[int, NotExistMediaInfo]]] = None):
         """
         自动择优下载
         """

--- a/app/chain/search.py
+++ b/app/chain/search.py
@@ -2,8 +2,7 @@ import pickle
 import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
-from typing import Dict
-from typing import List, Optional
+from typing import Optional
 
 from app.chain import ChainBase
 from app.core.context import Context
@@ -32,7 +31,7 @@ class SearchChain(ChainBase):
         self.torrenthelper = TorrentHelper()
 
     def search_by_id(self, tmdbid: int = None, doubanid: str = None,
-                     mtype: MediaType = None, area: str = "title", season: int = None) -> List[Context]:
+                     mtype: MediaType = None, area: str = "title", season: int = None) -> list[Context]:
         """
         根据TMDBID/豆瓣ID搜索资源，精确匹配，但不不过滤本地存在的资源
         :param tmdbid: TMDB ID
@@ -58,7 +57,7 @@ class SearchChain(ChainBase):
         self.systemconfig.set(SystemConfigKey.SearchResults, bytes_results)
         return results
 
-    def search_by_title(self, title: str, page: int = 0, site: int = None) -> List[TorrentInfo]:
+    def search_by_title(self, title: str, page: int = 0, site: int = None) -> list[TorrentInfo]:
         """
         根据标题搜索资源，不识别不过滤，直接返回站点内容
         :param title: 标题，为空时返回所有站点首页内容
@@ -72,7 +71,7 @@ class SearchChain(ChainBase):
         # 搜索
         return self.__search_all_sites(keywords=[title], sites=[site] if site else None, page=page) or []
 
-    def last_search_results(self) -> List[Context]:
+    def last_search_results(self) -> list[Context]:
         """
         获取上次搜索结果
         """
@@ -87,11 +86,11 @@ class SearchChain(ChainBase):
 
     def process(self, mediainfo: MediaInfo,
                 keyword: str = None,
-                no_exists: Dict[int, Dict[int, NotExistMediaInfo]] = None,
-                sites: List[int] = None,
+                no_exists: dict[int, dict[int, NotExistMediaInfo]] = None,
+                sites: list[int] = None,
                 priority_rule: str = None,
-                filter_rule: Dict[str, str] = None,
-                area: str = "title") -> List[Context]:
+                filter_rule: dict[str, str] = None,
+                area: str = "title") -> list[Context]:
         """
         根据媒体信息搜索种子资源，精确匹配，应用过滤规则，同时根据no_exists过滤本地已存在的资源
         :param mediainfo: 媒体信息
@@ -103,7 +102,7 @@ class SearchChain(ChainBase):
         :param area: 搜索范围，title or imdbid
         """
 
-        def __do_filter(torrent_list: List[TorrentInfo]) -> List[TorrentInfo]:
+        def __do_filter(torrent_list: list[TorrentInfo]) -> list[TorrentInfo]:
             """
             执行优先级过滤
             """
@@ -125,7 +124,7 @@ class SearchChain(ChainBase):
                                                         tmdbid=mediainfo.tmdb_id,
                                                         doubanid=mediainfo.douban_id)
             if not mediainfo:
-                logger.error(f'媒体信息识别失败！')
+                logger.error('媒体信息识别失败！')
                 return []
 
         # 缺失的季集
@@ -151,7 +150,7 @@ class SearchChain(ChainBase):
                                                        mediainfo.sg_title] if k]))
 
         # 执行搜索
-        torrents: List[TorrentInfo] = self.__search_all_sites(
+        torrents: list[TorrentInfo] = self.__search_all_sites(
             mediainfo=mediainfo,
             keywords=keywords,
             sites=sites,
@@ -260,11 +259,11 @@ class SearchChain(ChainBase):
         # 返回
         return contexts
 
-    def __search_all_sites(self, keywords: List[str],
+    def __search_all_sites(self, keywords: list[str],
                            mediainfo: Optional[MediaInfo] = None,
-                           sites: List[int] = None,
+                           sites: list[int] = None,
                            page: int = 0,
-                           area: str = "title") -> Optional[List[TorrentInfo]]:
+                           area: str = "title") -> Optional[list[TorrentInfo]]:
         """
         多线程搜索多个站点
         :param mediainfo:  识别的媒体信息
@@ -347,10 +346,10 @@ class SearchChain(ChainBase):
         return results
 
     def filter_torrents_by_rule(self,
-                                torrents: List[TorrentInfo],
+                                torrents: list[TorrentInfo],
                                 mediainfo: MediaInfo,
-                                filter_rule: Dict[str, str] = None,
-                                ) -> List[TorrentInfo]:
+                                filter_rule: dict[str, str] = None,
+                                ) -> list[TorrentInfo]:
         """
         使用过滤规则过滤种子
         :param torrents: 种子列表

--- a/app/chain/site.py
+++ b/app/chain/site.py
@@ -1,7 +1,7 @@
 import base64
 import re
 from datetime import datetime
-from typing import Tuple, Optional
+from typing import Optional
 from typing import Union
 from urllib.parse import urljoin
 
@@ -65,7 +65,7 @@ class SiteChain(ChainBase):
         return domain in self.special_site_test
 
     @staticmethod
-    def __zhuque_test(site: Site) -> Tuple[bool, str]:
+    def __zhuque_test(site: Site) -> tuple[bool, str]:
         """
         判断站点是否已经登陆：zhuique
         """
@@ -102,7 +102,7 @@ class SiteChain(ChainBase):
         return False, "Cookie已失效"
 
     @staticmethod
-    def __mteam_test(site: Site) -> Tuple[bool, str]:
+    def __mteam_test(site: Site) -> tuple[bool, str]:
         """
         判断站点是否已经登陆：m-team
         """
@@ -131,11 +131,11 @@ class SiteChain(ChainBase):
                 if res:
                     return True, "连接成功"
                 else:
-                    return True, f"连接成功，但更新状态失败"
+                    return True, "连接成功，但更新状态失败"
         return False, "鉴权已过期或无效"
 
     @staticmethod
-    def __yema_test(site: Site) -> Tuple[bool, str]:
+    def __yema_test(site: Site) -> tuple[bool, str]:
         """
         判断站点是否已经登陆：yemapt
         """
@@ -158,7 +158,7 @@ class SiteChain(ChainBase):
                 return True, "连接成功"
         return False, "Cookie已过期"
 
-    def __indexphp_test(self, site: Site) -> Tuple[bool, str]:
+    def __indexphp_test(self, site: Site) -> tuple[bool, str]:
         """
         判断站点是否已经登陆：ptlsp/1ptba
         """
@@ -166,7 +166,7 @@ class SiteChain(ChainBase):
         return self.__test(site)
 
     @staticmethod
-    def __parse_favicon(url: str, cookie: str, ua: str) -> Tuple[str, Optional[str]]:
+    def __parse_favicon(url: str, cookie: str, ua: str) -> tuple[str, Optional[str]]:
         """
         解析站点favicon,返回base64 fav图标
         :param url: 站点地址
@@ -194,7 +194,7 @@ class SiteChain(ChainBase):
             logger.error(f"获取站点图标失败：{favicon_url}")
         return favicon_url, None
 
-    def sync_cookies(self, manual=False) -> Tuple[bool, str]:
+    def sync_cookies(self, manual=False) -> tuple[bool, str]:
         """
         通过CookieCloud同步站点Cookie
         """
@@ -370,7 +370,7 @@ class SiteChain(ChainBase):
                 logger.info(f"清理站点配置：{key}")
                 self.systemconfig.delete(key)
 
-    def test(self, url: str) -> Tuple[bool, str]:
+    def test(self, url: str) -> tuple[bool, str]:
         """
         测试站点是否可用
         :param url: 站点域名
@@ -403,7 +403,7 @@ class SiteChain(ChainBase):
             return False, f"{str(e)}！"
 
     @staticmethod
-    def __test(site_info: Site) -> Tuple[bool, str]:
+    def __test(site_info: Site) -> tuple[bool, str]:
         """
         通用站点测试
         """
@@ -423,8 +423,8 @@ class SiteChain(ChainBase):
                                                              proxies=proxy_server)
             if not public and not SiteUtils.is_logged_in(page_source):
                 if under_challenge(page_source):
-                    return False, f"无法通过Cloudflare！"
-                return False, f"仿真登录失败，Cookie已失效！"
+                    return False, "无法通过Cloudflare！"
+                return False, "仿真登录失败，Cookie已失效！"
         else:
             res = RequestUtils(cookies=site_cookie,
                                ua=ua,
@@ -445,7 +445,7 @@ class SiteChain(ChainBase):
             elif res is not None:
                 return False, f"状态码：{res.status_code}！"
             else:
-                return False, f"无法打开网站！"
+                return False, "无法打开网站！"
         return True, "连接成功"
 
     def remote_list(self, channel: MessageChannel, userid: Union[str, int] = None):
@@ -527,7 +527,7 @@ class SiteChain(ChainBase):
         self.remote_list(channel, userid)
 
     def update_cookie(self, site_info: Site,
-                      username: str, password: str, two_step_code: str = None) -> Tuple[bool, str]:
+                      username: str, password: str, two_step_code: str = None) -> tuple[bool, str]:
         """
         根据用户名密码更新站点Cookie
         :param site_info: 站点信息

--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -3,7 +3,7 @@ import random
 import time
 from datetime import datetime
 from json import JSONDecodeError
-from typing import Dict, List, Optional, Union, Tuple
+from typing import Optional, Union
 
 from app.chain import ChainBase
 from app.chain.download import DownloadChain
@@ -58,7 +58,7 @@ class SubscribeChain(ChainBase):
             username: str = None,
             message: bool = True,
             exist_ok: bool = False,
-            **kwargs) -> Tuple[Optional[int], str]:
+            **kwargs) -> tuple[Optional[int], str]:
         """
         识别媒体信息并添加订阅
         """
@@ -110,7 +110,7 @@ class SubscribeChain(ChainBase):
                                                      bangumiid=mediainfo.bangumi_id,
                                                      cache=False)
                     if not mediainfo:
-                        logger.error(f"媒体信息识别失败！")
+                        logger.error("媒体信息识别失败！")
                         return None, "媒体信息识别失败"
                     if not mediainfo.seasons:
                         logger.error(f"媒体信息中没有季集信息，标题：{title}，tmdbid：{tmdbid}，doubanid：{doubanid}")
@@ -390,7 +390,7 @@ class SubscribeChain(ChainBase):
                 self.message.put('所有订阅搜索完成！', title="订阅搜索", role="system")
 
     def update_subscribe_priority(self, subscribe: Subscribe, meta: MetaInfo,
-                                  mediainfo: MediaInfo, downloads: List[Context]):
+                                  mediainfo: MediaInfo, downloads: list[Context]):
         """
         更新订阅已下载资源的优先级
         """
@@ -411,8 +411,8 @@ class SubscribeChain(ChainBase):
             })
 
     def finish_subscribe_or_not(self, subscribe: Subscribe, meta: MetaInfo, mediainfo: MediaInfo,
-                                downloads: List[Context] = None,
-                                lefts: Dict[Union[int | str], Dict[int, NotExistMediaInfo]] = None,
+                                downloads: list[Context] = None,
+                                lefts: dict[Union[int | str], dict[int, NotExistMediaInfo]] = None,
                                 force: bool = False):
         """
         判断是否应完成订阅
@@ -461,7 +461,7 @@ class SubscribeChain(ChainBase):
             self.torrentschain.refresh(sites=sites)
         )
 
-    def get_sub_sites(self, subscribe: Subscribe) -> List[int]:
+    def get_sub_sites(self, subscribe: Subscribe) -> list[int]:
         """
         获取订阅中涉及的站点清单
         """
@@ -473,7 +473,7 @@ class SubscribeChain(ChainBase):
         # 默认站点
         return self.systemconfig.get(SystemConfigKey.RssSites) or []
 
-    def get_subscribed_sites(self) -> Optional[List[int]]:
+    def get_subscribed_sites(self) -> Optional[list[int]]:
         """
         获取订阅中涉及的所有站点清单（节约资源）
         :return: 返回[]代表所有站点命中，返回None代表没有订阅
@@ -511,7 +511,7 @@ class SubscribeChain(ChainBase):
             "min_seeders_time": default_rule.get("min_seeders_time"),
         }
 
-    def match(self, torrents: Dict[str, List[Context]]):
+    def match(self, torrents: dict[str, list[Context]]):
         """
         从缓存中匹配订阅，并自动下载
         """
@@ -662,7 +662,7 @@ class SubscribeChain(ChainBase):
                         priority_rule = self.systemconfig.get(SystemConfigKey.BestVersionFilterRules)
                     else:
                         priority_rule = self.systemconfig.get(SystemConfigKey.SubscribeFilterRules)
-                    result: List[TorrentInfo] = self.filter_torrents(
+                    result: list[TorrentInfo] = self.filter_torrents(
                         rule_string=priority_rule,
                         torrent_list=[torrent_info],
                         mediainfo=torrent_mediainfo)
@@ -809,7 +809,7 @@ class SubscribeChain(ChainBase):
             })
             logger.info(f'{subscribe.name} 订阅元数据更新完成')
 
-    def __update_subscribe_note(self, subscribe: Subscribe, downloads: List[Context]):
+    def __update_subscribe_note(self, subscribe: Subscribe, downloads: list[Context]):
         """
         更新已下载集数到note字段
         """
@@ -844,7 +844,7 @@ class SubscribeChain(ChainBase):
             })
 
     @staticmethod
-    def __check_subscribe_note(subscribe: Subscribe, episodes: List[int]) -> bool:
+    def __check_subscribe_note(subscribe: Subscribe, episodes: list[int]) -> bool:
         """
         检查当前集是否已下载过
         """
@@ -860,7 +860,7 @@ class SubscribeChain(ChainBase):
             return True
         return False
 
-    def __update_lack_episodes(self, lefts: Dict[Union[int, str], Dict[int, NotExistMediaInfo]],
+    def __update_lack_episodes(self, lefts: dict[Union[int, str], dict[int, NotExistMediaInfo]],
                                subscribe: Subscribe,
                                mediainfo: MediaInfo,
                                update_date: bool = False):
@@ -979,7 +979,7 @@ class SubscribeChain(ChainBase):
         self.remote_list(channel, userid)
 
     @staticmethod
-    def __get_subscribe_no_exits(no_exists: Dict[Union[int, str], Dict[int, NotExistMediaInfo]],
+    def __get_subscribe_no_exits(no_exists: dict[Union[int, str], dict[int, NotExistMediaInfo]],
                                  mediakey: Union[str, int],
                                  begin_season: int,
                                  total_episode: int,

--- a/app/chain/system.py
+++ b/app/chain/system.py
@@ -25,7 +25,7 @@ class SystemChain(ChainBase, metaclass=Singleton):
         """
         self.clear_cache()
         self.post_message(Notification(channel=channel,
-                                       title=f"缓存清理完成！", userid=userid))
+                                       title="缓存清理完成！", userid=userid))
 
     def restart(self, channel: MessageChannel, userid: Union[int, str]):
         """

--- a/app/chain/tmdb.py
+++ b/app/chain/tmdb.py
@@ -1,5 +1,5 @@
 import random
-from typing import Optional, List
+from typing import Optional
 
 from cachetools import cached, TTLCache
 
@@ -17,7 +17,7 @@ class TmdbChain(ChainBase, metaclass=Singleton):
     """
 
     def tmdb_discover(self, mtype: MediaType, sort_by: str, with_genres: str,
-                      with_original_language: str, page: int = 1) -> Optional[List[MediaInfo]]:
+                      with_original_language: str, page: int = 1) -> Optional[list[MediaInfo]]:
         """
         :param mtype:  媒体类型
         :param sort_by:  排序方式
@@ -31,7 +31,7 @@ class TmdbChain(ChainBase, metaclass=Singleton):
                                with_original_language=with_original_language,
                                page=page)
 
-    def tmdb_trending(self, page: int = 1) -> Optional[List[MediaInfo]]:
+    def tmdb_trending(self, page: int = 1) -> Optional[list[MediaInfo]]:
         """
         TMDB流行趋势
         :param page: 第几页
@@ -39,14 +39,14 @@ class TmdbChain(ChainBase, metaclass=Singleton):
         """
         return self.run_module("tmdb_trending", page=page)
 
-    def tmdb_seasons(self, tmdbid: int) -> List[schemas.TmdbSeason]:
+    def tmdb_seasons(self, tmdbid: int) -> list[schemas.TmdbSeason]:
         """
         根据TMDBID查询themoviedb所有季信息
         :param tmdbid:  TMDBID
         """
         return self.run_module("tmdb_seasons", tmdbid=tmdbid)
 
-    def tmdb_episodes(self, tmdbid: int, season: int) -> List[schemas.TmdbEpisode]:
+    def tmdb_episodes(self, tmdbid: int, season: int) -> list[schemas.TmdbEpisode]:
         """
         根据TMDBID查询某季的所有信信息
         :param tmdbid:  TMDBID
@@ -54,35 +54,35 @@ class TmdbChain(ChainBase, metaclass=Singleton):
         """
         return self.run_module("tmdb_episodes", tmdbid=tmdbid, season=season)
 
-    def movie_similar(self, tmdbid: int) -> Optional[List[MediaInfo]]:
+    def movie_similar(self, tmdbid: int) -> Optional[list[MediaInfo]]:
         """
         根据TMDBID查询类似电影
         :param tmdbid:  TMDBID
         """
         return self.run_module("tmdb_movie_similar", tmdbid=tmdbid)
 
-    def tv_similar(self, tmdbid: int) -> Optional[List[MediaInfo]]:
+    def tv_similar(self, tmdbid: int) -> Optional[list[MediaInfo]]:
         """
         根据TMDBID查询类似电视剧
         :param tmdbid:  TMDBID
         """
         return self.run_module("tmdb_tv_similar", tmdbid=tmdbid)
 
-    def movie_recommend(self, tmdbid: int) -> Optional[List[MediaInfo]]:
+    def movie_recommend(self, tmdbid: int) -> Optional[list[MediaInfo]]:
         """
         根据TMDBID查询推荐电影
         :param tmdbid:  TMDBID
         """
         return self.run_module("tmdb_movie_recommend", tmdbid=tmdbid)
 
-    def tv_recommend(self, tmdbid: int) -> Optional[List[MediaInfo]]:
+    def tv_recommend(self, tmdbid: int) -> Optional[list[MediaInfo]]:
         """
         根据TMDBID查询推荐电视剧
         :param tmdbid:  TMDBID
         """
         return self.run_module("tmdb_tv_recommend", tmdbid=tmdbid)
 
-    def movie_credits(self, tmdbid: int, page: int = 1) -> Optional[List[schemas.MediaPerson]]:
+    def movie_credits(self, tmdbid: int, page: int = 1) -> Optional[list[schemas.MediaPerson]]:
         """
         根据TMDBID查询电影演职人员
         :param tmdbid:  TMDBID
@@ -90,7 +90,7 @@ class TmdbChain(ChainBase, metaclass=Singleton):
         """
         return self.run_module("tmdb_movie_credits", tmdbid=tmdbid, page=page)
 
-    def tv_credits(self, tmdbid: int, page: int = 1) -> Optional[List[schemas.MediaPerson]]:
+    def tv_credits(self, tmdbid: int, page: int = 1) -> Optional[list[schemas.MediaPerson]]:
         """
         根据TMDBID查询电视剧演职人员
         :param tmdbid:  TMDBID
@@ -105,7 +105,7 @@ class TmdbChain(ChainBase, metaclass=Singleton):
         """
         return self.run_module("tmdb_person_detail", person_id=person_id)
 
-    def person_credits(self, person_id: int, page: int = 1) -> Optional[List[MediaInfo]]:
+    def person_credits(self, person_id: int, page: int = 1) -> Optional[list[MediaInfo]]:
         """
         根据人物ID查询人物参演作品
         :param person_id:  人物ID

--- a/app/chain/torrents.py
+++ b/app/chain/torrents.py
@@ -1,6 +1,6 @@
 import re
 import traceback
-from typing import Dict, List, Union
+from typing import Union
 
 from cachetools import cached, TTLCache
 
@@ -43,12 +43,12 @@ class TorrentsChain(ChainBase, metaclass=Singleton):
         远程刷新订阅，发送消息
         """
         self.post_message(Notification(channel=channel,
-                                       title=f"开始刷新种子 ...", userid=userid))
+                                       title="开始刷新种子 ...", userid=userid))
         self.refresh()
         self.post_message(Notification(channel=channel,
-                                       title=f"种子刷新完成！", userid=userid))
+                                       title="种子刷新完成！", userid=userid))
 
-    def get_torrents(self, stype: str = None) -> Dict[str, List[Context]]:
+    def get_torrents(self, stype: str = None) -> dict[str, list[Context]]:
         """
         获取当前缓存的种子
         :param stype: 强制指定缓存类型，spider:爬虫缓存，rss:rss缓存
@@ -67,13 +67,13 @@ class TorrentsChain(ChainBase, metaclass=Singleton):
         """
         清理种子缓存数据
         """
-        logger.info(f'开始清理种子缓存数据 ...')
+        logger.info('开始清理种子缓存数据 ...')
         self.remove_cache(self._spider_file)
         self.remove_cache(self._rss_file)
-        logger.info(f'种子缓存数据清理完成')
+        logger.info('种子缓存数据清理完成')
 
     @cached(cache=TTLCache(maxsize=128, ttl=595))
-    def browse(self, domain: str) -> List[TorrentInfo]:
+    def browse(self, domain: str) -> list[TorrentInfo]:
         """
         浏览站点首页内容，返回种子清单，TTL缓存10分钟
         :param domain: 站点域名
@@ -86,7 +86,7 @@ class TorrentsChain(ChainBase, metaclass=Singleton):
         return self.refresh_torrents(site=site)
 
     @cached(cache=TTLCache(maxsize=128, ttl=295))
-    def rss(self, domain: str) -> List[TorrentInfo]:
+    def rss(self, domain: str) -> list[TorrentInfo]:
         """
         获取站点RSS内容，返回种子清单，TTL缓存5分钟
         :param domain: 站点域名
@@ -108,7 +108,7 @@ class TorrentsChain(ChainBase, metaclass=Singleton):
             logger.error(f'站点 {domain} 未获取到RSS数据！')
             return []
         # 组装种子
-        ret_torrents: List[TorrentInfo] = []
+        ret_torrents: list[TorrentInfo] = []
         for item in rss_items:
             if not item.get("title"):
                 continue
@@ -129,7 +129,7 @@ class TorrentsChain(ChainBase, metaclass=Singleton):
 
         return ret_torrents
 
-    def refresh(self, stype: str = None, sites: List[int] = None) -> Dict[str, List[Context]]:
+    def refresh(self, stype: str = None, sites: list[int] = None) -> dict[str, list[Context]]:
         """
         刷新站点最新资源，识别并缓存起来
         :param stype: 强制指定缓存类型，spider:爬虫缓存，rss:rss缓存
@@ -164,10 +164,10 @@ class TorrentsChain(ChainBase, metaclass=Singleton):
             domains.append(domain)
             if stype == "spider":
                 # 刷新首页种子
-                torrents: List[TorrentInfo] = self.browse(domain=domain)
+                torrents: list[TorrentInfo] = self.browse(domain=domain)
             else:
                 # 刷新RSS种子
-                torrents: List[TorrentInfo] = self.rss(domain=domain)
+                torrents: list[TorrentInfo] = self.rss(domain=domain)
             # 按pubdate降序排列
             torrents.sort(key=lambda x: x.pubdate or '', reverse=True)
             # 取前N条

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -2,7 +2,7 @@ import re
 import shutil
 import threading
 from pathlib import Path
-from typing import List, Optional, Tuple, Union, Dict
+from typing import Optional, Union
 
 from app.chain import ChainBase
 from app.chain.media import MediaChain
@@ -55,7 +55,7 @@ class TransferChain(ChainBase):
         with lock:
             logger.info("开始执行下载器文件转移 ...")
             # 从下载器获取种子列表
-            torrents: Optional[List[TransferTorrent]] = self.list_torrents(status=TorrentStatus.TRANSFER)
+            torrents: Optional[list[TransferTorrent]] = self.list_torrents(status=TorrentStatus.TRANSFER)
             if not torrents:
                 logger.info("没有获取到已完成的下载任务")
                 return False
@@ -94,7 +94,7 @@ class TransferChain(ChainBase):
                     target: Path = None, transfer_type: str = None,
                     season: int = None, epformat: EpisodeFormat = None,
                     min_filesize: int = 0, scrape: bool = None,
-                    force: bool = False) -> Tuple[bool, str]:
+                    force: bool = False) -> tuple[bool, str]:
         """
         执行一个复杂目录的转移操作
         :param path: 待转移目录或文件
@@ -136,7 +136,7 @@ class TransferChain(ChainBase):
             transfer_files = [f for f in transfer_files if formaterHandler.match(f.name)]
 
         # 汇总错误信息
-        err_msgs: List[str] = []
+        err_msgs: list[str] = []
         # 总文件数
         total_num = len(transfer_files)
         # 已处理数量
@@ -155,13 +155,13 @@ class TransferChain(ChainBase):
         # 处理所有待转移目录或文件，默认一个转移路径或文件只有一个媒体信息
         for trans_path in trans_paths:
             # 汇总季集清单
-            season_episodes: Dict[Tuple, List[int]] = {}
+            season_episodes: dict[tuple, list[int]] = {}
             # 汇总元数据
-            metas: Dict[Tuple, MetaBase] = {}
+            metas: dict[tuple, MetaBase] = {}
             # 汇总媒体信息
-            medias: Dict[Tuple, MediaInfo] = {}
+            medias: dict[tuple, MediaInfo] = {}
             # 汇总转移信息
-            transfers: Dict[Tuple, TransferInfo] = {}
+            transfers: dict[tuple, TransferInfo] = {}
 
             # 如果是目录且不是⼀蓝光原盘，获取所有文件并转移
             if (not trans_path.is_file()
@@ -510,7 +510,7 @@ class TransferChain(ChainBase):
             return
 
     def re_transfer(self, logid: int, mtype: MediaType = None,
-                    mediaid: str = None) -> Tuple[bool, str]:
+                    mediaid: str = None) -> tuple[bool, str]:
         """
         根据历史记录，重新识别转移，只支持简单条件
         :param logid: 历史记录ID
@@ -564,7 +564,7 @@ class TransferChain(ChainBase):
                         epformat: EpisodeFormat = None,
                         min_filesize: int = 0,
                         scrape: bool = None,
-                        force: bool = False) -> Tuple[bool, Union[str, list]]:
+                        force: bool = False) -> tuple[bool, Union[str, list]]:
         """
         手动转移，支持复杂条件，带进度显示
         :param in_path: 源文件路径
@@ -644,7 +644,7 @@ class TransferChain(ChainBase):
             mtype=NotificationType.Organize,
             title=msg_title, text=msg_str, image=mediainfo.get_message_image()))
 
-    def delete_files(self, path: Path) -> Tuple[bool, str]:
+    def delete_files(self, path: Path) -> tuple[bool, str]:
         """
         删除转移后的文件以及空目录
         :param path: 文件路径

--- a/app/command.py
+++ b/app/command.py
@@ -2,7 +2,7 @@ import importlib
 import threading
 import traceback
 from threading import Thread
-from typing import Any, Union, Dict
+from typing import Any, Union
 
 from app.chain import ChainBase
 from app.chain.download import DownloadChain
@@ -235,7 +235,7 @@ class Command(metaclass=Singleton):
                             }
                         )
 
-    def __run_command(self, command: Dict[str, any],
+    def __run_command(self, command: dict[str, any],
                       data_str: str = "",
                       channel: MessageChannel = None, userid: Union[str, int] = None):
         """

--- a/app/core/context.py
+++ b/app/core/context.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass, field, asdict
-from typing import List, Dict, Any, Tuple
+from typing import Any
 
 from app.core.config import settings
 from app.core.meta import MetaBase
@@ -178,9 +178,9 @@ class MediaInfo:
     # 所有别名和译名
     names: list = field(default_factory=list)
     # 各季的剧集清单信息
-    seasons: Dict[int, list] = field(default_factory=dict)
+    seasons: dict[int, list] = field(default_factory=dict)
     # 各季详情
-    season_info: List[dict] = field(default_factory=list)
+    season_info: list[dict] = field(default_factory=list)
     # 各季的年份
     season_years: dict = field(default_factory=dict)
     # 二级分类
@@ -192,9 +192,9 @@ class MediaInfo:
     # Bangumi INFO
     bangumi_info: dict = field(default_factory=dict)
     # 导演
-    directors: List[dict] = field(default_factory=list)
+    directors: list[dict] = field(default_factory=list)
     # 演员
-    actors: List[dict] = field(default_factory=list)
+    actors: list[dict] = field(default_factory=list)
     # 是否成人内容
     adult: bool = False
     # 创建人
@@ -202,7 +202,7 @@ class MediaInfo:
     # 集时长
     episode_run_time: list = field(default_factory=list)
     # 风格
-    genres: List[dict] = field(default_factory=list)
+    genres: list[dict] = field(default_factory=list)
     # 首播日期
     first_air_date: str = None
     # 首页
@@ -301,7 +301,7 @@ class MediaInfo:
         初始化媒信息
         """
 
-        def __directors_actors(tmdbinfo: dict) -> Tuple[List[dict], List[dict]]:
+        def __directors_actors(tmdbinfo: dict) -> tuple[list[dict], list[dict]]:
             """
             查询导演和演员
             :param tmdbinfo: TMDB元数据

--- a/app/core/event.py
+++ b/app/core/event.py
@@ -1,5 +1,5 @@
 from queue import Queue, Empty
-from typing import Dict, Any
+from typing import Any
 
 from app.log import logger
 from app.utils.singleton import Singleton
@@ -15,7 +15,7 @@ class EventManager(metaclass=Singleton):
         # 事件队列
         self._eventQueue = Queue()
         # 事件响应函数字典
-        self._handlers: Dict[str, Dict[str, Any]] = {}
+        self._handlers: dict[str, dict[str, Any]] = {}
         # 已禁用的事件响应
         self._disabled_handlers = []
 

--- a/app/core/meta/__init__.py
+++ b/app/core/meta/__init__.py
@@ -1,3 +1,3 @@
-from .metabase import MetaBase
-from .metavideo import MetaVideo
-from .metaanime import MetaAnime
+from .metabase import MetaBase as MetaBase
+from .metavideo import MetaVideo as MetaVideo
+from .metaanime import MetaAnime as MetaAnime

--- a/app/core/meta/metabase.py
+++ b/app/core/meta/metabase.py
@@ -1,6 +1,6 @@
 import traceback
 from dataclasses import dataclass, asdict
-from typing import Union, Optional, List, Self
+from typing import Union, Optional, Self
 
 import cn2an
 import regex as re
@@ -60,7 +60,7 @@ class MetaBase(object):
     # 音频编码
     audio_encode: Optional[str] = None
     # 应用的识别词信息
-    apply_words: Optional[List[str]] = None
+    apply_words: Optional[list[str]] = None
     # 附加信息
     tmdbid: int = None
     doubanid: str = None
@@ -306,7 +306,7 @@ class MetaBase(object):
                 return ""
 
     @property
-    def season_list(self) -> List[int]:
+    def season_list(self) -> list[int]:
         """
         返回季的数组
         """
@@ -336,7 +336,7 @@ class MetaBase(object):
             return ""
 
     @property
-    def episode_list(self) -> List[int]:
+    def episode_list(self) -> list[int]:
         """
         返回集的数组
         """

--- a/app/core/meta/words.py
+++ b/app/core/meta/words.py
@@ -1,4 +1,3 @@
-from typing import List, Tuple
 
 import cn2an
 import regex as re
@@ -14,7 +13,7 @@ class WordsMatcher(metaclass=Singleton):
     def __init__(self):
         self.systemconfig = SystemConfigOper()
 
-    def prepare(self, title: str) -> Tuple[str, List[str]]:
+    def prepare(self, title: str) -> tuple[str, list[str]]:
         """
         预处理标题，支持三种格式
         1：屏蔽词
@@ -23,7 +22,7 @@ class WordsMatcher(metaclass=Singleton):
         """
         appley_words = []
         # 读取自定义识别词
-        words: List[str] = self.systemconfig.get(SystemConfigKey.CustomIdentifiers) or []
+        words: list[str] = self.systemconfig.get(SystemConfigKey.CustomIdentifiers) or []
         for word in words:
             if not word or word.startswith("#"):
                 continue
@@ -69,7 +68,7 @@ class WordsMatcher(metaclass=Singleton):
         return title, appley_words
 
     @staticmethod
-    def __replace_regex(title: str, replaced: str, replace: str) -> Tuple[str, str, bool]:
+    def __replace_regex(title: str, replaced: str, replace: str) -> tuple[str, str, bool]:
         """
         正则替换
         """
@@ -83,7 +82,7 @@ class WordsMatcher(metaclass=Singleton):
             return title, str(err), False
 
     @staticmethod
-    def __episode_offset(title: str, front: str, back: str, offset: str) -> Tuple[str, str, bool]:
+    def __episode_offset(title: str, front: str, back: str, offset: str) -> tuple[str, str, bool]:
         """
         集数偏移
         """

--- a/app/core/metainfo.py
+++ b/app/core/metainfo.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Tuple
 
 import regex as re
 
@@ -99,7 +98,7 @@ def is_anime(name: str) -> bool:
     return False
 
 
-def find_metainfo(title: str) -> Tuple[str, dict]:
+def find_metainfo(title: str) -> tuple[str, dict]:
     """
     从标题中提取媒体信息
     """

--- a/app/core/module.py
+++ b/app/core/module.py
@@ -1,5 +1,6 @@
 import traceback
-from typing import Generator, Optional, Tuple, Any
+from typing import Optional, Any
+from collections.abc import Generator
 
 from app.core.config import settings
 from app.helper.module import ModuleHelper
@@ -68,7 +69,7 @@ class ModuleManager(metaclass=Singleton):
         self.stop()
         self.load_modules()
 
-    def test(self, modleid: str) -> Tuple[bool, str]:
+    def test(self, modleid: str) -> tuple[bool, str]:
         """
         测试模块
         """

--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -5,7 +5,8 @@ import os
 import threading
 import time
 import traceback
-from typing import List, Any, Dict, Tuple, Optional, Callable
+from typing import Any, Optional
+from collections.abc import Callable
 
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
@@ -319,7 +320,7 @@ class PluginManager(metaclass=Singleton):
             return False
         return self.systemconfig.delete(self._config_key % pid)
 
-    def get_plugin_form(self, pid: str) -> Tuple[List[dict], Dict[str, Any]]:
+    def get_plugin_form(self, pid: str) -> tuple[list[dict], dict[str, Any]]:
         """
         获取插件表单
         :param pid: 插件ID
@@ -331,7 +332,7 @@ class PluginManager(metaclass=Singleton):
             return plugin.get_form() or ([], {})
         return [], {}
 
-    def get_plugin_page(self, pid: str) -> List[dict]:
+    def get_plugin_page(self, pid: str) -> list[dict]:
         """
         获取插件页面
         :param pid: 插件ID
@@ -364,11 +365,11 @@ class PluginManager(metaclass=Singleton):
             # 检查方法的参数个数
             params_count = __get_params_count(plugin.get_dashboard)
             if params_count > 1:
-                dashboard: Tuple = plugin.get_dashboard(key=key, **kwargs)
+                dashboard: tuple = plugin.get_dashboard(key=key, **kwargs)
             elif params_count > 0:
-                dashboard: Tuple = plugin.get_dashboard(**kwargs)
+                dashboard: tuple = plugin.get_dashboard(**kwargs)
             else:
-                dashboard: Tuple = plugin.get_dashboard()
+                dashboard: tuple = plugin.get_dashboard()
             if dashboard:
                 cols, attrs, elements = dashboard
                 return schemas.PluginDashboard(
@@ -381,7 +382,7 @@ class PluginManager(metaclass=Singleton):
                 )
         return None
 
-    def get_plugin_commands(self) -> List[Dict[str, Any]]:
+    def get_plugin_commands(self) -> list[dict[str, Any]]:
         """
         获取插件命令
         [{
@@ -401,7 +402,7 @@ class PluginManager(metaclass=Singleton):
                     logger.error(f"获取插件命令出错：{str(e)}")
         return ret_commands
 
-    def get_plugin_apis(self, plugin_id: str = None) -> List[Dict[str, Any]]:
+    def get_plugin_apis(self, plugin_id: str = None) -> list[dict[str, Any]]:
         """
         获取插件API
         [{
@@ -427,7 +428,7 @@ class PluginManager(metaclass=Singleton):
                     logger.error(f"获取插件 {pid} API出错：{str(e)}")
         return ret_apis
 
-    def get_plugin_services(self) -> List[Dict[str, Any]]:
+    def get_plugin_services(self) -> list[dict[str, Any]]:
         """
         获取插件服务
         [{
@@ -508,24 +509,24 @@ class PluginManager(metaclass=Singleton):
             return None
         return getattr(plugin, method)(*args, **kwargs)
 
-    def get_plugin_ids(self) -> List[str]:
+    def get_plugin_ids(self) -> list[str]:
         """
         获取所有插件ID
         """
         return list(self._plugins.keys())
 
-    def get_running_plugin_ids(self) -> List[str]:
+    def get_running_plugin_ids(self) -> list[str]:
         """
         获取所有运行态插件ID
         """
         return list(self._running_plugins.keys())
 
-    def get_online_plugins(self) -> List[schemas.Plugin]:
+    def get_online_plugins(self) -> list[schemas.Plugin]:
         """
         获取所有在线插件信息
         """
 
-        def __get_plugin_info(market: str) -> Optional[List[schemas.Plugin]]:
+        def __get_plugin_info(market: str) -> Optional[list[schemas.Plugin]]:
             """
             获取插件信息
             """
@@ -641,7 +642,7 @@ class PluginManager(metaclass=Singleton):
         logger.info(f"共获取到 {len(result)} 个第三方插件")
         return result
 
-    def get_local_plugins(self) -> List[schemas.Plugin]:
+    def get_local_plugins(self) -> list[schemas.Plugin]:
         """
         获取所有本地已下载的插件信息
         """

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,5 +1,6 @@
 from typing import Any, Self, List
-from typing import Tuple, Optional, Generator
+from typing import Tuple, Optional
+from collections.abc import Generator
 
 from sqlalchemy import create_engine, QueuePool
 from sqlalchemy import inspect
@@ -57,7 +58,7 @@ def get_args_db(args: tuple, kwargs: dict) -> Optional[Session]:
     return db
 
 
-def update_args_db(args: tuple, kwargs: dict, db: Session) -> Tuple[tuple, dict]:
+def update_args_db(args: tuple, kwargs: dict, db: Session) -> tuple[tuple, dict]:
     """
     更新参数中的数据库Session对象，关键字传参时更新db的值，否则更新第1或第2个参数
     """
@@ -172,7 +173,7 @@ class Base:
 
     @classmethod
     @db_query
-    def list(cls, db: Session) -> List[Self]:
+    def list(cls, db: Session) -> list[Self]:
         result = db.query(cls).all()
         return list(result)
 

--- a/app/db/downloadhistory_oper.py
+++ b/app/db/downloadhistory_oper.py
@@ -1,4 +1,3 @@
-from typing import List
 
 from app.db import DbOper
 from app.db.models.downloadhistory import DownloadHistory, DownloadFiles
@@ -29,7 +28,7 @@ class DownloadHistoryOper(DbOper):
         """
         DownloadHistory(**kwargs).create(self._db)
 
-    def add_files(self, file_items: List[dict]):
+    def add_files(self, file_items: list[dict]):
         """
         新增下载历史文件
         """
@@ -43,7 +42,7 @@ class DownloadHistoryOper(DbOper):
         """
         DownloadFiles.truncate(self._db)
 
-    def get_files_by_hash(self, download_hash: str, state: int = None) -> List[DownloadFiles]:
+    def get_files_by_hash(self, download_hash: str, state: int = None) -> list[DownloadFiles]:
         """
         按Hash查询下载文件记录
         :param download_hash: 数据key
@@ -58,14 +57,14 @@ class DownloadHistoryOper(DbOper):
         """
         return DownloadFiles.get_by_fullpath(self._db, fullpath=fullpath, all_files=False)
 
-    def get_files_by_fullpath(self, fullpath: str) -> List[DownloadFiles]:
+    def get_files_by_fullpath(self, fullpath: str) -> list[DownloadFiles]:
         """
         按fullpath查询下载文件记录
         :param fullpath: 数据key
         """
         return DownloadFiles.get_by_fullpath(self._db, fullpath=fullpath, all_files=True)
 
-    def get_files_by_savepath(self, fullpath: str) -> List[DownloadFiles]:
+    def get_files_by_savepath(self, fullpath: str) -> list[DownloadFiles]:
         """
         按savepath查询下载文件记录
         :param fullpath: 数据key
@@ -89,7 +88,7 @@ class DownloadHistoryOper(DbOper):
             return fileinfo.download_hash
         return ""
 
-    def list_by_page(self, page: int = 1, count: int = 30) -> List[DownloadHistory]:
+    def list_by_page(self, page: int = 1, count: int = 30) -> list[DownloadHistory]:
         """
         分页查询下载历史
         """
@@ -102,7 +101,7 @@ class DownloadHistoryOper(DbOper):
         DownloadHistory.truncate(self._db)
 
     def get_last_by(self, mtype=None, title: str = None, year: str = None,
-                    season: str = None, episode: str = None, tmdbid=None) -> List[DownloadHistory]:
+                    season: str = None, episode: str = None, tmdbid=None) -> list[DownloadHistory]:
         """
         按类型、标题、年份、季集查询下载记录
         """
@@ -114,7 +113,7 @@ class DownloadHistoryOper(DbOper):
                                            episode=episode,
                                            tmdbid=tmdbid)
 
-    def list_by_user_date(self, date: str, username: str = None) -> List[DownloadHistory]:
+    def list_by_user_date(self, date: str, username: str = None) -> list[DownloadHistory]:
         """
         查询某用户某时间之前的下载历史
         """
@@ -122,7 +121,7 @@ class DownloadHistoryOper(DbOper):
                                                  date=date,
                                                  username=username)
 
-    def list_by_date(self, date: str, type: str, tmdbid: str, seasons: str = None) -> List[DownloadHistory]:
+    def list_by_date(self, date: str, type: str, tmdbid: str, seasons: str = None) -> list[DownloadHistory]:
         """
         查询某时间之后的下载历史
         """
@@ -132,7 +131,7 @@ class DownloadHistoryOper(DbOper):
                                             tmdbid=tmdbid,
                                             seasons=seasons)
 
-    def list_by_type(self, mtype: str, days: int = 7) -> List[DownloadHistory]:
+    def list_by_type(self, mtype: str, days: int = 7) -> list[DownloadHistory]:
         """
         获取指定类型的下载历史
         """

--- a/app/db/models/__init__.py
+++ b/app/db/models/__init__.py
@@ -1,10 +1,10 @@
-from .downloadhistory import DownloadHistory, DownloadFiles
-from .mediaserver import MediaServerItem
-from .plugindata import PluginData
-from .site import Site
-from .siteicon import SiteIcon
-from .subscribe import Subscribe
-from .systemconfig import SystemConfig
-from .transferhistory import TransferHistory
-from .user import User
-from .userconfig import UserConfig
+from .downloadhistory import DownloadHistory as DownloadHistory, DownloadFiles as DownloadFiles
+from .mediaserver import MediaServerItem as MediaServerItem
+from .plugindata import PluginData as PluginData
+from .site import Site as Site
+from .siteicon import SiteIcon as SiteIcon
+from .subscribe import Subscribe as Subscribe
+from .systemconfig import SystemConfig as SystemConfig
+from .transferhistory import TransferHistory as TransferHistory
+from .user import User as User
+from .userconfig import UserConfig as UserConfig

--- a/app/db/models/user.py
+++ b/app/db/models/user.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Optional
+from typing import Optional
 
 from sqlalchemy import Boolean, Column, Integer, String, Sequence
 from sqlalchemy.orm import Session
@@ -34,7 +34,7 @@ class User(Base):
 
     @staticmethod
     @db_query
-    def authenticate(db: Session, name: str, password: str, otp_password: str) -> Tuple[bool, Optional[User]]:
+    def authenticate(db: Session, name: str, password: str, otp_password: str) -> tuple[bool, Optional[User]]:
         user = db.query(User).filter(User.name == name).first()
         if not user:
             return False, None

--- a/app/db/site_oper.py
+++ b/app/db/site_oper.py
@@ -1,7 +1,7 @@
-from typing import Tuple, List
 
 from app.db import DbOper
 from app.db.models.site import Site
+import builtins
 
 
 class SiteOper(DbOper):
@@ -9,7 +9,7 @@ class SiteOper(DbOper):
     站点管理
     """
 
-    def add(self, **kwargs) -> Tuple[bool, str]:
+    def add(self, **kwargs) -> tuple[bool, str]:
         """
         新增站点
         """
@@ -25,19 +25,19 @@ class SiteOper(DbOper):
         """
         return Site.get(self._db, sid)
 
-    def list(self) -> List[Site]:
+    def list(self) -> list[Site]:
         """
         获取站点列表
         """
         return Site.list(self._db)
 
-    def list_order_by_pri(self) -> List[Site]:
+    def list_order_by_pri(self) -> builtins.list[Site]:
         """
         获取站点列表
         """
         return Site.list_order_by_pri(self._db)
 
-    def list_active(self) -> List[Site]:
+    def list_active(self) -> builtins.list[Site]:
         """
         按状态获取站点列表
         """
@@ -63,7 +63,7 @@ class SiteOper(DbOper):
         """
         return Site.get_by_domain(self._db, domain)
 
-    def get_domains_by_ids(self, ids: List[int]) -> List[str]:
+    def get_domains_by_ids(self, ids: builtins.list[int]) -> builtins.list[str]:
         """
         按ID获取站点域名
         """
@@ -75,7 +75,7 @@ class SiteOper(DbOper):
         """
         return Site.get_by_domain(self._db, domain) is not None
 
-    def update_cookie(self, domain: str, cookies: str) -> Tuple[bool, str]:
+    def update_cookie(self, domain: str, cookies: str) -> tuple[bool, str]:
         """
         更新站点Cookie
         """
@@ -87,7 +87,7 @@ class SiteOper(DbOper):
         })
         return True, "更新站点Cookie成功"
 
-    def update_rss(self, domain: str, rss: str) -> Tuple[bool, str]:
+    def update_rss(self, domain: str, rss: str) -> tuple[bool, str]:
         """
         更新站点rss
         """

--- a/app/db/siteicon_oper.py
+++ b/app/db/siteicon_oper.py
@@ -1,4 +1,3 @@
-from typing import List
 
 from app.db import DbOper
 from app.db.models.siteicon import SiteIcon
@@ -9,7 +8,7 @@ class SiteIconOper(DbOper):
     站点管理
     """
 
-    def list(self) -> List[SiteIcon]:
+    def list(self) -> list[SiteIcon]:
         """
         获取站点图标列表
         """

--- a/app/db/subscribe_oper.py
+++ b/app/db/subscribe_oper.py
@@ -1,10 +1,10 @@
 import json
 import time
-from typing import Tuple, List
 
 from app.core.context import MediaInfo
 from app.db import DbOper
 from app.db.models.subscribe import Subscribe
+import builtins
 
 
 class SubscribeOper(DbOper):
@@ -12,7 +12,7 @@ class SubscribeOper(DbOper):
     订阅管理
     """
 
-    def add(self, mediainfo: MediaInfo, **kwargs) -> Tuple[int, str]:
+    def add(self, mediainfo: MediaInfo, **kwargs) -> tuple[int, str]:
         """
         新增订阅
         """
@@ -67,7 +67,7 @@ class SubscribeOper(DbOper):
         """
         return Subscribe.get(self._db, rid=sid)
 
-    def list(self, state: str = None) -> List[Subscribe]:
+    def list(self, state: str = None) -> list[Subscribe]:
         """
         获取订阅列表
         """
@@ -89,13 +89,13 @@ class SubscribeOper(DbOper):
         subscribe.update(self._db, payload)
         return subscribe
 
-    def list_by_tmdbid(self, tmdbid: int, season: int = None) -> List[Subscribe]:
+    def list_by_tmdbid(self, tmdbid: int, season: int = None) -> builtins.list[Subscribe]:
         """
         获取指定tmdb_id的订阅
         """
         return Subscribe.get_by_tmdbid(self._db, tmdbid=tmdbid, season=season)
 
-    def list_by_username(self, username: str, state: str = None, mtype: str = None) -> List[Subscribe]:
+    def list_by_username(self, username: str, state: str = None, mtype: str = None) -> builtins.list[Subscribe]:
         """
         获取指定用户的订阅
         """

--- a/app/db/transferhistory_oper.py
+++ b/app/db/transferhistory_oper.py
@@ -1,7 +1,7 @@
 import json
 import time
 from pathlib import Path
-from typing import Any, List
+from typing import Any
 
 from app.core.context import MediaInfo
 from app.core.meta import MetaBase
@@ -22,7 +22,7 @@ class TransferHistoryOper(DbOper):
         """
         return TransferHistory.get(self._db, historyid)
 
-    def get_by_title(self, title: str) -> List[TransferHistory]:
+    def get_by_title(self, title: str) -> list[TransferHistory]:
         """
         按标题查询转移记录
         :param title: 数据key
@@ -36,7 +36,7 @@ class TransferHistoryOper(DbOper):
         """
         return TransferHistory.get_by_src(self._db, src)
 
-    def list_by_hash(self, download_hash: str) -> List[TransferHistory]:
+    def list_by_hash(self, download_hash: str) -> list[TransferHistory]:
         """
         按种子hash查询转移记录
         :param download_hash: 种子hash
@@ -52,14 +52,14 @@ class TransferHistoryOper(DbOper):
         })
         TransferHistory(**kwargs).create(self._db)
 
-    def statistic(self, days: int = 7) -> List[Any]:
+    def statistic(self, days: int = 7) -> list[Any]:
         """
         统计最近days天的下载历史数量
         """
         return TransferHistory.statistic(self._db, days)
 
     def get_by(self, title: str = None, year: str = None, mtype: str = None,
-               season: str = None, episode: str = None, tmdbid: int = None, dest: str = None) -> List[TransferHistory]:
+               season: str = None, episode: str = None, tmdbid: int = None, dest: str = None) -> list[TransferHistory]:
         """
         按类型、标题、年份、季集查询转移记录
         """
@@ -178,7 +178,7 @@ class TransferHistoryOper(DbOper):
             )
         return his
 
-    def list_by_date(self, date: str) -> List[TransferHistory]:
+    def list_by_date(self, date: str) -> list[TransferHistory]:
         """
         查询某时间之后的转移历史
         :param date: 日期

--- a/app/db/userconfig_oper.py
+++ b/app/db/userconfig_oper.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Union, Dict, Optional
+from typing import Any, Union, Optional
 
 from app.db import DbOper
 from app.db.models.userconfig import UserConfig
@@ -10,7 +10,7 @@ from app.utils.singleton import Singleton
 
 class UserConfigOper(DbOper, metaclass=Singleton):
     # 配置缓存
-    __USERCONF: Dict[str, Dict[str, Any]] = {}
+    __USERCONF: dict[str, dict[str, Any]] = {}
 
     def __init__(self):
         """
@@ -76,7 +76,7 @@ class UserConfigOper(DbOper, metaclass=Singleton):
         user_cache[key] = value
         self.__USERCONF = cache
 
-    def __get_config_caches(self, username: str) -> Optional[Dict[str, Any]]:
+    def __get_config_caches(self, username: str) -> Optional[dict[str, Any]]:
         """
         获取配置缓存
         """

--- a/app/helper/__init__.py
+++ b/app/helper/__init__.py
@@ -1,2 +1,2 @@
-from .doh import doh_query_json
-from .cloudflare import under_challenge
+from .doh import doh_query_json as doh_query_json
+from .cloudflare import under_challenge as under_challenge

--- a/app/helper/browser.py
+++ b/app/helper/browser.py
@@ -1,4 +1,5 @@
-from typing import Callable, Any
+from typing import Any
+from collections.abc import Callable
 
 from playwright.sync_api import sync_playwright, Page
 from cf_clearance import sync_cf_retry, sync_stealth

--- a/app/helper/cookie.py
+++ b/app/helper/cookie.py
@@ -1,5 +1,5 @@
 import base64
-from typing import Tuple, Optional
+from typing import Optional
 
 from lxml import etree
 from playwright.sync_api import Page
@@ -74,7 +74,7 @@ class CookieHelper:
                            username: str,
                            password: str,
                            two_step_code: str = None,
-                           proxies: dict = None) -> Tuple[Optional[str], Optional[str], str]:
+                           proxies: dict = None) -> tuple[Optional[str], Optional[str], str]:
         """
         获取站点cookie和ua
         :param url: 站点地址
@@ -85,7 +85,7 @@ class CookieHelper:
         :return: cookie、ua、message
         """
 
-        def __page_handler(page: Page) -> Tuple[Optional[str], Optional[str], str]:
+        def __page_handler(page: Page) -> tuple[Optional[str], Optional[str], str]:
             """
             页面处理
             :return: Cookie和UA

--- a/app/helper/cookiecloud.py
+++ b/app/helper/cookiecloud.py
@@ -1,6 +1,6 @@
 import json
 from hashlib import md5
-from typing import Any, Dict, Tuple, Optional
+from typing import Any, Optional
 
 from app.core.config import settings
 from app.utils.common import decrypt
@@ -22,7 +22,7 @@ class CookieCloudHelper:
         self._enable_local = settings.COOKIECLOUD_ENABLE_LOCAL
         self._local_path = settings.COOKIE_PATH
 
-    def download(self) -> Tuple[Optional[dict], str]:
+    def download(self) -> tuple[Optional[dict], str]:
         """
         从CookieCloud下载数据
         :return: Cookie数据、错误信息
@@ -113,7 +113,7 @@ class CookieCloudHelper:
         md5_generator.update((str(self._key).strip() + '-' + str(self._password).strip()).encode('utf-8'))
         return (md5_generator.hexdigest()[:16]).encode('utf-8')
 
-    def _load_local_encrypt_data(self, uuid: str) -> Dict[str, Any]:
+    def _load_local_encrypt_data(self, uuid: str) -> dict[str, Any]:
         file_path = self._local_path / f"{uuid}.json"
         # 检查文件是否存在
         if not file_path.exists():

--- a/app/helper/directory.py
+++ b/app/helper/directory.py
@@ -1,6 +1,5 @@
-import os
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from app import schemas
 from app.core.config import settings
@@ -20,20 +19,20 @@ class DirectoryHelper:
     def __init__(self):
         self.systemconfig = SystemConfigOper()
 
-    def get_download_dirs(self) -> List[schemas.MediaDirectory]:
+    def get_download_dirs(self) -> list[schemas.MediaDirectory]:
         """
         获取下载目录
         """
-        dir_conf: List[dict] = self.systemconfig.get(SystemConfigKey.DownloadDirectories)
+        dir_conf: list[dict] = self.systemconfig.get(SystemConfigKey.DownloadDirectories)
         if not dir_conf:
             return []
         return [schemas.MediaDirectory(**d) for d in dir_conf]
 
-    def get_library_dirs(self) -> List[schemas.MediaDirectory]:
+    def get_library_dirs(self) -> list[schemas.MediaDirectory]:
         """
         获取媒体库目录
         """
-        dir_conf: List[dict] = self.systemconfig.get(SystemConfigKey.LibraryDirectories)
+        dir_conf: list[dict] = self.systemconfig.get(SystemConfigKey.LibraryDirectories)
         if not dir_conf:
             return []
         return [schemas.MediaDirectory(**d) for d in dir_conf]

--- a/app/helper/doh.py
+++ b/app/helper/doh.py
@@ -10,7 +10,7 @@ import socket
 import struct
 import urllib
 import urllib.request
-from typing import Dict, Optional
+from typing import Optional
 
 from app.core.config import settings
 from app.log import logger
@@ -31,7 +31,7 @@ _executor = concurrent.futures.ThreadPoolExecutor()
 
 # 定义默认的DoH配置
 _doh_timeout = 5
-_doh_cache: Dict[str, str] = {}
+_doh_cache: dict[str, str] = {}
 _doh_resolvers = [
     # https://developers.cloudflare.com/1.1.1.1/encryption/dns-over-https
     "1.0.0.1",

--- a/app/helper/format.py
+++ b/app/helper/format.py
@@ -1,5 +1,5 @@
 import re
-from typing import Tuple, Optional
+from typing import Optional
 
 import parse
 
@@ -69,7 +69,7 @@ class FormatParser(object):
             return True
         return False
 
-    def split_episode(self, file_name: str) -> Tuple[Optional[int], Optional[int], Optional[str]]:
+    def split_episode(self, file_name: str) -> tuple[Optional[int], Optional[int], Optional[str]]:
         """
         拆分集数，返回开始集数，结束集数，Part信息
         """
@@ -87,7 +87,7 @@ class FormatParser(object):
         return s + self.__offset if s is not None else None, \
             e + self.__offset if e is not None else None, self.part
 
-    def __handle_single(self, file: str) -> Tuple[Optional[int], Optional[int]]:
+    def __handle_single(self, file: str) -> tuple[Optional[int], Optional[int]]:
         """
         处理单集，返回单集的开始和结束集数
         """

--- a/app/helper/nfo.py
+++ b/app/helper/nfo.py
@@ -1,6 +1,6 @@
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 
 class NfoReader:
@@ -13,5 +13,5 @@ class NfoReader:
         element = self.root.find(element_path)
         return element.text if element is not None else None
 
-    def get_elements(self, element_path) -> List[ET.Element]:
+    def get_elements(self, element_path) -> list[ET.Element]:
         return self.root.findall(element_path)

--- a/app/helper/plugin.py
+++ b/app/helper/plugin.py
@@ -2,7 +2,7 @@ import json
 import shutil
 import traceback
 from pathlib import Path
-from typing import Dict, Tuple, Optional, List
+from typing import Optional
 
 from cachetools import TTLCache, cached
 
@@ -36,7 +36,7 @@ class PluginHelper(metaclass=Singleton):
                     self.systemconfig.set(SystemConfigKey.PluginInstallReport, "1")
 
     @cached(cache=TTLCache(maxsize=1000, ttl=1800))
-    def get_plugins(self, repo_url: str) -> Dict[str, dict]:
+    def get_plugins(self, repo_url: str) -> dict[str, dict]:
         """
         获取Github所有最新插件列表
         :param repo_url: Github仓库地址
@@ -58,7 +58,7 @@ class PluginHelper(metaclass=Singleton):
         return {}
 
     @staticmethod
-    def get_repo_info(repo_url: str) -> Tuple[Optional[str], Optional[str]]:
+    def get_repo_info(repo_url: str) -> tuple[Optional[str], Optional[str]]:
         """
         获取Github仓库信息
         :param repo_url: Github仓库地址
@@ -77,7 +77,7 @@ class PluginHelper(metaclass=Singleton):
         return user, repo
 
     @cached(cache=TTLCache(maxsize=1, ttl=1800))
-    def get_statistic(self) -> Dict:
+    def get_statistic(self) -> dict:
         """
         获取插件安装统计
         """
@@ -121,7 +121,7 @@ class PluginHelper(metaclass=Singleton):
                                            })
         return True if res else False
 
-    def install(self, pid: str, repo_url: str) -> Tuple[bool, str]:
+    def install(self, pid: str, repo_url: str) -> tuple[bool, str]:
         """
         安装插件
         """
@@ -133,7 +133,7 @@ class PluginHelper(metaclass=Singleton):
         if not user or not repo:
             return False, "不支持的插件仓库地址格式"
 
-        def __get_filelist(_p: str) -> Tuple[Optional[list], Optional[str]]:
+        def __get_filelist(_p: str) -> tuple[Optional[list], Optional[str]]:
             """
             获取插件的文件列表
             """
@@ -149,7 +149,7 @@ class PluginHelper(metaclass=Singleton):
                 return None, "插件在仓库中不存在"
             return ret, ""
 
-        def __download_files(_p: str, _l: List[dict]) -> Tuple[bool, str]:
+        def __download_files(_p: str, _l: list[dict]) -> tuple[bool, str]:
             """
             下载插件文件
             """

--- a/app/helper/progress.py
+++ b/app/helper/progress.py
@@ -1,12 +1,12 @@
 from enum import Enum
-from typing import Union, Dict
+from typing import Union
 
 from app.schemas.types import ProgressKey
 from app.utils.singleton import Singleton
 
 
 class ProgressHelper(metaclass=Singleton):
-    _process_detail: Dict[str, dict] = {}
+    _process_detail: dict[str, dict] = {}
 
     def __init__(self):
         self._process_detail = {}

--- a/app/helper/resource.py
+++ b/app/helper/resource.py
@@ -16,7 +16,7 @@ class ResourceHelper(metaclass=Singleton):
     """
     # 资源包的git仓库地址
     _repo = "https://raw.githubusercontent.com/jxxghp/MoviePilot-Resources/main/package.json"
-    _files_api = f"https://api.github.com/repos/jxxghp/MoviePilot-Resources/contents/resources"
+    _files_api = "https://api.github.com/repos/jxxghp/MoviePilot-Resources/contents/resources"
     _base_dir: Path = settings.ROOT_PATH
 
     def __init__(self):

--- a/app/helper/rss.py
+++ b/app/helper/rss.py
@@ -1,7 +1,7 @@
 import re
 import traceback
 import xml.dom.minidom
-from typing import List, Tuple, Union
+from typing import Union
 from urllib.parse import urljoin
 
 import chardet
@@ -225,7 +225,7 @@ class RssHelper:
     }
 
     @staticmethod
-    def parse(url, proxy: bool = False, timeout: int = 15) -> Union[List[dict], None]:
+    def parse(url, proxy: bool = False, timeout: int = 15) -> Union[list[dict], None]:
         """
         解析RSS订阅URL，获取RSS中的种子信息
         :param url: RSS地址
@@ -322,7 +322,7 @@ class RssHelper:
                     return None
         return ret_array
 
-    def get_rss_link(self, url: str, cookie: str, ua: str, proxy: bool = False) -> Tuple[str, str]:
+    def get_rss_link(self, url: str, cookie: str, ua: str, proxy: bool = False) -> tuple[str, str]:
         """
         获取站点rss地址
         :param url: 站点地址

--- a/app/helper/subscribe.py
+++ b/app/helper/subscribe.py
@@ -1,5 +1,4 @@
 from threading import Thread
-from typing import List
 
 from cachetools import TTLCache, cached
 
@@ -32,7 +31,7 @@ class SubscribeHelper(metaclass=Singleton):
                     self.systemconfig.set(SystemConfigKey.SubscribeReport, "1")
 
     @cached(cache=TTLCache(maxsize=20, ttl=1800))
-    def get_statistic(self, stype: str, page: int = 1, count: int = 30) -> List[dict]:
+    def get_statistic(self, stype: str, page: int = 1, count: int = 30) -> list[dict]:
         """
         获取订阅统计数据
         """

--- a/app/helper/torrent.py
+++ b/app/helper/torrent.py
@@ -2,7 +2,7 @@ import datetime
 import re
 import traceback
 from pathlib import Path
-from typing import Tuple, Optional, List, Union, Dict
+from typing import Optional, Union
 from urllib.parse import unquote
 
 from requests import Response
@@ -35,13 +35,13 @@ class TorrentHelper(metaclass=Singleton):
                          ua: str = None,
                          referer: str = None,
                          proxy: bool = False) \
-            -> Tuple[Optional[Path], Optional[Union[str, bytes]], Optional[str], Optional[list], Optional[str]]:
+            -> tuple[Optional[Path], Optional[Union[str, bytes]], Optional[str], Optional[list], Optional[str]]:
         """
         把种子下载到本地
         :return: 种子保存路径、种子内容、种子主目录、种子文件清单、错误信息
         """
         if url.startswith("magnet:"):
-            return None, url, "", [], f"磁力链接"
+            return None, url, "", [], "磁力链接"
         # 请求种子文件
         req = RequestUtils(
             ua=ua,
@@ -52,7 +52,7 @@ class TorrentHelper(metaclass=Singleton):
         while req and req.status_code in [301, 302]:
             url = req.headers['Location']
             if url and url.startswith("magnet:"):
-                return None, url, "", [], f"获取到磁力链接"
+                return None, url, "", [], "获取到磁力链接"
             req = RequestUtils(
                 ua=ua,
                 cookies=cookie,
@@ -65,7 +65,7 @@ class TorrentHelper(metaclass=Singleton):
             # 解析内容格式
             if req.text and str(req.text).startswith("magnet:"):
                 # 磁力链接
-                return None, req.text, "", [], f"获取到磁力链接"
+                return None, req.text, "", [], "获取到磁力链接"
             elif req.text and "下载种子文件" in req.text:
                 # 首次下载提示页面
                 skip_flag = False
@@ -134,7 +134,7 @@ class TorrentHelper(metaclass=Singleton):
             return None, None, "", [], f"下载种子出错，状态码：{req.status_code}"
 
     @staticmethod
-    def get_torrent_info(torrent_path: Path) -> Tuple[str, List[str]]:
+    def get_torrent_info(torrent_path: Path) -> tuple[str, list[str]]:
         """
         获取种子文件的文件夹名和文件清单
         :param torrent_path: 种子文件路径
@@ -190,7 +190,7 @@ class TorrentHelper(metaclass=Singleton):
             file_name = str(datetime.datetime.now())
         return file_name
 
-    def sort_torrents(self, torrent_list: List[Context]) -> List[Context]:
+    def sort_torrents(self, torrent_list: list[Context]) -> list[Context]:
         """
         对种子对行排序
         """
@@ -237,7 +237,7 @@ class TorrentHelper(metaclass=Singleton):
 
         return torrent_list
 
-    def sort_group_torrents(self, torrent_list: List[Context]) -> List[Context]:
+    def sort_group_torrents(self, torrent_list: list[Context]) -> list[Context]:
         """
         对媒体信息进行排序、去重
         """
@@ -300,13 +300,13 @@ class TorrentHelper(metaclass=Singleton):
 
     @staticmethod
     def filter_torrent(torrent_info: TorrentInfo,
-                       filter_rule: Dict[str, str],
+                       filter_rule: dict[str, str],
                        mediainfo: MediaInfo) -> bool:
         """
         检查种子是否匹配订阅过滤规则
         """
 
-        def __get_size_range(size_str: str) -> Tuple[float, float]:
+        def __get_size_range(size_str: str) -> tuple[float, float]:
             """
             获取大小范围
             """

--- a/app/log.py
+++ b/app/log.py
@@ -2,7 +2,7 @@ import inspect
 import logging
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any
 
 import click
 
@@ -36,7 +36,7 @@ class LoggerManager:
     日志管理
     """
     # 管理所有的Logger
-    _loggers: Dict[str, Any] = {}
+    _loggers: dict[str, Any] = {}
     # 默认日志文件
     _default_log_file = "moviepilot.log"
 
@@ -98,7 +98,7 @@ class LoggerManager:
 
         # 终端日志
         console_handler = logging.StreamHandler()
-        console_formatter = CustomFormatter(f"%(leveltext)s%(message)s")
+        console_formatter = CustomFormatter("%(leveltext)s%(message)s")
         console_handler.setFormatter(console_formatter)
         _logger.addHandler(console_handler)
 
@@ -108,7 +108,7 @@ class LoggerManager:
                                            maxBytes=5 * 1024 * 1024,
                                            backupCount=3,
                                            encoding='utf-8')
-        file_formater = CustomFormatter(f"【%(levelname)s】%(asctime)s - %(message)s")
+        file_formater = CustomFormatter("【%(levelname)s】%(asctime)s - %(message)s")
         file_handler.setFormatter(file_formater)
         _logger.addHandler(file_handler)
 

--- a/app/main.py
+++ b/app/main.py
@@ -96,7 +96,7 @@ def stop_frontend():
             or not SystemUtils.is_windows():
         return
     import subprocess
-    subprocess.Popen(f"taskkill /f /im nginx.exe", shell=True)
+    subprocess.Popen("taskkill /f /im nginx.exe", shell=True)
 
 
 def start_tray():

--- a/app/modules/__init__.py
+++ b/app/modules/__init__.py
@@ -20,7 +20,7 @@ class _ModuleBase(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+    def init_setting(self) -> tuple[str, Union[str, bool]]:
         """
         模块开关设置，返回开关名和开关值，开关值为True时代表有值即打开，不实现该方法或返回None代表不使用开关
         部分模块支持同时开启多个，此时设置项以,分隔，开关值使用in判断
@@ -44,7 +44,7 @@ class _ModuleBase(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def test(self) -> Tuple[bool, str]:
+    def test(self) -> tuple[bool, str]:
         """
         模块测试, 返回测试结果和错误信息
         """

--- a/app/modules/bangumi/__init__.py
+++ b/app/modules/bangumi/__init__.py
@@ -19,7 +19,7 @@ class BangumiModule(_ModuleBase):
     def stop(self):
         pass
 
-    def test(self) -> Tuple[bool, str]:
+    def test(self) -> tuple[bool, str]:
         """
         测试模块连接性
         """
@@ -30,7 +30,7 @@ class BangumiModule(_ModuleBase):
             return False, f"无法连接Bangumi，错误码：{ret.status_code}"
         return False, "Bangumi网络连接失败"
 
-    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+    def init_setting(self) -> tuple[str, Union[str, bool]]:
         pass
 
     @staticmethod
@@ -60,7 +60,7 @@ class BangumiModule(_ModuleBase):
 
         return None
 
-    def search_medias(self, meta: MetaBase) -> Optional[List[MediaInfo]]:
+    def search_medias(self, meta: MetaBase) -> Optional[list[MediaInfo]]:
         """
         搜索媒体信息
         :param meta:  识别的元数据
@@ -88,7 +88,7 @@ class BangumiModule(_ModuleBase):
         logger.info(f"开始获取Bangumi信息：{bangumiid} ...")
         return self.bangumiapi.detail(bangumiid)
 
-    def bangumi_calendar(self) -> Optional[List[MediaInfo]]:
+    def bangumi_calendar(self) -> Optional[list[MediaInfo]]:
         """
         获取Bangumi每日放送
         """
@@ -97,7 +97,7 @@ class BangumiModule(_ModuleBase):
             return [MediaInfo(bangumi_info=info) for info in infos]
         return []
 
-    def bangumi_credits(self, bangumiid: int) -> List[schemas.MediaPerson]:
+    def bangumi_credits(self, bangumiid: int) -> list[schemas.MediaPerson]:
         """
         根据TMDBID查询电影演职员表
         :param bangumiid:  BangumiID
@@ -107,7 +107,7 @@ class BangumiModule(_ModuleBase):
             return [schemas.MediaPerson(source='bangumi', **person) for person in persons]
         return []
 
-    def bangumi_recommend(self, bangumiid: int) -> List[MediaInfo]:
+    def bangumi_recommend(self, bangumiid: int) -> list[MediaInfo]:
         """
         根据BangumiID查询推荐电影
         :param bangumiid:  BangumiID
@@ -134,7 +134,7 @@ class BangumiModule(_ModuleBase):
             })
         return None
 
-    def bangumi_person_credits(self, person_id: int) -> List[MediaInfo]:
+    def bangumi_person_credits(self, person_id: int) -> list[MediaInfo]:
         """
         根据TMDBID查询人物参演作品
         :param person_id:  人物ID

--- a/app/modules/douban/__init__.py
+++ b/app/modules/douban/__init__.py
@@ -34,7 +34,7 @@ class DoubanModule(_ModuleBase):
     def stop(self):
         self.doubanapi.close()
 
-    def test(self) -> Tuple[bool, str]:
+    def test(self) -> tuple[bool, str]:
         """
         测试模块连接性
         """
@@ -45,7 +45,7 @@ class DoubanModule(_ModuleBase):
             return False, f"无法连接豆瓣，错误码：{ret.status_code}"
         return False, "豆瓣网络连接失败"
 
-    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+    def init_setting(self) -> tuple[str, Union[str, bool]]:
         pass
 
     @staticmethod
@@ -455,7 +455,7 @@ class DoubanModule(_ModuleBase):
             return __douban_movie() or __douban_tv()
 
     def douban_discover(self, mtype: MediaType, sort: str, tags: str,
-                        page: int = 1, count: int = 30) -> Optional[List[MediaInfo]]:
+                        page: int = 1, count: int = 30) -> Optional[list[MediaInfo]]:
         """
         发现豆瓣电影、剧集
         :param mtype:  媒体类型
@@ -482,7 +482,7 @@ class DoubanModule(_ModuleBase):
                     and "tv_large.jpg" not in media.poster_path]
         return []
 
-    def movie_showing(self, page: int = 1, count: int = 30) -> List[MediaInfo]:
+    def movie_showing(self, page: int = 1, count: int = 30) -> list[MediaInfo]:
         """
         获取正在上映的电影
         """
@@ -492,7 +492,7 @@ class DoubanModule(_ModuleBase):
             return [MediaInfo(douban_info=info) for info in infos.get("subject_collection_items")]
         return []
 
-    def tv_weekly_chinese(self, page: int = 1, count: int = 30) -> List[MediaInfo]:
+    def tv_weekly_chinese(self, page: int = 1, count: int = 30) -> list[MediaInfo]:
         """
         获取豆瓣本周口碑国产剧
         """
@@ -502,7 +502,7 @@ class DoubanModule(_ModuleBase):
             return [MediaInfo(douban_info=info) for info in infos.get("subject_collection_items")]
         return []
 
-    def tv_weekly_global(self, page: int = 1, count: int = 30) -> List[MediaInfo]:
+    def tv_weekly_global(self, page: int = 1, count: int = 30) -> list[MediaInfo]:
         """
         获取豆瓣本周口碑外国剧
         """
@@ -512,7 +512,7 @@ class DoubanModule(_ModuleBase):
             return [MediaInfo(douban_info=info) for info in infos.get("subject_collection_items")]
         return []
 
-    def tv_animation(self, page: int = 1, count: int = 30) -> List[MediaInfo]:
+    def tv_animation(self, page: int = 1, count: int = 30) -> list[MediaInfo]:
         """
         获取豆瓣动画剧
         """
@@ -522,7 +522,7 @@ class DoubanModule(_ModuleBase):
             return [MediaInfo(douban_info=info) for info in infos.get("subject_collection_items")]
         return []
 
-    def movie_hot(self, page: int = 1, count: int = 30) -> List[MediaInfo]:
+    def movie_hot(self, page: int = 1, count: int = 30) -> list[MediaInfo]:
         """
         获取豆瓣热门电影
         """
@@ -532,7 +532,7 @@ class DoubanModule(_ModuleBase):
             return [MediaInfo(douban_info=info) for info in infos.get("subject_collection_items")]
         return []
 
-    def tv_hot(self, page: int = 1, count: int = 30) -> List[MediaInfo]:
+    def tv_hot(self, page: int = 1, count: int = 30) -> list[MediaInfo]:
         """
         获取豆瓣热门剧集
         """
@@ -542,7 +542,7 @@ class DoubanModule(_ModuleBase):
             return [MediaInfo(douban_info=info) for info in infos.get("subject_collection_items")]
         return []
 
-    def search_medias(self, meta: MetaBase) -> Optional[List[MediaInfo]]:
+    def search_medias(self, meta: MetaBase) -> Optional[list[MediaInfo]]:
         """
         搜索媒体信息
         :param meta:  识别的元数据
@@ -575,7 +575,7 @@ class DoubanModule(_ModuleBase):
                     media.season = meta.begin_season
         return ret_medias
 
-    def search_persons(self, name: str) -> Optional[List[MediaPerson]]:
+    def search_persons(self, name: str) -> Optional[list[MediaPerson]]:
         """
         搜索人物信息
         """
@@ -648,7 +648,7 @@ class DoubanModule(_ModuleBase):
                 return item
         return {}
 
-    def movie_top250(self, page: int = 1, count: int = 30) -> List[MediaInfo]:
+    def movie_top250(self, page: int = 1, count: int = 30) -> list[MediaInfo]:
         """
         获取豆瓣电影TOP250
         """
@@ -797,7 +797,7 @@ class DoubanModule(_ModuleBase):
         self.cache.clear()
         logger.info("豆瓣缓存清除完成")
 
-    def douban_movie_credits(self, doubanid: str) -> List[schemas.MediaPerson]:
+    def douban_movie_credits(self, doubanid: str) -> list[schemas.MediaPerson]:
         """
         根据TMDBID查询电影演职员表
         :param doubanid:  豆瓣ID
@@ -813,7 +813,7 @@ class DoubanModule(_ModuleBase):
             return [schemas.MediaPerson(source='douban', **doubaninfo) for doubaninfo in ret_list]
         return []
 
-    def douban_tv_credits(self, doubanid: str) -> List[schemas.MediaPerson]:
+    def douban_tv_credits(self, doubanid: str) -> list[schemas.MediaPerson]:
         """
         根据TMDBID查询电视剧演职员表
         :param doubanid:  豆瓣ID
@@ -829,7 +829,7 @@ class DoubanModule(_ModuleBase):
             return [schemas.MediaPerson(source='douban', **doubaninfo) for doubaninfo in ret_list]
         return []
 
-    def douban_movie_recommend(self, doubanid: str) -> List[MediaInfo]:
+    def douban_movie_recommend(self, doubanid: str) -> list[MediaInfo]:
         """
         根据豆瓣ID查询推荐电影
         :param doubanid:  豆瓣ID
@@ -839,7 +839,7 @@ class DoubanModule(_ModuleBase):
             return [MediaInfo(douban_info=info) for info in recommend]
         return []
 
-    def douban_tv_recommend(self, doubanid: str) -> List[MediaInfo]:
+    def douban_tv_recommend(self, doubanid: str) -> list[MediaInfo]:
         """
         根据豆瓣ID查询推荐电视剧
         :param doubanid:  豆瓣ID
@@ -872,7 +872,7 @@ class DoubanModule(_ModuleBase):
             })
         return schemas.MediaPerson(source='douban')
 
-    def douban_person_credits(self, person_id: int, page: int = 1) -> List[MediaInfo]:
+    def douban_person_credits(self, person_id: int, page: int = 1) -> list[MediaInfo]:
         """
         根据TMDBID查询人物参演作品
         :param person_id:  人物ID

--- a/app/modules/emby/__init__.py
+++ b/app/modules/emby/__init__.py
@@ -1,4 +1,5 @@
-from typing import Optional, Tuple, Union, Any, List, Generator
+from typing import Optional, Tuple, Union, Any, List
+from collections.abc import Generator
 
 from app import schemas
 from app.core.context import MediaInfo
@@ -21,7 +22,7 @@ class EmbyModule(_ModuleBase):
     def stop(self):
         pass
 
-    def test(self) -> Tuple[bool, str]:
+    def test(self) -> tuple[bool, str]:
         """
         测试模块连接性
         """
@@ -31,7 +32,7 @@ class EmbyModule(_ModuleBase):
             return False, "无法连接Emby，请检查参数配置"
         return True, ""
 
-    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+    def init_setting(self) -> tuple[str, Union[str, bool]]:
         return "MEDIASERVER", "emby"
 
     def scheduler_job(self) -> None:
@@ -109,7 +110,7 @@ class EmbyModule(_ModuleBase):
                     itemid=itemid
                 )
 
-    def media_statistic(self) -> List[schemas.Statistic]:
+    def media_statistic(self) -> list[schemas.Statistic]:
         """
         媒体数量统计
         """
@@ -117,7 +118,7 @@ class EmbyModule(_ModuleBase):
         media_statistic.user_count = self.emby.get_user_count()
         return [media_statistic]
 
-    def mediaserver_librarys(self, server: str = None, username: str = None) -> Optional[List[schemas.MediaServerLibrary]]:
+    def mediaserver_librarys(self, server: str = None, username: str = None) -> Optional[list[schemas.MediaServerLibrary]]:
         """
         媒体库列表
         """
@@ -142,7 +143,7 @@ class EmbyModule(_ModuleBase):
         return self.emby.get_iteminfo(item_id)
 
     def mediaserver_tv_episodes(self, server: str,
-                                item_id: Union[str, int]) -> Optional[List[schemas.MediaServerSeasonInfo]]:
+                                item_id: Union[str, int]) -> Optional[list[schemas.MediaServerSeasonInfo]]:
         """
         获取剧集信息
         """
@@ -157,7 +158,7 @@ class EmbyModule(_ModuleBase):
         ) for season, episodes in seasoninfo.items()]
 
     def mediaserver_playing(self, count: int = 20,
-                            server: str = None, username: str = None) -> List[schemas.MediaServerPlayItem]:
+                            server: str = None, username: str = None) -> list[schemas.MediaServerPlayItem]:
         """
         获取媒体服务器正在播放信息
         """
@@ -174,7 +175,7 @@ class EmbyModule(_ModuleBase):
         return self.emby.get_play_url(item_id)
 
     def mediaserver_latest(self, count: int = 20,
-                           server: str = None, username: str = None) -> List[schemas.MediaServerPlayItem]:
+                           server: str = None, username: str = None) -> list[schemas.MediaServerPlayItem]:
         """
         获取媒体服务器最新入库条目
         """

--- a/app/modules/emby/emby.py
+++ b/app/modules/emby/emby.py
@@ -2,7 +2,8 @@ import json
 import re
 import traceback
 from pathlib import Path
-from typing import List, Optional, Union, Dict, Generator, Tuple
+from typing import Optional, Union
+from collections.abc import Generator
 
 from requests import Response
 
@@ -48,7 +49,7 @@ class Emby:
         self.user = self.get_user()
         self.folders = self.get_emby_folders()
 
-    def get_emby_folders(self) -> List[dict]:
+    def get_emby_folders(self) -> list[dict]:
         """
         获取Emby媒体库路径列表
         """
@@ -60,13 +61,13 @@ class Emby:
             if res:
                 return res.json()
             else:
-                logger.error(f"Library/SelectableMediaFolders 未获取到返回数据")
+                logger.error("Library/SelectableMediaFolders 未获取到返回数据")
                 return []
         except Exception as e:
-            logger.error(f"连接Library/SelectableMediaFolders 出错：" + str(e))
+            logger.error("连接Library/SelectableMediaFolders 出错：" + str(e))
             return []
 
-    def get_emby_virtual_folders(self) -> List[dict]:
+    def get_emby_virtual_folders(self) -> list[dict]:
         """
         获取Emby媒体库所有路径列表（包含共享路径）
         """
@@ -95,13 +96,13 @@ class Emby:
                         })
                 return librarys
             else:
-                logger.error(f"Library/VirtualFolders/Query 未获取到返回数据")
+                logger.error("Library/VirtualFolders/Query 未获取到返回数据")
                 return []
         except Exception as e:
-            logger.error(f"连接Library/VirtualFolders/Query 出错：" + str(e))
+            logger.error("连接Library/VirtualFolders/Query 出错：" + str(e))
             return []
 
-    def __get_emby_librarys(self, username: str = None) -> List[dict]:
+    def __get_emby_librarys(self, username: str = None) -> list[dict]:
         """
         获取Emby媒体库列表
         """
@@ -117,13 +118,13 @@ class Emby:
             if res:
                 return res.json().get("Items")
             else:
-                logger.error(f"User/Views 未获取到返回数据")
+                logger.error("User/Views 未获取到返回数据")
                 return []
         except Exception as e:
-            logger.error(f"连接User/Views 出错：" + str(e))
+            logger.error("连接User/Views 出错：" + str(e))
             return []
 
-    def get_librarys(self, username: str = None) -> List[schemas.MediaServerLibrary]:
+    def get_librarys(self, username: str = None) -> list[schemas.MediaServerLibrary]:
         """
         获取媒体服务器所有媒体库列表
         """
@@ -177,9 +178,9 @@ class Emby:
                     if user.get("Policy", {}).get("IsAdministrator"):
                         return user.get("Id")
             else:
-                logger.error(f"Users 未获取到返回数据")
+                logger.error("Users 未获取到返回数据")
         except Exception as e:
-            logger.error(f"连接Users出错：" + str(e))
+            logger.error("连接Users出错：" + str(e))
         return None
 
     def authenticate(self, username: str, password: str) -> Optional[str]:
@@ -214,9 +215,9 @@ class Emby:
                     logger.info(f"用户 {username} Emby认证成功")
                     return auth_token
             else:
-                logger.error(f"Users/AuthenticateByName 未获取到返回数据")
+                logger.error("Users/AuthenticateByName 未获取到返回数据")
         except Exception as e:
-            logger.error(f"连接Users/AuthenticateByName出错：" + str(e))
+            logger.error("连接Users/AuthenticateByName出错：" + str(e))
         return None
 
     def get_server_id(self) -> Optional[str]:
@@ -231,10 +232,10 @@ class Emby:
             if res:
                 return res.json().get("Id")
             else:
-                logger.error(f"System/Info 未获取到返回数据")
+                logger.error("System/Info 未获取到返回数据")
         except Exception as e:
 
-            logger.error(f"连接System/Info出错：" + str(e))
+            logger.error("连接System/Info出错：" + str(e))
         return None
 
     def get_user_count(self) -> int:
@@ -249,10 +250,10 @@ class Emby:
             if res:
                 return res.json().get("TotalRecordCount")
             else:
-                logger.error(f"Users/Query 未获取到返回数据")
+                logger.error("Users/Query 未获取到返回数据")
                 return 0
         except Exception as e:
-            logger.error(f"连接Users/Query出错：" + str(e))
+            logger.error("连接Users/Query出错：" + str(e))
             return 0
 
     def get_medias_count(self) -> schemas.Statistic:
@@ -273,10 +274,10 @@ class Emby:
                     episode_count=result.get("EpisodeCount") or 0
                 )
             else:
-                logger.error(f"Items/Counts 未获取到返回数据")
+                logger.error("Items/Counts 未获取到返回数据")
                 return schemas.Statistic()
         except Exception as e:
-            logger.error(f"连接Items/Counts出错：" + str(e))
+            logger.error("连接Items/Counts出错：" + str(e))
             return schemas.Statistic()
 
     def __get_emby_series_id_by_name(self, name: str, year: str) -> Optional[str]:
@@ -308,14 +309,14 @@ class Emby:
                                 not year or str(res_item.get('ProductionYear')) == str(year)):
                             return res_item.get('Id')
         except Exception as e:
-            logger.error(f"连接Items出错：" + str(e))
+            logger.error("连接Items出错：" + str(e))
             return None
         return ""
 
     def get_movies(self,
                    title: str,
                    year: str = None,
-                   tmdb_id: int = None) -> Optional[List[schemas.MediaServerItem]]:
+                   tmdb_id: int = None) -> Optional[list[schemas.MediaServerItem]]:
         """
         根据标题和年份，检查电影是否在Emby中存在，存在则返回列表
         :param title: 标题
@@ -360,7 +361,7 @@ class Emby:
                             ret_movies.append(mediaserver_item)
                     return ret_movies
         except Exception as e:
-            logger.error(f"连接Items出错：" + str(e))
+            logger.error("连接Items出错：" + str(e))
             return None
         return []
 
@@ -370,7 +371,7 @@ class Emby:
                         year: str = None,
                         tmdb_id: int = None,
                         season: int = None
-                        ) -> Tuple[Optional[str], Optional[Dict[int, List[Dict[int, list]]]]]:
+                        ) -> tuple[Optional[str], Optional[dict[int, list[dict[int, list]]]]]:
         """
         根据标题和年份和季，返回Emby中的剧集列表
         :param item_id: Emby中的ID
@@ -421,7 +422,7 @@ class Emby:
                 # 返回
                 return item_id, season_episodes
         except Exception as e:
-            logger.error(f"连接Shows/Id/Episodes出错：" + str(e))
+            logger.error("连接Shows/Id/Episodes出错：" + str(e))
             return None, None
         return None, {}
 
@@ -444,10 +445,10 @@ class Emby:
                         if image.get("ProviderName") == "TheMovieDb" and image.get("Type") == image_type:
                             return image.get("Url")
             # 数据为空
-            logger.info(f"Items/RemoteImages 未获取到返回数据，采用本地图片")
+            logger.info("Items/RemoteImages 未获取到返回数据，采用本地图片")
             return self.generate_external_image_link(item_id, image_type)
         except Exception as e:
-            logger.error(f"连接Items/Id/RemoteImages出错：" + str(e))
+            logger.error("连接Items/Id/RemoteImages出错：" + str(e))
         return None
 
     def generate_external_image_link(self, item_id: str, image_type: str) -> Optional[str]:
@@ -471,7 +472,7 @@ class Emby:
                 logger.error("Items/Id/Images 未获取到返回数据或无该影片{}图片".format(image_type))
                 return None
         except Exception as e:
-            logger.error(f"连接Items/Id/Images出错：" + str(e))
+            logger.error("连接Items/Id/Images出错：" + str(e))
             return None
 
     def __refresh_emby_library_by_id(self, item_id: str) -> bool:
@@ -488,7 +489,7 @@ class Emby:
             else:
                 logger.info(f"刷新媒体库对象 {item_id} 失败，无法连接Emby！")
         except Exception as e:
-            logger.error(f"连接Items/Id/Refresh出错：" + str(e))
+            logger.error("连接Items/Id/Refresh出错：" + str(e))
             return False
         return False
 
@@ -504,13 +505,13 @@ class Emby:
             if res:
                 return True
             else:
-                logger.info(f"刷新媒体库失败，无法连接Emby！")
+                logger.info("刷新媒体库失败，无法连接Emby！")
         except Exception as e:
-            logger.error(f"连接Library/Refresh出错：" + str(e))
+            logger.error("连接Library/Refresh出错：" + str(e))
             return False
         return False
 
-    def refresh_library_by_items(self, items: List[schemas.RefreshMediaItem]) -> bool:
+    def refresh_library_by_items(self, items: list[schemas.RefreshMediaItem]) -> bool:
         """
         按类型、名称、年份来刷新媒体库
         :param items: 已识别的需要刷新媒体库的媒体信息列表
@@ -518,7 +519,7 @@ class Emby:
         if not items:
             return False
         # 收集要刷新的媒体库信息
-        logger.info(f"开始刷新Emby媒体库...")
+        logger.info("开始刷新Emby媒体库...")
         library_ids = []
         for item in items:
             library_id = self.__get_emby_library_id_by_item(item)
@@ -530,7 +531,7 @@ class Emby:
         for library_id in library_ids:
             if library_id != "/":
                 return self.__refresh_emby_library_by_id(library_id)
-        logger.info(f"Emby媒体库刷新完成")
+        logger.info("Emby媒体库刷新完成")
 
     def __get_emby_library_id_by_item(self, item: schemas.RefreshMediaItem) -> Optional[str]:
         """
@@ -597,7 +598,7 @@ class Emby:
                     path=item.get("Path")
                 )
         except Exception as e:
-            logger.error(f"连接Items/Id出错：" + str(e))
+            logger.error("连接Items/Id出错：" + str(e))
         return None
 
     def get_items(self, parent: str) -> Generator:
@@ -622,7 +623,7 @@ class Emby:
                         for item in self.get_items(parent=result.get('Id')):
                             yield item
         except Exception as e:
-            logger.error(f"连接Users/Items出错：" + str(e))
+            logger.error("连接Users/Items出错：" + str(e))
         yield None
 
     def get_webhook_message(self, form: any, args: dict) -> Optional[schemas.WebhookEventInfo]:
@@ -872,7 +873,7 @@ class Emby:
                 result = json.dumps(dict(args))
             message = json.loads(result)
         except Exception as e:
-            logger.debug(f"解析emby webhook报文出错：" + str(e))
+            logger.debug("解析emby webhook报文出错：" + str(e))
             return None
         eventType = message.get('Event')
         if not eventType:
@@ -962,7 +963,7 @@ class Emby:
         try:
             return RequestUtils(content_type="application/json").get_res(url=url)
         except Exception as e:
-            logger.error(f"连接Emby出错：" + str(e))
+            logger.error("连接Emby出错：" + str(e))
             return None
 
     def post_data(self, url: str, data: str = None, headers: dict = None) -> Optional[Response]:
@@ -982,7 +983,7 @@ class Emby:
                 headers=headers,
             ).post_res(url=url, data=data)
         except Exception as e:
-            logger.error(f"连接Emby出错：" + str(e))
+            logger.error("连接Emby出错：" + str(e))
             return None
 
     def get_play_url(self, item_id: str) -> str:
@@ -1019,7 +1020,7 @@ class Emby:
             return ""
         return "%sItems/%s/Images/Primary" % (self._host, item_id)
 
-    def get_resume(self, num: int = 12, username: str = None) -> Optional[List[schemas.MediaServerPlayItem]]:
+    def get_resume(self, num: int = 12, username: str = None) -> Optional[list[schemas.MediaServerPlayItem]]:
         """
         获得继续观看
         """
@@ -1077,12 +1078,12 @@ class Emby:
                     ))
                 return ret_resume
             else:
-                logger.error(f"Users/Items/Resume 未获取到返回数据")
+                logger.error("Users/Items/Resume 未获取到返回数据")
         except Exception as e:
-            logger.error(f"连接Users/Items/Resume出错：" + str(e))
+            logger.error("连接Users/Items/Resume出错：" + str(e))
         return []
 
-    def get_latest(self, num: int = 20, username: str = None) -> Optional[List[schemas.MediaServerPlayItem]]:
+    def get_latest(self, num: int = 20, username: str = None) -> Optional[list[schemas.MediaServerPlayItem]]:
         """
         获得最近更新
         """
@@ -1123,9 +1124,9 @@ class Emby:
                     ))
                 return ret_latest
             else:
-                logger.error(f"Users/Items/Latest 未获取到返回数据")
+                logger.error("Users/Items/Latest 未获取到返回数据")
         except Exception as e:
-            logger.error(f"连接Users/Items/Latest出错：" + str(e))
+            logger.error("连接Users/Items/Latest出错：" + str(e))
         return []
 
     def get_user_library_folders(self):

--- a/app/modules/fanart/__init__.py
+++ b/app/modules/fanart/__init__.py
@@ -317,7 +317,7 @@ class FanartModule(_ModuleBase):
     def stop(self):
         pass
 
-    def test(self) -> Tuple[bool, str]:
+    def test(self) -> tuple[bool, str]:
         """
         测试模块连接性
         """
@@ -328,7 +328,7 @@ class FanartModule(_ModuleBase):
             return False, f"无法连接fanart，错误码：{ret.status_code}"
         return False, "fanart网络连接失败"
 
-    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+    def init_setting(self) -> tuple[str, Union[str, bool]]:
         return "FANART_API_KEY", True
 
     @staticmethod

--- a/app/modules/filetransfer/__init__.py
+++ b/app/modules/filetransfer/__init__.py
@@ -40,7 +40,7 @@ class FileTransferModule(_ModuleBase):
     def stop(self):
         pass
 
-    def test(self) -> Tuple[bool, str]:
+    def test(self) -> tuple[bool, str]:
         """
         测试模块连接性
         """
@@ -80,12 +80,12 @@ class FileTransferModule(_ModuleBase):
                                   f"与下载目录 {d_path.path} 在同一磁盘/存储空间/映射路径的目录，将无法硬链接"
         return True, ""
 
-    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+    def init_setting(self) -> tuple[str, Union[str, bool]]:
         pass
 
     def transfer(self, path: Path, meta: MetaBase, mediainfo: MediaInfo,
                  transfer_type: str, target: Path = None,
-                 episodes_info: List[TmdbEpisode] = None,
+                 episodes_info: list[TmdbEpisode] = None,
                  scrape: bool = None) -> TransferInfo:
         """
         文件转移
@@ -213,7 +213,7 @@ class FileTransferModule(_ModuleBase):
 
         # 比对文件名并转移字幕
         org_dir: Path = org_path.parent
-        file_list: List[Path] = SystemUtils.list_files(org_dir, settings.RMT_SUBEXT)
+        file_list: list[Path] = SystemUtils.list_files(org_dir, settings.RMT_SUBEXT)
         if len(file_list) == 0:
             logger.debug(f"{org_dir} 目录下没有找到字幕文件...")
         else:
@@ -283,7 +283,7 @@ class FileTransferModule(_ModuleBase):
                                     return retcode
                             # 如果字幕文件的大小与已存在文件相同, 说明已经转移过了, 则跳出循环
                             elif new_file.stat().st_size == file_item.stat().st_size:
-                                logger.info(f"字幕 new_file 已存在")
+                                logger.info("字幕 new_file 已存在")
                                 break
                             # 否则 循环继续 > 通过new_sub_tag_list 获取新的tag附加到字幕文件名, 继续检查是否能转移
                         except OSError as reason:
@@ -301,8 +301,8 @@ class FileTransferModule(_ModuleBase):
         """
         dir_name = org_path.parent
         file_name = org_path.name
-        file_list: List[Path] = SystemUtils.list_files(dir_name, ['.mka'])
-        pending_file_list: List[Path] = [file for file in file_list if org_path.stem == file.stem]
+        file_list: list[Path] = SystemUtils.list_files(dir_name, ['.mka'])
+        pending_file_list: list[Path] = [file for file in file_list if org_path.stem == file.stem]
         if len(pending_file_list) == 0:
             logger.debug(f"{dir_name} 目录下没有找到匹配的音轨文件")
         else:
@@ -435,7 +435,7 @@ class FileTransferModule(_ModuleBase):
                        mediainfo: MediaInfo,
                        transfer_type: str,
                        target_dir: Path,
-                       episodes_info: List[TmdbEpisode] = None,
+                       episodes_info: list[TmdbEpisode] = None,
                        need_scrape: bool = False
                        ) -> TransferInfo:
         """
@@ -508,7 +508,7 @@ class FileTransferModule(_ModuleBase):
                 if in_meta.begin_episode is None:
                     logger.warn(f"文件 {in_path} 转移失败：未识别到文件集数")
                     return TransferInfo(success=False,
-                                        message=f"未识别到文件集数",
+                                        message="未识别到文件集数",
                                         path=in_path,
                                         fail_list=[str(in_path)])
 
@@ -556,14 +556,14 @@ class FileTransferModule(_ModuleBase):
                                 overflag = True
                             else:
                                 return TransferInfo(success=False,
-                                                    message=f"媒体库中已存在，且质量更好",
+                                                    message="媒体库中已存在，且质量更好",
                                                     path=in_path,
                                                     target_path=new_file,
                                                     fail_list=[str(in_path)])
                         case 'never':
                             # 存在不覆盖
                             return TransferInfo(success=False,
-                                                message=f"媒体库中已存在，当前设置为不覆盖",
+                                                message="媒体库中已存在，当前设置为不覆盖",
                                                 path=in_path,
                                                 target_path=new_file,
                                                 fail_list=[str(in_path)])
@@ -604,7 +604,7 @@ class FileTransferModule(_ModuleBase):
 
     @staticmethod
     def __get_naming_dict(meta: MetaBase, mediainfo: MediaInfo, file_ext: str = None,
-                          episodes_info: List[TmdbEpisode] = None) -> dict:
+                          episodes_info: list[TmdbEpisode] = None) -> dict:
         """
         根据媒体信息，返回Format字典
         :param meta: 文件元数据
@@ -747,7 +747,7 @@ class FileTransferModule(_ModuleBase):
                 return ExistMediaInfo(type=MediaType.MOVIE)
             else:
                 # 电视剧检索集数
-                seasons: Dict[int, list] = {}
+                seasons: dict[int, list] = {}
                 for media_file in media_files:
                     file_meta = MetaInfo(media_file.stem)
                     season_index = file_meta.begin_season or 1

--- a/app/modules/filter/__init__.py
+++ b/app/modules/filter/__init__.py
@@ -15,7 +15,7 @@ class FilterModule(_ModuleBase):
     media: MediaInfo = None
 
     # 内置规则集
-    rule_set: Dict[str, dict] = {
+    rule_set: dict[str, dict] = {
         # 蓝光原盘
         "BLU": {
             "include": [r'Blu-?Ray.+VC-?1|Blu-?Ray.+AVC|UHD.+blu-?ray.+HEVC|MiniBD'],
@@ -146,13 +146,13 @@ class FilterModule(_ModuleBase):
     def test(self):
         pass
 
-    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+    def init_setting(self) -> tuple[str, Union[str, bool]]:
         pass
 
     def filter_torrents(self, rule_string: str,
-                        torrent_list: List[TorrentInfo],
-                        season_episodes: Dict[int, list] = None,
-                        mediainfo: MediaInfo = None) -> List[TorrentInfo]:
+                        torrent_list: list[TorrentInfo],
+                        season_episodes: dict[int, list] = None,
+                        mediainfo: MediaInfo = None) -> list[TorrentInfo]:
         """
         过滤种子资源
         :param rule_string:  过滤规则
@@ -180,7 +180,7 @@ class FilterModule(_ModuleBase):
         return ret_torrents
 
     @staticmethod
-    def __match_season_episodes(torrent: TorrentInfo, season_episodes: Dict[int, list]):
+    def __match_season_episodes(torrent: TorrentInfo, season_episodes: dict[int, list]):
         """
         判断种子是否匹配季集数
         """

--- a/app/modules/indexer/__init__.py
+++ b/app/modules/indexer/__init__.py
@@ -33,7 +33,7 @@ class IndexerModule(_ModuleBase):
     def stop(self):
         pass
 
-    def test(self) -> Tuple[bool, str]:
+    def test(self) -> tuple[bool, str]:
         """
         测试模块连接性
         """
@@ -42,13 +42,13 @@ class IndexerModule(_ModuleBase):
             return False, "未配置站点或未通过用户认证"
         return True, ""
 
-    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+    def init_setting(self) -> tuple[str, Union[str, bool]]:
         return "INDEXER", "builtin"
 
     def search_torrents(self, site: CommentedMap,
-                        keywords: List[str] = None,
+                        keywords: list[str] = None,
                         mtype: MediaType = None,
-                        page: int = 0) -> List[TorrentInfo]:
+                        page: int = 0) -> list[TorrentInfo]:
         """
         搜索一个站点
         :param site:  站点
@@ -58,7 +58,7 @@ class IndexerModule(_ModuleBase):
         :return: 资源列表
         """
 
-        def __remove_duplicate(_torrents: List[TorrentInfo]) -> List[TorrentInfo]:
+        def __remove_duplicate(_torrents: list[TorrentInfo]) -> list[TorrentInfo]:
             """
             去除重复的种子
             :param _torrents: 种子列表
@@ -170,7 +170,7 @@ class IndexerModule(_ModuleBase):
     def __spider_search(indexer: CommentedMap,
                         search_word: str = None,
                         mtype: MediaType = None,
-                        page: int = 0) -> (bool, List[dict]):
+                        page: int = 0) -> (bool, list[dict]):
         """
         根据关键字搜索单个站点
         :param: indexer: 站点配置
@@ -187,7 +187,7 @@ class IndexerModule(_ModuleBase):
 
         return _spider.is_error, _spider.get_torrents()
 
-    def refresh_torrents(self, site: CommentedMap) -> Optional[List[TorrentInfo]]:
+    def refresh_torrents(self, site: CommentedMap) -> Optional[list[TorrentInfo]]:
         """
         获取站点最新一页的种子，多个站点需要多线程处理
         :param site:  站点

--- a/app/modules/indexer/mtorrent.py
+++ b/app/modules/indexer/mtorrent.py
@@ -1,7 +1,6 @@
 import base64
 import json
 import re
-from typing import Tuple, List
 
 from ruamel.yaml import CommentedMap
 
@@ -65,7 +64,7 @@ class MTorrentSpider:
             self._token = indexer.get('token')
             self._timeout = indexer.get('timeout') or 15
 
-    def search(self, keyword: str, mtype: MediaType = None, page: int = 0) -> Tuple[bool, List[dict]]:
+    def search(self, keyword: str, mtype: MediaType = None, page: int = 0) -> tuple[bool, list[dict]]:
         """
         搜索
         """

--- a/app/modules/indexer/spider.py
+++ b/app/modules/indexer/spider.py
@@ -2,7 +2,6 @@ import copy
 import datetime
 import re
 import traceback
-from typing import List
 from urllib.parse import quote, urlencode, urlparse, parse_qs
 
 import chardet
@@ -16,6 +15,7 @@ from app.log import logger
 from app.schemas.types import MediaType
 from app.utils.http import RequestUtils
 from app.utils.string import StringUtils
+import builtins
 
 
 class TorrentSpider:
@@ -112,7 +112,7 @@ class TorrentSpider:
             self.referer = referer
         self.torrents_info_array = []
 
-    def get_torrents(self) -> List[dict]:
+    def get_torrents(self) -> builtins.list[dict]:
         """
         开始请求
         """
@@ -731,7 +731,7 @@ class TorrentSpider:
             items = items[0]
         return items
 
-    def parse(self, html_text: str) -> List[dict]:
+    def parse(self, html_text: str) -> builtins.list[dict]:
         """
         解析整个页面
         """

--- a/app/modules/indexer/tnode.py
+++ b/app/modules/indexer/tnode.py
@@ -1,5 +1,4 @@
 import re
-from typing import Tuple, List
 
 from ruamel.yaml import CommentedMap
 
@@ -51,7 +50,7 @@ class TNodeSpider:
             if csrf_token:
                 self._token = csrf_token.group(1)
 
-    def search(self, keyword: str, page: int = 0) -> Tuple[bool, List[dict]]:
+    def search(self, keyword: str, page: int = 0) -> tuple[bool, list[dict]]:
         if not self._token:
             logger.warn(f"{self._name} 未获取到token，无法搜索")
             return True, []

--- a/app/modules/indexer/torrentleech.py
+++ b/app/modules/indexer/torrentleech.py
@@ -1,4 +1,3 @@
-from typing import List, Tuple
 from urllib.parse import quote
 
 from ruamel.yaml import CommentedMap
@@ -25,7 +24,7 @@ class TorrentLeech:
             self._proxy = settings.PROXY
             self._timeout = indexer.get('timeout') or 15
 
-    def search(self, keyword: str, page: int = 0) -> Tuple[bool, List[dict]]:
+    def search(self, keyword: str, page: int = 0) -> tuple[bool, list[dict]]:
 
         if StringUtils.is_chinese(keyword):
             # 不支持中文

--- a/app/modules/indexer/yema.py
+++ b/app/modules/indexer/yema.py
@@ -1,4 +1,3 @@
-from typing import Tuple, List
 
 from ruamel.yaml import CommentedMap
 
@@ -43,7 +42,7 @@ class YemaSpider:
             self._ua = indexer.get('ua')
             self._timeout = indexer.get('timeout') or 15
 
-    def search(self, keyword: str, mtype: MediaType = None, page: int = 0) -> Tuple[bool, List[dict]]:
+    def search(self, keyword: str, mtype: MediaType = None, page: int = 0) -> tuple[bool, list[dict]]:
         """
         搜索
         """

--- a/app/modules/jellyfin/__init__.py
+++ b/app/modules/jellyfin/__init__.py
@@ -1,4 +1,5 @@
-from typing import Optional, Tuple, Union, Any, List, Generator
+from typing import Optional, Tuple, Union, Any, List
+from collections.abc import Generator
 
 from app import schemas
 from app.core.context import MediaInfo
@@ -18,7 +19,7 @@ class JellyfinModule(_ModuleBase):
     def get_name() -> str:
         return "Jellyfin"
 
-    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+    def init_setting(self) -> tuple[str, Union[str, bool]]:
         return "MEDIASERVER", "jellyfin"
 
     def scheduler_job(self) -> None:
@@ -32,7 +33,7 @@ class JellyfinModule(_ModuleBase):
     def stop(self):
         pass
 
-    def test(self) -> Tuple[bool, str]:
+    def test(self) -> tuple[bool, str]:
         """
         测试模块连接性
         """
@@ -107,7 +108,7 @@ class JellyfinModule(_ModuleBase):
                     itemid=itemid
                 )
 
-    def media_statistic(self) -> List[schemas.Statistic]:
+    def media_statistic(self) -> list[schemas.Statistic]:
         """
         媒体数量统计
         """
@@ -115,7 +116,7 @@ class JellyfinModule(_ModuleBase):
         media_statistic.user_count = self.jellyfin.get_user_count()
         return [media_statistic]
 
-    def mediaserver_librarys(self, server: str = None, username: str = None) -> Optional[List[schemas.MediaServerLibrary]]:
+    def mediaserver_librarys(self, server: str = None, username: str = None) -> Optional[list[schemas.MediaServerLibrary]]:
         """
         媒体库列表
         """
@@ -140,7 +141,7 @@ class JellyfinModule(_ModuleBase):
         return self.jellyfin.get_iteminfo(item_id)
 
     def mediaserver_tv_episodes(self, server: str,
-                                item_id: Union[str, int]) -> Optional[List[schemas.MediaServerSeasonInfo]]:
+                                item_id: Union[str, int]) -> Optional[list[schemas.MediaServerSeasonInfo]]:
         """
         获取剧集信息
         """
@@ -155,7 +156,7 @@ class JellyfinModule(_ModuleBase):
         ) for season, episodes in seasoninfo.items()]
 
     def mediaserver_playing(self, count: int = 20,
-                            server: str = None, username: str = None) -> List[schemas.MediaServerPlayItem]:
+                            server: str = None, username: str = None) -> list[schemas.MediaServerPlayItem]:
         """
         获取媒体服务器正在播放信息
         """
@@ -172,7 +173,7 @@ class JellyfinModule(_ModuleBase):
         return self.jellyfin.get_play_url(item_id)
 
     def mediaserver_latest(self, count: int = 20,
-                           server: str = None, username: str = None) -> List[schemas.MediaServerPlayItem]:
+                           server: str = None, username: str = None) -> list[schemas.MediaServerPlayItem]:
         """
         获取媒体服务器最新入库条目
         """

--- a/app/modules/jellyfin/jellyfin.py
+++ b/app/modules/jellyfin/jellyfin.py
@@ -1,5 +1,6 @@
 import json
-from typing import List, Union, Optional, Dict, Generator, Tuple
+from typing import Union, Optional
+from collections.abc import Generator
 
 from requests import Response
 
@@ -44,7 +45,7 @@ class Jellyfin:
         self.user = self.get_user()
         self.serverid = self.get_server_id()
 
-    def get_jellyfin_folders(self) -> List[dict]:
+    def get_jellyfin_folders(self) -> list[dict]:
         """
         获取Jellyfin媒体库路径列表
         """
@@ -56,13 +57,13 @@ class Jellyfin:
             if res:
                 return res.json()
             else:
-                logger.error(f"Library/SelectableMediaFolders 未获取到返回数据")
+                logger.error("Library/SelectableMediaFolders 未获取到返回数据")
                 return []
         except Exception as e:
-            logger.error(f"连接Library/SelectableMediaFolders 出错：" + str(e))
+            logger.error("连接Library/SelectableMediaFolders 出错：" + str(e))
             return []
 
-    def get_jellyfin_virtual_folders(self) -> List[dict]:
+    def get_jellyfin_virtual_folders(self) -> list[dict]:
         """
         获取Jellyfin媒体库所有路径列表（包含共享路径）
         """
@@ -91,13 +92,13 @@ class Jellyfin:
                         })
                 return librarys
             else:
-                logger.error(f"Library/VirtualFolders 未获取到返回数据")
+                logger.error("Library/VirtualFolders 未获取到返回数据")
                 return []
         except Exception as e:
-            logger.error(f"连接Library/VirtualFolders 出错：" + str(e))
+            logger.error("连接Library/VirtualFolders 出错：" + str(e))
             return []
 
-    def __get_jellyfin_librarys(self, username: str = None) -> List[dict]:
+    def __get_jellyfin_librarys(self, username: str = None) -> list[dict]:
         """
         获取Jellyfin媒体库的信息
         """
@@ -113,13 +114,13 @@ class Jellyfin:
             if res:
                 return res.json().get("Items")
             else:
-                logger.error(f"Users/Views 未获取到返回数据")
+                logger.error("Users/Views 未获取到返回数据")
                 return []
         except Exception as e:
-            logger.error(f"连接Users/Views 出错：" + str(e))
+            logger.error("连接Users/Views 出错：" + str(e))
             return []
 
-    def get_librarys(self, username: str = None) -> List[schemas.MediaServerLibrary]:
+    def get_librarys(self, username: str = None) -> list[schemas.MediaServerLibrary]:
         """
         获取媒体服务器所有媒体库列表
         """
@@ -167,10 +168,10 @@ class Jellyfin:
             if res:
                 return len(res.json())
             else:
-                logger.error(f"Users 未获取到返回数据")
+                logger.error("Users 未获取到返回数据")
                 return 0
         except Exception as e:
-            logger.error(f"连接Users出错：" + str(e))
+            logger.error("连接Users出错：" + str(e))
             return 0
 
     def get_user(self, user_name: str = None) -> Optional[Union[str, int]]:
@@ -194,9 +195,9 @@ class Jellyfin:
                     if user.get("Policy", {}).get("IsAdministrator"):
                         return user.get("Id")
             else:
-                logger.error(f"Users 未获取到返回数据")
+                logger.error("Users 未获取到返回数据")
         except Exception as e:
-            logger.error(f"连接Users出错：" + str(e))
+            logger.error("连接Users出错：" + str(e))
         return None
 
     def authenticate(self, username: str, password: str) -> Optional[str]:
@@ -231,9 +232,9 @@ class Jellyfin:
                     logger.info(f"用户 {username} Jellyfin认证成功")
                     return auth_token
             else:
-                logger.error(f"Users/AuthenticateByName 未获取到返回数据")
+                logger.error("Users/AuthenticateByName 未获取到返回数据")
         except Exception as e:
-            logger.error(f"连接Users/AuthenticateByName出错：" + str(e))
+            logger.error("连接Users/AuthenticateByName出错：" + str(e))
         return None
 
     def get_server_id(self) -> Optional[str]:
@@ -248,9 +249,9 @@ class Jellyfin:
             if res:
                 return res.json().get("Id")
             else:
-                logger.error(f"System/Info 未获取到返回数据")
+                logger.error("System/Info 未获取到返回数据")
         except Exception as e:
-            logger.error(f"连接System/Info出错：" + str(e))
+            logger.error("连接System/Info出错：" + str(e))
         return None
 
     def get_medias_count(self) -> schemas.Statistic:
@@ -271,10 +272,10 @@ class Jellyfin:
                     episode_count=result.get("EpisodeCount") or 0
                 )
             else:
-                logger.error(f"Items/Counts 未获取到返回数据")
+                logger.error("Items/Counts 未获取到返回数据")
                 return schemas.Statistic()
         except Exception as e:
-            logger.error(f"连接Items/Counts出错：" + str(e))
+            logger.error("连接Items/Counts出错：" + str(e))
         return schemas.Statistic()
 
     def __get_jellyfin_series_id_by_name(self, name: str, year: str) -> Optional[str]:
@@ -296,14 +297,14 @@ class Jellyfin:
                                 not year or str(res_item.get('ProductionYear')) == str(year)):
                             return res_item.get('Id')
         except Exception as e:
-            logger.error(f"连接Items出错：" + str(e))
+            logger.error("连接Items出错：" + str(e))
             return None
         return ""
 
     def get_movies(self,
                    title: str,
                    year: str = None,
-                   tmdb_id: int = None) -> Optional[List[schemas.MediaServerItem]]:
+                   tmdb_id: int = None) -> Optional[list[schemas.MediaServerItem]]:
         """
         根据标题和年份，检查电影是否在Jellyfin中存在，存在则返回列表
         :param title: 标题
@@ -348,7 +349,7 @@ class Jellyfin:
                             ret_movies.append(mediaserver_item)
                     return ret_movies
         except Exception as e:
-            logger.error(f"连接Items出错：" + str(e))
+            logger.error("连接Items出错：" + str(e))
             return None
         return []
 
@@ -357,7 +358,7 @@ class Jellyfin:
                         title: str = None,
                         year: str = None,
                         tmdb_id: int = None,
-                        season: int = None) -> Tuple[Optional[str], Optional[Dict[int, list]]]:
+                        season: int = None) -> tuple[Optional[str], Optional[dict[int, list]]]:
         """
         根据标题和年份和季，返回Jellyfin中的剧集列表
         :param item_id: Jellyfin中的Id
@@ -407,7 +408,7 @@ class Jellyfin:
                     season_episodes[season_index].append(episode_index)
                 return item_id, season_episodes
         except Exception as e:
-            logger.error(f"连接Shows/Id/Episodes出错：" + str(e))
+            logger.error("连接Shows/Id/Episodes出错：" + str(e))
             return None, None
         return None, {}
 
@@ -430,10 +431,10 @@ class Jellyfin:
                         return image.get("Url")
                 # return images[0].get("Url") # 首选无则返回第一张
             else:
-                logger.info(f"Items/RemoteImages 未获取到返回数据，采用本地图片")
+                logger.info("Items/RemoteImages 未获取到返回数据，采用本地图片")
                 return self.generate_image_link(item_id, image_type, True)
         except Exception as e:
-            logger.error(f"连接Items/Id/RemoteImages出错：" + str(e))
+            logger.error("连接Items/Id/RemoteImages出错：" + str(e))
             return None
         return None
 
@@ -466,7 +467,7 @@ class Jellyfin:
                 logger.error("Items/Id/Images 未获取到返回数据或无该影片{}图片".format(image_type))
                 return None
         except Exception as e:
-            logger.error(f"连接Items/Id/Images出错：" + str(e))
+            logger.error("连接Items/Id/Images出错：" + str(e))
             return None
 
     def get_itemId_ancestors(self, item_id: str, index: int, key: str) -> Optional[Union[str, list, int, dict, bool]]:
@@ -483,10 +484,10 @@ class Jellyfin:
             if res:
                 return res.json()[index].get(key)
             else:
-                logger.error(f"Items/Id/Ancestors 未获取到返回数据")
+                logger.error("Items/Id/Ancestors 未获取到返回数据")
                 return None
         except Exception as e:
-            logger.error(f"连接Items/Id/Ancestors出错：" + str(e))
+            logger.error("连接Items/Id/Ancestors出错：" + str(e))
             return None
 
     def refresh_root_library(self) -> bool:
@@ -501,9 +502,9 @@ class Jellyfin:
             if res:
                 return True
             else:
-                logger.info(f"刷新媒体库失败，无法连接Jellyfin！")
+                logger.info("刷新媒体库失败，无法连接Jellyfin！")
         except Exception as e:
-            logger.error(f"连接Library/Refresh出错：" + str(e))
+            logger.error("连接Library/Refresh出错：" + str(e))
             return False
 
     def get_webhook_message(self, body: any) -> Optional[schemas.WebhookEventInfo]:
@@ -574,7 +575,7 @@ class Jellyfin:
         try:
             message = json.loads(body)
         except Exception as e:
-            logger.debug(f"解析Jellyfin Webhook报文出错：" + str(e))
+            logger.debug("解析Jellyfin Webhook报文出错：" + str(e))
             return None
         if not message:
             return None
@@ -657,7 +658,7 @@ class Jellyfin:
                     path=item.get("Path")
                 )
         except Exception as e:
-            logger.error(f"连接Users/Items出错：" + str(e))
+            logger.error("连接Users/Items出错：" + str(e))
         return None
 
     def get_items(self, parent: str) -> Generator:
@@ -682,7 +683,7 @@ class Jellyfin:
                         for item in self.get_items(result.get("Id")):
                             yield item
         except Exception as e:
-            logger.error(f"连接Users/Items出错：" + str(e))
+            logger.error("连接Users/Items出错：" + str(e))
         yield None
 
     def get_data(self, url: str) -> Optional[Response]:
@@ -698,7 +699,7 @@ class Jellyfin:
         try:
             return RequestUtils(accept_type="application/json").get_res(url=url)
         except Exception as e:
-            logger.error(f"连接Jellyfin出错：" + str(e))
+            logger.error("连接Jellyfin出错：" + str(e))
             return None
 
     def post_data(self, url: str, data: str = None, headers: dict = None) -> Optional[Response]:
@@ -718,7 +719,7 @@ class Jellyfin:
                 headers=headers
             ).post_res(url=url, data=data)
         except Exception as e:
-            logger.error(f"连接Jellyfin出错：" + str(e))
+            logger.error("连接Jellyfin出错：" + str(e))
             return None
 
     def get_play_url(self, item_id: str) -> str:
@@ -755,7 +756,7 @@ class Jellyfin:
         return f"{self._host}Items/{item_id}/" \
                f"Images/Backdrop?tag={image_tag}&fillWidth=666&api_key={self._apikey}"
 
-    def get_resume(self, num: int = 12, username: str = None) -> Optional[List[schemas.MediaServerPlayItem]]:
+    def get_resume(self, num: int = 12, username: str = None) -> Optional[list[schemas.MediaServerPlayItem]]:
         """
         获得继续观看
         """
@@ -811,12 +812,12 @@ class Jellyfin:
                     ))
                 return ret_resume
             else:
-                logger.error(f"Users/Items/Resume 未获取到返回数据")
+                logger.error("Users/Items/Resume 未获取到返回数据")
         except Exception as e:
-            logger.error(f"连接Users/Items/Resume出错：" + str(e))
+            logger.error("连接Users/Items/Resume出错：" + str(e))
         return []
 
-    def get_latest(self, num=20, username: str = None) -> Optional[List[schemas.MediaServerPlayItem]]:
+    def get_latest(self, num=20, username: str = None) -> Optional[list[schemas.MediaServerPlayItem]]:
         """
         获得最近更新
         """
@@ -857,9 +858,9 @@ class Jellyfin:
                     ))
                 return ret_latest
             else:
-                logger.error(f"Users/Items/Latest 未获取到返回数据")
+                logger.error("Users/Items/Latest 未获取到返回数据")
         except Exception as e:
-            logger.error(f"连接Users/Items/Latest出错：" + str(e))
+            logger.error("连接Users/Items/Latest出错：" + str(e))
         return []
 
     def get_user_library_folders(self):

--- a/app/modules/plex/__init__.py
+++ b/app/modules/plex/__init__.py
@@ -1,4 +1,5 @@
-from typing import Optional, Tuple, Union, Any, List, Generator
+from typing import Optional, Tuple, Union, Any, List
+from collections.abc import Generator
 
 from app import schemas
 from app.core.context import MediaInfo
@@ -21,7 +22,7 @@ class PlexModule(_ModuleBase):
     def stop(self):
         pass
 
-    def test(self) -> Tuple[bool, str]:
+    def test(self) -> tuple[bool, str]:
         """
         测试模块连接性
         """
@@ -31,7 +32,7 @@ class PlexModule(_ModuleBase):
             return False, "无法连接Plex，请检查参数配置"
         return True, ""
 
-    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+    def init_setting(self) -> tuple[str, Union[str, bool]]:
         return "MEDIASERVER", "plex"
 
     def scheduler_job(self) -> None:
@@ -101,7 +102,7 @@ class PlexModule(_ModuleBase):
                     itemid=item_id
                 )
 
-    def media_statistic(self) -> List[schemas.Statistic]:
+    def media_statistic(self) -> list[schemas.Statistic]:
         """
         媒体数量统计
         """
@@ -109,7 +110,7 @@ class PlexModule(_ModuleBase):
         media_statistic.user_count = 1
         return [media_statistic]
 
-    def mediaserver_librarys(self, server: str = None, **kwargs) -> Optional[List[schemas.MediaServerLibrary]]:
+    def mediaserver_librarys(self, server: str = None, **kwargs) -> Optional[list[schemas.MediaServerLibrary]]:
         """
         媒体库列表
         """
@@ -134,7 +135,7 @@ class PlexModule(_ModuleBase):
         return self.plex.get_iteminfo(item_id)
 
     def mediaserver_tv_episodes(self, server: str,
-                                item_id: Union[str, int]) -> Optional[List[schemas.MediaServerSeasonInfo]]:
+                                item_id: Union[str, int]) -> Optional[list[schemas.MediaServerSeasonInfo]]:
         """
         获取剧集信息
         """
@@ -148,7 +149,7 @@ class PlexModule(_ModuleBase):
             episodes=episodes
         ) for season, episodes in seasoninfo.items()]
 
-    def mediaserver_playing(self, count: int = 20, server: str = None, **kwargs) -> List[schemas.MediaServerPlayItem]:
+    def mediaserver_playing(self, count: int = 20, server: str = None, **kwargs) -> list[schemas.MediaServerPlayItem]:
         """
         获取媒体服务器正在播放信息
         """
@@ -156,7 +157,7 @@ class PlexModule(_ModuleBase):
             return []
         return self.plex.get_resume(count)
 
-    def mediaserver_latest(self, count: int = 20, server: str = None, **kwargs) -> List[schemas.MediaServerPlayItem]:
+    def mediaserver_latest(self, count: int = 20, server: str = None, **kwargs) -> list[schemas.MediaServerPlayItem]:
         """
         获取媒体服务器最新入库条目
         """

--- a/app/modules/plex/plex.py
+++ b/app/modules/plex/plex.py
@@ -1,7 +1,8 @@
 import json
 from functools import lru_cache
 from pathlib import Path
-from typing import List, Optional, Dict, Tuple, Generator, Any
+from typing import Optional, Any
+from collections.abc import Generator
 from urllib.parse import quote_plus
 
 from plexapi import media
@@ -59,7 +60,7 @@ class Plex:
             logger.error(f"Plex服务器连接失败：{str(e)}")
 
     @lru_cache(maxsize=10)
-    def __get_library_images(self, library_key: str, mtype: int) -> Optional[List[str]]:
+    def __get_library_images(self, library_key: str, mtype: int) -> Optional[list[str]]:
         """
         获取媒体服务器最近添加的媒体的图片列表
         param: library_key
@@ -95,7 +96,7 @@ class Plex:
         return [f"{self._host.rstrip('/') + url}?X-Plex-Token={self._token}" for url in
                 list(poster_urls.keys())[:total_size]]
 
-    def get_librarys(self) -> List[schemas.MediaServerLibrary]:
+    def get_librarys(self) -> list[schemas.MediaServerLibrary]:
         """
         获取媒体服务器所有媒体库列表
         """
@@ -162,7 +163,7 @@ class Plex:
                    title: str,
                    original_title: str = None,
                    year: str = None,
-                   tmdb_id: int = None) -> Optional[List[schemas.MediaServerItem]]:
+                   tmdb_id: int = None) -> Optional[list[schemas.MediaServerItem]]:
         """
         根据标题和年份，检查电影是否在Plex中存在，存在则返回列表
         :param title: 标题
@@ -220,7 +221,7 @@ class Plex:
                         original_title: str = None,
                         year: str = None,
                         tmdb_id: int = None,
-                        season: int = None) -> Tuple[Optional[str], Optional[Dict[int, list]]]:
+                        season: int = None) -> tuple[Optional[str], Optional[dict[int, list]]]:
         """
         根据标题、年份、季查询电视剧所有集信息
         :param item_id: 媒体ID
@@ -287,7 +288,7 @@ class Plex:
                 if hasattr(image, 'key') and image.key.startswith('http'):
                     return image.key
         except Exception as e:
-            logger.error(f"获取封面出错：" + str(e))
+            logger.error("获取封面出错：" + str(e))
         return None
 
     def refresh_root_library(self) -> bool:
@@ -298,7 +299,7 @@ class Plex:
             return False
         return self._plex.library.update()
 
-    def refresh_library_by_items(self, items: List[schemas.RefreshMediaItem]) -> bool:
+    def refresh_library_by_items(self, items: list[schemas.RefreshMediaItem]) -> bool:
         """
         按路径刷新媒体库 item: target_path
         """
@@ -320,7 +321,7 @@ class Plex:
                 self._plex.query(f'/library/sections/{lib_key}/refresh?path={quote_plus(str(Path(path).parent))}')
 
     @staticmethod
-    def __find_librarie(path: Path, libraries: List[Any]) -> Tuple[str, str]:
+    def __find_librarie(path: Path, libraries: list[Any]) -> tuple[str, str]:
         """
         判断这个path属于哪个媒体库
         多个媒体库配置的目录不应有重复和嵌套,
@@ -377,7 +378,7 @@ class Plex:
         return None
 
     @staticmethod
-    def __get_ids(guids: List[Any]) -> dict:
+    def __get_ids(guids: list[Any]) -> dict:
         def parse_tmdb_id(value: str) -> (bool, int):
             """尝试将TMDB ID字符串转换为整数。如果成功，返回(True, int)，失败则返回(False, None)。"""
             try:
@@ -623,7 +624,7 @@ class Plex:
         """
         return f'{self._playhost or self._host}web/index.html#!/server/{self._plex.machineIdentifier}/details?key={item_id}'
 
-    def get_resume(self, num: int = 12) -> Optional[List[schemas.MediaServerPlayItem]]:
+    def get_resume(self, num: int = 12) -> Optional[list[schemas.MediaServerPlayItem]]:
         """
         获取继续观看的媒体
         """
@@ -655,7 +656,7 @@ class Plex:
             ))
         return ret_resume[:num]
 
-    def get_latest(self, num: int = 20) -> Optional[List[schemas.MediaServerPlayItem]]:
+    def get_latest(self, num: int = 20) -> Optional[list[schemas.MediaServerPlayItem]]:
         """
         获取最近添加媒体
         """

--- a/app/modules/qbittorrent/__init__.py
+++ b/app/modules/qbittorrent/__init__.py
@@ -30,7 +30,7 @@ class QbittorrentModule(_ModuleBase):
     def stop(self):
         pass
 
-    def test(self) -> Tuple[bool, str]:
+    def test(self) -> tuple[bool, str]:
         """
         测试模块连接性
         """
@@ -40,7 +40,7 @@ class QbittorrentModule(_ModuleBase):
             return False, "无法获取Qbittorrent状态，请检查参数配置"
         return True, ""
 
-    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+    def init_setting(self) -> tuple[str, Union[str, bool]]:
         return "DOWNLOADER", "qbittorrent"
 
     def scheduler_job(self) -> None:
@@ -52,8 +52,8 @@ class QbittorrentModule(_ModuleBase):
             self.qbittorrent.reconnect()
 
     def download(self, content: Union[Path, str], download_dir: Path, cookie: str,
-                 episodes: Set[int] = None, category: str = None,
-                 downloader: str = settings.DEFAULT_DOWNLOADER) -> Optional[Tuple[Optional[str], str]]:
+                 episodes: set[int] = None, category: str = None,
+                 downloader: str = settings.DEFAULT_DOWNLOADER) -> Optional[tuple[Optional[str], str]]:
         """
         根据种子文件，选择并添加下载任务
         :param content:  种子文件地址或者磁力链接
@@ -65,7 +65,7 @@ class QbittorrentModule(_ModuleBase):
         :return: 种子Hash，错误信息
         """
 
-        def __get_torrent_info() -> Tuple[str, int]:
+        def __get_torrent_info() -> tuple[str, int]:
             """
             获取种子名称
             """
@@ -109,7 +109,7 @@ class QbittorrentModule(_ModuleBase):
             # 读取种子的名称
             torrent_name, torrent_size = __get_torrent_info()
             if not torrent_name:
-                return None, f"添加种子任务失败：无法读取种子文件"
+                return None, "添加种子任务失败：无法读取种子文件"
             # 查询所有下载器的种子
             torrents, error = self.qbittorrent.get_torrents()
             if error:
@@ -127,7 +127,7 @@ class QbittorrentModule(_ModuleBase):
                         if settings.TORRENT_TAG and settings.TORRENT_TAG not in torrent_tags:
                             logger.info(f"给种子 {torrent_hash} 打上标签：{settings.TORRENT_TAG}")
                             self.qbittorrent.set_torrents_tag(ids=torrent_hash, tags=[settings.TORRENT_TAG])
-                        return torrent_hash, f"下载任务已存在"
+                        return torrent_hash, "下载任务已存在"
             return None, f"添加种子任务失败：{content}"
         else:
             # 获取种子Hash
@@ -173,7 +173,7 @@ class QbittorrentModule(_ModuleBase):
     def list_torrents(self, status: TorrentStatus = None,
                       hashs: Union[list, str] = None,
                       downloader: str = settings.DEFAULT_DOWNLOADER
-                      ) -> Optional[List[Union[TransferTorrent, DownloadingTorrent]]]:
+                      ) -> Optional[list[Union[TransferTorrent, DownloadingTorrent]]]:
         """
         获取下载器种子列表
         :param status:  种子状态

--- a/app/modules/qbittorrent/qbittorrent.py
+++ b/app/modules/qbittorrent/qbittorrent.py
@@ -1,5 +1,5 @@
 import time
-from typing import Optional, Union, Tuple, List
+from typing import Optional, Union
 
 import qbittorrentapi
 from qbittorrentapi import TorrentDictionary, TorrentFilesList
@@ -70,7 +70,7 @@ class Qbittorrent:
 
     def get_torrents(self, ids: Union[str, list] = None,
                      status: Union[str, list] = None,
-                     tags: Union[str, list] = None) -> Tuple[List[TorrentDictionary], bool]:
+                     tags: Union[str, list] = None) -> tuple[list[TorrentDictionary], bool]:
         """
         获取种子列表
         return: 种子列表, 是否发生异常
@@ -95,7 +95,7 @@ class Qbittorrent:
             return [], True
 
     def get_completed_torrents(self, ids: Union[str, list] = None,
-                               tags: Union[str, list] = None) -> Optional[List[TorrentDictionary]]:
+                               tags: Union[str, list] = None) -> Optional[list[TorrentDictionary]]:
         """
         获取已完成的种子
         return: 种子列表, 如发生异常则返回None
@@ -107,7 +107,7 @@ class Qbittorrent:
         return None if error else torrents or []
 
     def get_downloading_torrents(self, ids: Union[str, list] = None,
-                                 tags: Union[str, list] = None) -> Optional[List[TorrentDictionary]]:
+                                 tags: Union[str, list] = None) -> Optional[list[TorrentDictionary]]:
         """
         获取正在下载的种子
         return: 种子列表, 如发生异常则返回None
@@ -372,7 +372,7 @@ class Qbittorrent:
             logger.error(f"设置速度限制出错：{str(err)}")
             return False
 
-    def get_speed_limit(self) -> Optional[Tuple[float, float]]:
+    def get_speed_limit(self) -> Optional[tuple[float, float]]:
         """
         获取QB速度
         :return: 返回download_limit 和upload_limit ，默认是0

--- a/app/modules/slack/__init__.py
+++ b/app/modules/slack/__init__.py
@@ -23,7 +23,7 @@ class SlackModule(_ModuleBase):
     def stop(self):
         self.slack.stop()
 
-    def test(self) -> Tuple[bool, str]:
+    def test(self) -> tuple[bool, str]:
         """
         测试模块连接性
         """
@@ -32,7 +32,7 @@ class SlackModule(_ModuleBase):
             return True, ""
         return False, "Slack未就续，请检查参数设置和网络连接"
 
-    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+    def init_setting(self) -> tuple[str, Union[str, bool]]:
         return "MESSAGER", "slack"
 
     @staticmethod
@@ -205,7 +205,7 @@ class SlackModule(_ModuleBase):
                             image=message.image, userid=message.userid)
 
     @checkMessage(MessageChannel.Slack)
-    def post_medias_message(self, message: Notification, medias: List[MediaInfo]) -> Optional[bool]:
+    def post_medias_message(self, message: Notification, medias: list[MediaInfo]) -> Optional[bool]:
         """
         发送媒体信息选择列表
         :param message: 消息体
@@ -215,7 +215,7 @@ class SlackModule(_ModuleBase):
         return self.slack.send_meidas_msg(title=message.title, medias=medias, userid=message.userid)
 
     @checkMessage(MessageChannel.Slack)
-    def post_torrents_message(self, message: Notification, torrents: List[Context]) -> Optional[bool]:
+    def post_torrents_message(self, message: Notification, torrents: list[Context]) -> Optional[bool]:
         """
         发送种子信息选择列表
         :param message: 消息体

--- a/app/modules/slack/slack.py
+++ b/app/modules/slack/slack.py
@@ -1,6 +1,6 @@
 import re
 from threading import Lock
-from typing import List, Optional
+from typing import Optional
 
 import requests
 from slack_bolt import App
@@ -161,7 +161,7 @@ class Slack:
             logger.error(f"Slack消息发送失败: {msg_e}")
             return False, str(msg_e)
 
-    def send_meidas_msg(self, medias: List[MediaInfo], userid: str = "", title: str = "") -> Optional[bool]:
+    def send_meidas_msg(self, medias: list[MediaInfo], userid: str = "", title: str = "") -> Optional[bool]:
         """
         发送列表类消息
         """
@@ -244,7 +244,7 @@ class Slack:
             logger.error(f"Slack消息发送失败: {msg_e}")
             return False
 
-    def send_torrents_msg(self, torrents: List[Context],
+    def send_torrents_msg(self, torrents: list[Context],
                           userid: str = "", title: str = "") -> Optional[bool]:
         """
         发送列表消息

--- a/app/modules/subtitle/__init__.py
+++ b/app/modules/subtitle/__init__.py
@@ -32,7 +32,7 @@ class SubtitleModule(_ModuleBase):
     def get_name() -> str:
         return "站点字幕"
 
-    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+    def init_setting(self) -> tuple[str, Union[str, bool]]:
         pass
 
     def stop(self) -> None:

--- a/app/modules/synologychat/__init__.py
+++ b/app/modules/synologychat/__init__.py
@@ -20,7 +20,7 @@ class SynologyChatModule(_ModuleBase):
     def stop(self):
         pass
 
-    def test(self) -> Tuple[bool, str]:
+    def test(self) -> tuple[bool, str]:
         """
         测试模块连接性
         """
@@ -29,7 +29,7 @@ class SynologyChatModule(_ModuleBase):
             return True, ""
         return False, "SynologyChat未就续，请检查参数设置、网络连接以及机器人是否可见"
 
-    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+    def init_setting(self) -> tuple[str, Union[str, bool]]:
         return "MESSAGER", "synologychat"
 
     def message_parser(self, body: Any, form: Any,
@@ -77,7 +77,7 @@ class SynologyChatModule(_ModuleBase):
                                    image=message.image, userid=message.userid)
 
     @checkMessage(MessageChannel.SynologyChat)
-    def post_medias_message(self, message: Notification, medias: List[MediaInfo]) -> Optional[bool]:
+    def post_medias_message(self, message: Notification, medias: list[MediaInfo]) -> Optional[bool]:
         """
         发送媒体信息选择列表
         :param message: 消息体
@@ -88,7 +88,7 @@ class SynologyChatModule(_ModuleBase):
                                                  userid=message.userid)
 
     @checkMessage(MessageChannel.SynologyChat)
-    def post_torrents_message(self, message: Notification, torrents: List[Context]) -> Optional[bool]:
+    def post_torrents_message(self, message: Notification, torrents: list[Context]) -> Optional[bool]:
         """
         发送种子信息选择列表
         :param message: 消息体

--- a/app/modules/synologychat/synologychat.py
+++ b/app/modules/synologychat/synologychat.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Optional, List
+from typing import Optional
 from urllib.parse import quote
 from threading import Lock
 
@@ -58,7 +58,7 @@ class SynologyChat:
                 if not text:
                     text = "\n".join(titles[1:])
                 else:
-                    text = f"%s\n%s" % ("\n".join(titles[1:]), text)
+                    text = "%s\n%s" % ("\n".join(titles[1:]), text)
 
             if text:
                 caption = "*%s*\n%s" % (title, text.replace("\n\n", "\n"))
@@ -82,7 +82,7 @@ class SynologyChat:
             logger.error(f"SynologyChat发送消息错误：{str(msg_e)}")
             return False
 
-    def send_meidas_msg(self, medias: List[MediaInfo], userid: str = "", title: str = "") -> Optional[bool]:
+    def send_meidas_msg(self, medias: list[MediaInfo], userid: str = "", title: str = "") -> Optional[bool]:
         """
         发送列表类消息
         """
@@ -126,7 +126,7 @@ class SynologyChat:
             logger.error(f"SynologyChat发送消息错误：{str(msg_e)}")
             return False
 
-    def send_torrents_msg(self, torrents: List[Context],
+    def send_torrents_msg(self, torrents: list[Context],
                           userid: str = "", title: str = "") -> Optional[bool]:
         """
         发送列表消息
@@ -209,5 +209,5 @@ class SynologyChat:
             logger.error(f"SynologyChat请求失败，错误码：{ret.status_code}，错误原因：{ret.reason}")
             return False
         else:
-            logger.error(f"SynologyChat请求失败，未获取到返回信息")
+            logger.error("SynologyChat请求失败，未获取到返回信息")
             return False

--- a/app/modules/telegram/__init__.py
+++ b/app/modules/telegram/__init__.py
@@ -22,7 +22,7 @@ class TelegramModule(_ModuleBase):
     def stop(self):
         self.telegram.stop()
 
-    def test(self) -> Tuple[bool, str]:
+    def test(self) -> tuple[bool, str]:
         """
         测试模块连接性
         """
@@ -31,7 +31,7 @@ class TelegramModule(_ModuleBase):
             return True, ""
         return False, "Telegram未就续，请检查参数设置和网络连接"
 
-    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+    def init_setting(self) -> tuple[str, Union[str, bool]]:
         return "MESSAGER", "telegram"
 
     def message_parser(self, body: Any, form: Any,
@@ -113,7 +113,7 @@ class TelegramModule(_ModuleBase):
                                image=message.image, userid=message.userid)
 
     @checkMessage(MessageChannel.Telegram)
-    def post_medias_message(self, message: Notification, medias: List[MediaInfo]) -> Optional[bool]:
+    def post_medias_message(self, message: Notification, medias: list[MediaInfo]) -> Optional[bool]:
         """
         发送媒体信息选择列表
         :param message: 消息体
@@ -124,7 +124,7 @@ class TelegramModule(_ModuleBase):
                                              userid=message.userid)
 
     @checkMessage(MessageChannel.Telegram)
-    def post_torrents_message(self, message: Notification, torrents: List[Context]) -> Optional[bool]:
+    def post_torrents_message(self, message: Notification, torrents: list[Context]) -> Optional[bool]:
         """
         发送种子信息选择列表
         :param message: 消息体
@@ -133,7 +133,7 @@ class TelegramModule(_ModuleBase):
         """
         return self.telegram.send_torrents_msg(title=message.title, torrents=torrents, userid=message.userid)
 
-    def register_commands(self, commands: Dict[str, dict]):
+    def register_commands(self, commands: dict[str, dict]):
         """
         注册命令，实现这个函数接收系统可用的命令菜单
         :param commands: 命令字典

--- a/app/modules/telegram/telegram.py
+++ b/app/modules/telegram/telegram.py
@@ -2,7 +2,7 @@ import re
 import threading
 from pathlib import Path
 from threading import Event
-from typing import Optional, List, Dict
+from typing import Optional
 
 import telebot
 from telebot import apihelper
@@ -100,7 +100,7 @@ class Telegram:
             logger.error(f"发送消息失败：{msg_e}")
             return False
 
-    def send_meidas_msg(self, medias: List[MediaInfo], userid: str = "", title: str = "") -> Optional[bool]:
+    def send_meidas_msg(self, medias: list[MediaInfo], userid: str = "", title: str = "") -> Optional[bool]:
         """
         发送媒体列表消息
         """
@@ -138,7 +138,7 @@ class Telegram:
             logger.error(f"发送消息失败：{msg_e}")
             return False
 
-    def send_torrents_msg(self, torrents: List[Context],
+    def send_torrents_msg(self, torrents: list[Context],
                           userid: str = "", title: str = "") -> Optional[bool]:
         """
         发送列表消息
@@ -217,7 +217,7 @@ class Telegram:
             raise Exception("发送文本消息失败")
         return True if ret else False
 
-    def register_commands(self, commands: Dict[str, dict]):
+    def register_commands(self, commands: dict[str, dict]):
         """
         注册菜单命令
         """

--- a/app/modules/themoviedb/__init__.py
+++ b/app/modules/themoviedb/__init__.py
@@ -47,7 +47,7 @@ class TheMovieDbModule(_ModuleBase):
         self.cache.save()
         self.tmdb.close()
 
-    def test(self) -> Tuple[bool, str]:
+    def test(self) -> tuple[bool, str]:
         """
         测试模块连接性
         """
@@ -59,7 +59,7 @@ class TheMovieDbModule(_ModuleBase):
             return False, f"无法连接 {settings.TMDB_API_DOMAIN}，错误码：{ret.status_code}"
         return False, f"{settings.TMDB_API_DOMAIN} 网络连接失败"
 
-    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+    def init_setting(self) -> tuple[str, Union[str, bool]]:
         pass
 
     def recognize_media(self, meta: MetaBase = None,
@@ -225,7 +225,7 @@ class TheMovieDbModule(_ModuleBase):
         """
         return self.tmdb.get_info(mtype=mtype, tmdbid=tmdbid)
 
-    def media_category(self) -> Optional[Dict[str, list]]:
+    def media_category(self) -> Optional[dict[str, list]]:
         """
         获取媒体分类
         :return: 获取二级分类配置字典项，需包括电影、电视剧
@@ -235,7 +235,7 @@ class TheMovieDbModule(_ModuleBase):
             MediaType.TV.value: list(self.category.tv_categorys)
         }
 
-    def search_medias(self, meta: MetaBase) -> Optional[List[MediaInfo]]:
+    def search_medias(self, meta: MetaBase) -> Optional[list[MediaInfo]]:
         """
         搜索媒体信息
         :param meta:  识别的元数据
@@ -274,7 +274,7 @@ class TheMovieDbModule(_ModuleBase):
             return medias
         return []
 
-    def search_persons(self, name: str) -> Optional[List[MediaPerson]]:
+    def search_persons(self, name: str) -> Optional[list[MediaPerson]]:
         """
         搜索人物信息
         """
@@ -333,7 +333,7 @@ class TheMovieDbModule(_ModuleBase):
         logger.info(f"{path} 刮削完成")
 
     def tmdb_discover(self, mtype: MediaType, sort_by: str, with_genres: str, with_original_language: str,
-                      page: int = 1) -> Optional[List[MediaInfo]]:
+                      page: int = 1) -> Optional[list[MediaInfo]]:
         """
         :param mtype:  媒体类型
         :param sort_by:  排序方式
@@ -358,7 +358,7 @@ class TheMovieDbModule(_ModuleBase):
             return [MediaInfo(tmdb_info=info) for info in infos]
         return []
 
-    def tmdb_trending(self, page: int = 1) -> List[MediaInfo]:
+    def tmdb_trending(self, page: int = 1) -> list[MediaInfo]:
         """
         TMDB流行趋势
         :param page: 第几页
@@ -369,7 +369,7 @@ class TheMovieDbModule(_ModuleBase):
             return [MediaInfo(tmdb_info=info) for info in trending]
         return []
 
-    def tmdb_seasons(self, tmdbid: int) -> List[schemas.TmdbSeason]:
+    def tmdb_seasons(self, tmdbid: int) -> list[schemas.TmdbSeason]:
         """
         根据TMDBID查询themoviedb所有季信息
         :param tmdbid:  TMDBID
@@ -380,7 +380,7 @@ class TheMovieDbModule(_ModuleBase):
         return [schemas.TmdbSeason(**season)
                 for season in tmdb_info.get("seasons", []) if season.get("season_number")]
 
-    def tmdb_episodes(self, tmdbid: int, season: int) -> List[schemas.TmdbEpisode]:
+    def tmdb_episodes(self, tmdbid: int, season: int) -> list[schemas.TmdbEpisode]:
         """
         根据TMDBID查询某季的所有信信息
         :param tmdbid:  TMDBID
@@ -475,7 +475,7 @@ class TheMovieDbModule(_ModuleBase):
             return f"https://{settings.TMDB_IMAGE_DOMAIN}/t/p/{image_prefix}{image_path}"
         return None
 
-    def tmdb_movie_similar(self, tmdbid: int) -> List[MediaInfo]:
+    def tmdb_movie_similar(self, tmdbid: int) -> list[MediaInfo]:
         """
         根据TMDBID查询类似电影
         :param tmdbid:  TMDBID
@@ -485,7 +485,7 @@ class TheMovieDbModule(_ModuleBase):
             return [MediaInfo(tmdb_info=info) for info in similar]
         return []
 
-    def tmdb_tv_similar(self, tmdbid: int) -> List[MediaInfo]:
+    def tmdb_tv_similar(self, tmdbid: int) -> list[MediaInfo]:
         """
         根据TMDBID查询类似电视剧
         :param tmdbid:  TMDBID
@@ -495,7 +495,7 @@ class TheMovieDbModule(_ModuleBase):
             return [MediaInfo(tmdb_info=info) for info in similar]
         return []
 
-    def tmdb_movie_recommend(self, tmdbid: int) -> List[MediaInfo]:
+    def tmdb_movie_recommend(self, tmdbid: int) -> list[MediaInfo]:
         """
         根据TMDBID查询推荐电影
         :param tmdbid:  TMDBID
@@ -505,7 +505,7 @@ class TheMovieDbModule(_ModuleBase):
             return [MediaInfo(tmdb_info=info) for info in recommend]
         return []
 
-    def tmdb_tv_recommend(self, tmdbid: int) -> List[MediaInfo]:
+    def tmdb_tv_recommend(self, tmdbid: int) -> list[MediaInfo]:
         """
         根据TMDBID查询推荐电视剧
         :param tmdbid:  TMDBID
@@ -515,7 +515,7 @@ class TheMovieDbModule(_ModuleBase):
             return [MediaInfo(tmdb_info=info) for info in recommend]
         return []
 
-    def tmdb_movie_credits(self, tmdbid: int, page: int = 1) -> List[schemas.MediaPerson]:
+    def tmdb_movie_credits(self, tmdbid: int, page: int = 1) -> list[schemas.MediaPerson]:
         """
         根据TMDBID查询电影演职员表
         :param tmdbid:  TMDBID
@@ -526,7 +526,7 @@ class TheMovieDbModule(_ModuleBase):
             return [schemas.MediaPerson(source="themoviedb", **info) for info in credit_infos]
         return []
 
-    def tmdb_tv_credits(self, tmdbid: int, page: int = 1) -> List[schemas.MediaPerson]:
+    def tmdb_tv_credits(self, tmdbid: int, page: int = 1) -> list[schemas.MediaPerson]:
         """
         根据TMDBID查询电视剧演职员表
         :param tmdbid:  TMDBID
@@ -547,7 +547,7 @@ class TheMovieDbModule(_ModuleBase):
             return schemas.MediaPerson(source="themoviedb", **detail)
         return schemas.MediaPerson()
 
-    def tmdb_person_credits(self, person_id: int, page: int = 1) -> List[MediaInfo]:
+    def tmdb_person_credits(self, person_id: int, page: int = 1) -> list[MediaInfo]:
         """
         根据TMDBID查询人物参演作品
         :param person_id:  人物ID

--- a/app/modules/themoviedb/category.py
+++ b/app/modules/themoviedb/category.py
@@ -40,7 +40,7 @@ class CategoryHelper(metaclass=Singleton):
         if self._categorys:
             self._movie_categorys = self._categorys.get('movie')
             self._tv_categorys = self._categorys.get('tv')
-        logger.info(f"已加载二级分类策略 category.yaml")
+        logger.info("已加载二级分类策略 category.yaml")
 
     @property
     def is_movie_category(self) -> bool:

--- a/app/modules/themoviedb/tmdbapi.py
+++ b/app/modules/themoviedb/tmdbapi.py
@@ -1,6 +1,6 @@
 import traceback
 from functools import lru_cache
-from typing import Optional, List
+from typing import Optional
 from urllib.parse import quote
 
 import zhconv
@@ -47,7 +47,7 @@ class TmdbApi:
         self.trending = Trending()
         self.person = Person()
 
-    def search_multiis(self, title: str) -> List[dict]:
+    def search_multiis(self, title: str) -> list[dict]:
         """
         同时查询模糊匹配的电影、电视剧TMDB信息
         """
@@ -61,7 +61,7 @@ class TmdbApi:
                 ret_infos.append(multi)
         return ret_infos
 
-    def search_movies(self, title: str, year: str) -> List[dict]:
+    def search_movies(self, title: str, year: str) -> list[dict]:
         """
         查询模糊匹配的所有电影TMDB信息
         """
@@ -78,7 +78,7 @@ class TmdbApi:
                 ret_infos.append(movie)
         return ret_infos
 
-    def search_tvs(self, title: str, year: str) -> List[dict]:
+    def search_tvs(self, title: str, year: str) -> list[dict]:
         """
         查询模糊匹配的所有电视剧TMDB信息
         """
@@ -95,7 +95,7 @@ class TmdbApi:
                 ret_infos.append(tv)
         return ret_infos
 
-    def search_persons(self, name: str) -> List[dict]:
+    def search_persons(self, name: str) -> list[dict]:
         """
         查询模糊匹配的所有人物TMDB信息
         """
@@ -123,7 +123,7 @@ class TmdbApi:
         return False
 
     @staticmethod
-    def __get_names(tmdb_info: dict) -> List[str]:
+    def __get_names(tmdb_info: dict) -> list[str]:
         """
         搜索tmdb中所有的标题和译名，用于名称匹配
         :param tmdb_info: TMDB信息
@@ -1106,7 +1106,7 @@ class TmdbApi:
             print(str(e))
             return {}
 
-    def get_movie_similar(self, tmdbid: int) -> List[dict]:
+    def get_movie_similar(self, tmdbid: int) -> list[dict]:
         """
         获取电影的相似电影
         """
@@ -1119,7 +1119,7 @@ class TmdbApi:
             print(str(e))
             return []
 
-    def get_tv_similar(self, tmdbid: int) -> List[dict]:
+    def get_tv_similar(self, tmdbid: int) -> list[dict]:
         """
         获取电视剧的相似电视剧
         """
@@ -1132,7 +1132,7 @@ class TmdbApi:
             print(str(e))
             return []
 
-    def get_movie_recommend(self, tmdbid: int) -> List[dict]:
+    def get_movie_recommend(self, tmdbid: int) -> list[dict]:
         """
         获取电影的推荐电影
         """
@@ -1145,7 +1145,7 @@ class TmdbApi:
             print(str(e))
             return []
 
-    def get_tv_recommend(self, tmdbid: int) -> List[dict]:
+    def get_tv_recommend(self, tmdbid: int) -> list[dict]:
         """
         获取电视剧的推荐电视剧
         """
@@ -1158,7 +1158,7 @@ class TmdbApi:
             print(str(e))
             return []
 
-    def get_movie_credits(self, tmdbid: int, page: int = 1, count: int = 24) -> List[dict]:
+    def get_movie_credits(self, tmdbid: int, page: int = 1, count: int = 24) -> list[dict]:
         """
         获取电影的演职员列表
         """
@@ -1175,7 +1175,7 @@ class TmdbApi:
             print(str(e))
             return []
 
-    def get_tv_credits(self, tmdbid: int, page: int = 1, count: int = 24) -> List[dict]:
+    def get_tv_credits(self, tmdbid: int, page: int = 1, count: int = 24) -> list[dict]:
         """
         获取电视剧的演职员列表
         """
@@ -1225,7 +1225,7 @@ class TmdbApi:
             print(str(e))
             return {}
 
-    def get_person_credits(self, person_id: int, page: int = 1, count: int = 24) -> List[dict]:
+    def get_person_credits(self, person_id: int, page: int = 1, count: int = 24) -> list[dict]:
         """
         获取人物参演作品
         """

--- a/app/modules/themoviedb/tmdbv3api/__init__.py
+++ b/app/modules/themoviedb/tmdbv3api/__init__.py
@@ -1,25 +1,25 @@
-from .objs.account import Account
-from .objs.auth import Authentication
-from .objs.certification import Certification
-from .objs.change import Change
-from .objs.collection import Collection
-from .objs.company import Company
-from .objs.configuration import Configuration
-from .objs.credit import Credit
-from .objs.discover import Discover
-from .objs.episode import Episode
-from .objs.find import Find
-from .objs.genre import Genre
-from .objs.group import Group
-from .objs.keyword import Keyword
-from .objs.list import List
-from .objs.movie import Movie
-from .objs.network import Network
-from .objs.person import Person
-from .objs.provider import Provider
-from .objs.review import Review
-from .objs.search import Search
-from .objs.season import Season
-from .objs.trending import Trending
-from .objs.tv import TV
-from .tmdb import TMDb
+from .objs.account import Account as Account
+from .objs.auth import Authentication as Authentication
+from .objs.certification import Certification as Certification
+from .objs.change import Change as Change
+from .objs.collection import Collection as Collection
+from .objs.company import Company as Company
+from .objs.configuration import Configuration as Configuration
+from .objs.credit import Credit as Credit
+from .objs.discover import Discover as Discover
+from .objs.episode import Episode as Episode
+from .objs.find import Find as Find
+from .objs.genre import Genre as Genre
+from .objs.group import Group as Group
+from .objs.keyword import Keyword as Keyword
+from .objs.list import List as List
+from .objs.movie import Movie as Movie
+from .objs.network import Network as Network
+from .objs.person import Person as Person
+from .objs.provider import Provider as Provider
+from .objs.review import Review as Review
+from .objs.search import Search as Search
+from .objs.season import Season as Season
+from .objs.trending import Trending as Trending
+from .objs.tv import TV as TV
+from .tmdb import TMDb as TMDb

--- a/app/modules/themoviedb/tmdbv3api/objs/tv.py
+++ b/app/modules/themoviedb/tmdbv3api/objs/tv.py
@@ -3,7 +3,7 @@ from ..tmdb import TMDb
 try:
     from urllib import quote
 except ImportError:
-    from urllib.parse import quote
+    pass
 
 
 class TV(TMDb):

--- a/app/modules/thetvdb/__init__.py
+++ b/app/modules/thetvdb/__init__.py
@@ -23,7 +23,7 @@ class TheTvDbModule(_ModuleBase):
     def stop(self):
         self.tvdb.close()
 
-    def test(self) -> Tuple[bool, str]:
+    def test(self) -> tuple[bool, str]:
         """
         测试模块连接性
         """
@@ -34,7 +34,7 @@ class TheTvDbModule(_ModuleBase):
             return False, f"无法连接 api.thetvdb.com，错误码：{ret.status_code}"
         return False, "api.thetvdb.com 网络连接失败"
 
-    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+    def init_setting(self) -> tuple[str, Union[str, bool]]:
         pass
 
     def tvdb_info(self, tvdbid: int) -> Optional[dict]:

--- a/app/modules/transmission/__init__.py
+++ b/app/modules/transmission/__init__.py
@@ -30,7 +30,7 @@ class TransmissionModule(_ModuleBase):
     def stop(self):
         pass
 
-    def test(self) -> Tuple[bool, str]:
+    def test(self) -> tuple[bool, str]:
         """
         测试模块连接性
         """
@@ -40,7 +40,7 @@ class TransmissionModule(_ModuleBase):
             return False, "无法获取Transmission状态，请检查参数配置"
         return True, ""
 
-    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+    def init_setting(self) -> tuple[str, Union[str, bool]]:
         return "DOWNLOADER", "transmission"
 
     def scheduler_job(self) -> None:
@@ -52,8 +52,8 @@ class TransmissionModule(_ModuleBase):
             self.transmission.reconnect()
 
     def download(self, content: Union[Path, str], download_dir: Path, cookie: str,
-                 episodes: Set[int] = None, category: str = None,
-                 downloader: str = settings.DEFAULT_DOWNLOADER) -> Optional[Tuple[Optional[str], str]]:
+                 episodes: set[int] = None, category: str = None,
+                 downloader: str = settings.DEFAULT_DOWNLOADER) -> Optional[tuple[Optional[str], str]]:
         """
         根据种子文件，选择并添加下载任务
         :param content:  种子文件地址或者磁力链接
@@ -65,7 +65,7 @@ class TransmissionModule(_ModuleBase):
         :return: 种子Hash
         """
 
-        def __get_torrent_info() -> Tuple[str, int]:
+        def __get_torrent_info() -> tuple[str, int]:
             """
             获取种子名称
             """
@@ -107,7 +107,7 @@ class TransmissionModule(_ModuleBase):
             # 读取种子的名称
             torrent_name, torrent_size = __get_torrent_info()
             if not torrent_name:
-                return None, f"添加种子任务失败：无法读取种子文件"
+                return None, "添加种子任务失败：无法读取种子文件"
             # 查询所有下载器的种子
             torrents, error = self.transmission.get_torrents()
             if error:
@@ -130,7 +130,7 @@ class TransmissionModule(_ModuleBase):
                             if settings.TORRENT_TAG and settings.TORRENT_TAG not in labels:
                                 labels.append(settings.TORRENT_TAG)
                                 self.transmission.set_torrent_tag(ids=torrent_hash, tags=labels)
-                        return torrent_hash, f"下载任务已存在"
+                        return torrent_hash, "下载任务已存在"
             return None, f"添加种子任务失败：{content}"
         else:
             torrent_hash = torrent.hashString
@@ -166,7 +166,7 @@ class TransmissionModule(_ModuleBase):
     def list_torrents(self, status: TorrentStatus = None,
                       hashs: Union[list, str] = None,
                       downloader: str = settings.DEFAULT_DOWNLOADER
-                      ) -> Optional[List[Union[TransferTorrent, DownloadingTorrent]]]:
+                      ) -> Optional[list[Union[TransferTorrent, DownloadingTorrent]]]:
         """
         获取下载器种子列表
         :param status:  种子状态
@@ -297,7 +297,7 @@ class TransmissionModule(_ModuleBase):
             return None
         return self.transmission.start_torrents(ids=hashs)
 
-    def torrent_files(self, tid: str, downloader: str = settings.DEFAULT_DOWNLOADER) -> Optional[List[File]]:
+    def torrent_files(self, tid: str, downloader: str = settings.DEFAULT_DOWNLOADER) -> Optional[list[File]]:
         """
         获取种子文件列表
         """

--- a/app/modules/transmission/transmission.py
+++ b/app/modules/transmission/transmission.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Tuple, List, Dict
+from typing import Optional, Union
 
 import transmission_rpc
 from transmission_rpc import Client, Torrent, File
@@ -69,7 +69,7 @@ class Transmission:
         self.trc = self.__login_transmission()
 
     def get_torrents(self, ids: Union[str, list] = None, status: Union[str, list] = None,
-                     tags: Union[str, list] = None) -> Tuple[List[Torrent], bool]:
+                     tags: Union[str, list] = None) -> tuple[list[Torrent], bool]:
         """
         获取种子列表
         返回结果 种子列表, 是否有错误
@@ -99,7 +99,7 @@ class Transmission:
         return ret_torrents, False
 
     def get_completed_torrents(self, ids: Union[str, list] = None,
-                               tags: Union[str, list] = None) -> Optional[List[Torrent]]:
+                               tags: Union[str, list] = None) -> Optional[list[Torrent]]:
         """
         获取已完成的种子列表
         return 种子列表, 发生错误时返回None
@@ -114,7 +114,7 @@ class Transmission:
             return None
 
     def get_downloading_torrents(self, ids: Union[str, list] = None,
-                                 tags: Union[str, list] = None) -> Optional[List[Torrent]]:
+                                 tags: Union[str, list] = None) -> Optional[list[Torrent]]:
         """
         获取正在下载的种子列表
         return 种子列表, 发生错误时返回None
@@ -145,7 +145,7 @@ class Transmission:
             logger.error(f"设置种子标签出错：{str(err)}")
             return False
 
-    def get_torrent_tags(self, ids: str) -> List[str]:
+    def get_torrent_tags(self, ids: str) -> list[str]:
         """
         获取所有种子标签
         """
@@ -229,7 +229,7 @@ class Transmission:
             logger.error(f"删除种子出错：{str(err)}")
             return False
 
-    def get_files(self, tid: str) -> Optional[List[File]]:
+    def get_files(self, tid: str) -> Optional[list[File]]:
         """
         获取种子文件列表
         """
@@ -307,7 +307,7 @@ class Transmission:
             logger.error(f"设置速度限制出错：{str(err)}")
             return False
 
-    def get_speed_limit(self) -> Optional[Tuple[float, float]]:
+    def get_speed_limit(self) -> Optional[tuple[float, float]]:
         """
         获取TR速度
         :return: download_limit 下载速度 默认是0

--- a/app/modules/vocechat/__init__.py
+++ b/app/modules/vocechat/__init__.py
@@ -22,7 +22,7 @@ class VoceChatModule(_ModuleBase):
     def stop(self):
         pass
 
-    def test(self) -> Tuple[bool, str]:
+    def test(self) -> tuple[bool, str]:
         """
         测试模块连接性
         """
@@ -31,7 +31,7 @@ class VoceChatModule(_ModuleBase):
             return True, ""
         return False, "获取VoceChat频道失败"
 
-    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+    def init_setting(self) -> tuple[str, Union[str, bool]]:
         return "MESSAGER", "vocechat"
 
     @staticmethod
@@ -106,7 +106,7 @@ class VoceChatModule(_ModuleBase):
         self.vocechat.send_msg(title=message.title, text=message.text, userid=message.userid)
 
     @checkMessage(MessageChannel.VoceChat)
-    def post_medias_message(self, message: Notification, medias: List[MediaInfo]) -> Optional[bool]:
+    def post_medias_message(self, message: Notification, medias: list[MediaInfo]) -> Optional[bool]:
         """
         发送媒体信息选择列表
         :param message: 消息内容
@@ -119,7 +119,7 @@ class VoceChatModule(_ModuleBase):
         return self.vocechat.send_medias_msg(title=message.title, medias=medias, userid=message.userid)
 
     @checkMessage(MessageChannel.VoceChat)
-    def post_torrents_message(self, message: Notification, torrents: List[Context]) -> Optional[bool]:
+    def post_torrents_message(self, message: Notification, torrents: list[Context]) -> Optional[bool]:
         """
         发送种子信息选择列表
         :param message: 消息内容
@@ -128,5 +128,5 @@ class VoceChatModule(_ModuleBase):
         """
         return self.vocechat.send_torrents_msg(title=message.title, torrents=torrents, userid=message.userid)
 
-    def register_commands(self, commands: Dict[str, dict]):
+    def register_commands(self, commands: dict[str, dict]):
         pass

--- a/app/modules/vocechat/vocechat.py
+++ b/app/modules/vocechat/vocechat.py
@@ -1,6 +1,6 @@
 import re
 import threading
-from typing import Optional, List
+from typing import Optional
 
 from app.core.config import settings
 from app.core.context import MediaInfo, Context
@@ -90,7 +90,7 @@ class VoceChat:
             logger.error(f"发送消息失败：{msg_e}")
             return False
 
-    def send_medias_msg(self, title: str, medias: List[MediaInfo], userid: str = "") -> Optional[bool]:
+    def send_medias_msg(self, title: str, medias: list[MediaInfo], userid: str = "") -> Optional[bool]:
         """
         发送列表类消息
         """
@@ -126,7 +126,7 @@ class VoceChat:
             logger.error(f"发送消息失败：{msg_e}")
             return False
 
-    def send_torrents_msg(self, torrents: List[Context],
+    def send_torrents_msg(self, torrents: list[Context],
                           userid: str = "", title: str = "") -> Optional[bool]:
         """
         发送列表消息

--- a/app/modules/wechat/__init__.py
+++ b/app/modules/wechat/__init__.py
@@ -24,7 +24,7 @@ class WechatModule(_ModuleBase):
     def stop(self):
         pass
 
-    def test(self) -> Tuple[bool, str]:
+    def test(self) -> tuple[bool, str]:
         """
         测试模块连接性
         """
@@ -33,7 +33,7 @@ class WechatModule(_ModuleBase):
             return True, ""
         return False, "获取微信token失败"
 
-    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+    def init_setting(self) -> tuple[str, Union[str, bool]]:
         return "MESSAGER", "wechat"
 
     def message_parser(self, body: Any, form: Any,
@@ -62,7 +62,7 @@ class WechatModule(_ModuleBase):
                                   sReceiveId=settings.WECHAT_CORPID)
             # 报文数据
             if not body:
-                logger.debug(f"微信请求数据为空")
+                logger.debug("微信请求数据为空")
                 return None
             logger.debug(f"收到微信请求：{body}")
             ret, sMsg = wxcpt.DecryptMsg(sPostData=body,
@@ -104,7 +104,7 @@ class WechatModule(_ModuleBase):
             user_id = DomUtils.tag_value(root_node, "FromUserName")
             # 没的消息类型和用户ID的消息不要
             if not msg_type or not user_id:
-                logger.warn(f"解析不到消息类型和用户ID")
+                logger.warn("解析不到消息类型和用户ID")
                 return None
             # 解析消息内容
             if msg_type == "event" and event == "click":
@@ -144,7 +144,7 @@ class WechatModule(_ModuleBase):
                              image=message.image, userid=message.userid)
 
     @checkMessage(MessageChannel.Wechat)
-    def post_medias_message(self, message: Notification, medias: List[MediaInfo]) -> Optional[bool]:
+    def post_medias_message(self, message: Notification, medias: list[MediaInfo]) -> Optional[bool]:
         """
         发送媒体信息选择列表
         :param message: 消息内容
@@ -157,7 +157,7 @@ class WechatModule(_ModuleBase):
         return self.wechat.send_medias_msg(medias=medias, userid=message.userid)
 
     @checkMessage(MessageChannel.Wechat)
-    def post_torrents_message(self, message: Notification, torrents: List[Context]) -> Optional[bool]:
+    def post_torrents_message(self, message: Notification, torrents: list[Context]) -> Optional[bool]:
         """
         发送种子信息选择列表
         :param message: 消息内容
@@ -166,7 +166,7 @@ class WechatModule(_ModuleBase):
         """
         return self.wechat.send_torrents_msg(title=message.title, torrents=torrents, userid=message.userid)
 
-    def register_commands(self, commands: Dict[str, dict]):
+    def register_commands(self, commands: dict[str, dict]):
         """
         注册命令，实现这个函数接收系统可用的命令菜单
         :param commands: 命令字典

--- a/app/modules/wechat/wechat.py
+++ b/app/modules/wechat/wechat.py
@@ -2,7 +2,7 @@ import json
 import re
 import threading
 from datetime import datetime
-from typing import Optional, List, Dict
+from typing import Optional
 
 from app.core.config import settings
 from app.core.context import MediaInfo, Context
@@ -81,7 +81,7 @@ class WeChat:
                 elif res is not None:
                     logger.error(f"获取微信access_token失败，错误码：{res.status_code}，错误原因：{res.reason}")
                 else:
-                    logger.error(f"获取微信access_token失败，未获取到返回信息")
+                    logger.error("获取微信access_token失败，未获取到返回信息")
                     raise Exception("获取微信access_token失败，网络连接失败")
             except Exception as e:
                 logger.error(f"获取微信access_token失败，错误信息：{str(e)}")
@@ -168,7 +168,7 @@ class WeChat:
 
         return ret_code
 
-    def send_medias_msg(self, medias: List[MediaInfo], userid: str = "") -> Optional[bool]:
+    def send_medias_msg(self, medias: list[MediaInfo], userid: str = "") -> Optional[bool]:
         """
         发送列表类消息
         """
@@ -204,7 +204,7 @@ class WeChat:
         }
         return self.__post_request(message_url, req_json)
 
-    def send_torrents_msg(self, torrents: List[Context],
+    def send_torrents_msg(self, torrents: list[Context],
                           userid: str = "", title: str = "") -> Optional[bool]:
         """
         发送列表消息
@@ -276,13 +276,13 @@ class WeChat:
                 logger.error(f"发送请求失败，错误码：{res.status_code}，错误原因：{res.reason}")
                 return False
             else:
-                logger.error(f"发送请求失败，未获取到返回信息")
+                logger.error("发送请求失败，未获取到返回信息")
                 return False
         except Exception as err:
             logger.error(f"发送请求失败，错误信息：{str(err)}")
             return False
 
-    def create_menus(self, commands: Dict[str, dict]):
+    def create_menus(self, commands: dict[str, dict]):
         """
         自动注册微信菜单
         :param commands: 命令字典
@@ -327,7 +327,7 @@ class WeChat:
         # 对commands按category分组
         category_dict = {}
         for key, value in commands.items():
-            category: Dict[str, dict] = value.get("category")
+            category: dict[str, dict] = value.get("category")
             if category:
                 if not category_dict.get(category):
                     category_dict[category] = {}

--- a/app/plugins/__init__.py
+++ b/app/plugins/__init__.py
@@ -64,7 +64,7 @@ class _PluginBase(metaclass=ABCMeta):
 
     @staticmethod
     @abstractmethod
-    def get_command() -> List[Dict[str, Any]]:
+    def get_command() -> list[dict[str, Any]]:
         """
         注册插件远程命令
         [{
@@ -78,7 +78,7 @@ class _PluginBase(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_api(self) -> List[Dict[str, Any]]:
+    def get_api(self) -> list[dict[str, Any]]:
         """
         注册插件API
         [{
@@ -92,7 +92,7 @@ class _PluginBase(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+    def get_form(self) -> tuple[list[dict], dict[str, Any]]:
         """
         拼装插件配置页面，需要返回两块数据：1、页面配置；2、数据结构
         插件配置页面使用Vuetify组件拼装，参考：https://vuetifyjs.com/
@@ -100,14 +100,14 @@ class _PluginBase(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_page(self) -> List[dict]:
+    def get_page(self) -> list[dict]:
         """
         拼装插件详情页面，需要返回页面配置，同时附带数据
         插件详情页面使用Vuetify组件拼装，参考：https://vuetifyjs.com/
         """
         pass
 
-    def get_service(self) -> List[Dict[str, Any]]:
+    def get_service(self) -> list[dict[str, Any]]:
         """
         注册插件公共服务
         [{
@@ -120,7 +120,7 @@ class _PluginBase(metaclass=ABCMeta):
         """
         pass
 
-    def get_dashboard(self, key: str, **kwargs) -> Optional[Tuple[Dict[str, Any], Dict[str, Any], List[dict]]]:
+    def get_dashboard(self, key: str, **kwargs) -> Optional[tuple[dict[str, Any], dict[str, Any], list[dict]]]:
         """
         获取插件仪表盘页面，需要返回：1、仪表板col配置字典；2、全局配置（自动刷新等）；3、仪表板页面元素配置json（含数据）
         1、col配置参考：
@@ -142,7 +142,7 @@ class _PluginBase(metaclass=ABCMeta):
         """
         pass
 
-    def get_dashboard_meta(self) -> Optional[List[Dict[str, str]]]:
+    def get_dashboard_meta(self) -> Optional[list[dict[str, str]]]:
         """
         获取插件仪表盘元信息
         返回示例：

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -2,7 +2,6 @@ import logging
 import threading
 import traceback
 from datetime import datetime, timedelta
-from typing import List
 
 import pytz
 from apscheduler.executors.pool import ThreadPoolExecutor
@@ -77,7 +76,7 @@ class Scheduler(metaclass=Singleton):
             # 最大重试次数
             __max_try__ = 30
             if self._auth_count > __max_try__:
-                SchedulerChain().messagehelper.put(title=f"用户认证失败",
+                SchedulerChain().messagehelper.put(title="用户认证失败",
                                                    message="用户认证失败次数过多，将不再尝试认证！",
                                                    role="system")
                 return
@@ -460,7 +459,7 @@ class Scheduler(metaclass=Singleton):
                                                        message=str(e),
                                                        role="system")
 
-    def list(self) -> List[schemas.ScheduleInfo]:
+    def list(self) -> list[schemas.ScheduleInfo]:
         """
         当前所有任务
         """

--- a/app/schemas/context.py
+++ b/app/schemas/context.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, List, Union
+from typing import Optional, Union
 
 from pydantic import BaseModel
 
@@ -56,7 +56,7 @@ class MetaInfo(BaseModel):
     # 资源类型
     edition: Optional[str] = None
     # 应用的识别词信息
-    apply_words: Optional[List[str]] = None
+    apply_words: Optional[list[str]] = None
 
 
 class MediaInfo(BaseModel):
@@ -104,9 +104,9 @@ class MediaInfo(BaseModel):
     # 二级分类
     category: Optional[str] = ""
     # 季季集清单
-    seasons: Optional[Dict[int, list]] = {}
+    seasons: Optional[dict[int, list]] = {}
     # 季详情
-    season_info: Optional[List[dict]] = []
+    season_info: Optional[list[dict]] = []
     # 别名和译名
     names: Optional[list] = []
     # 演员
@@ -123,7 +123,7 @@ class MediaInfo(BaseModel):
     # 集时长
     episode_run_time: Optional[list] = []
     # 风格
-    genres: Optional[List[dict]] = []
+    genres: Optional[list[dict]] = []
     # 首播日期
     first_air_date: Optional[str] = None
     # 首页

--- a/app/schemas/mediaserver.py
+++ b/app/schemas/mediaserver.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional, Dict, Union, List
+from typing import Optional, Union
 
 from pydantic import BaseModel
 
@@ -13,7 +13,7 @@ class ExistMediaInfo(BaseModel):
     # 类型 电影、电视剧
     type: Optional[MediaType]
     # 季
-    seasons: Optional[Dict[int, list]] = {}
+    seasons: Optional[dict[int, list]] = {}
     # 媒体服务器
     server: Optional[str] = None
     # 媒体ID
@@ -67,7 +67,7 @@ class MediaServerLibrary(BaseModel):
     # 封面图
     image: Optional[str] = None
     # 封面图列表
-    image_list: Optional[List[str]] = None
+    image_list: Optional[list[str]] = None
     # 跳转链接
     link: Optional[str] = None
 
@@ -101,7 +101,7 @@ class MediaServerItem(BaseModel):
     # 路径
     path: Optional[str] = None
     # 季集
-    seasoninfo: Optional[Dict[int, list]] = None
+    seasoninfo: Optional[dict[int, list]] = None
     # 备注
     note: Optional[str] = None
     # 同步时间
@@ -116,7 +116,7 @@ class MediaServerSeasonInfo(BaseModel):
     媒体服务器媒体剧集信息
     """
     season: Optional[int] = None
-    episodes: Optional[List[int]] = []
+    episodes: Optional[list[int]] = []
 
 
 class WebhookEventInfo(BaseModel):

--- a/app/schemas/plugin.py
+++ b/app/schemas/plugin.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -62,4 +62,4 @@ class PluginDashboard(Plugin):
     # col列数
     cols: Optional[dict] = {}
     # 页面元素
-    elements: Optional[List[dict]] = []
+    elements: Optional[list[dict]] = []

--- a/app/schemas/subscribe.py
+++ b/app/schemas/subscribe.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -53,7 +53,7 @@ class Subscribe(BaseModel):
     # 订阅用户
     username: Optional[str] = None
     # 订阅站点
-    sites: Optional[List[int]] = []
+    sites: Optional[list[int]] = []
     # 是否洗版
     best_version: Optional[int] = 0
     # 当前优先级

--- a/app/utils/object.py
+++ b/app/utils/object.py
@@ -1,6 +1,7 @@
 import inspect
 from types import FunctionType
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 
 
 class ObjectUtils:

--- a/app/utils/string.py
+++ b/app/utils/string.py
@@ -3,7 +3,8 @@ import datetime
 import hashlib
 import random
 import re
-from typing import Union, Tuple, Optional, Any, List, Generator
+from typing import Union, Optional, Any
+from collections.abc import Generator
 from urllib import parse
 
 import cn2an
@@ -252,7 +253,7 @@ class StringUtils:
         return False
 
     @staticmethod
-    def get_url_netloc(url: str) -> Tuple[str, str]:
+    def get_url_netloc(url: str) -> tuple[str, str]:
         """
         获取URL的协议和域名部分
         """
@@ -411,7 +412,7 @@ class StringUtils:
         return '; '.join(['='.join(item) for item in cj.items()])
 
     @staticmethod
-    def get_idlist(content: str, dicts: List[dict]):
+    def get_idlist(content: str, dicts: list[dict]):
         """
         从字符串中提取id列表
         :param content: 字符串
@@ -539,7 +540,7 @@ class StringUtils:
 
     @staticmethod
     def get_keyword(content: str) \
-            -> Tuple[Optional[MediaType], Optional[str], Optional[int], Optional[int], Optional[str], Optional[str]]:
+            -> tuple[Optional[MediaType], Optional[str], Optional[int], Optional[int], Optional[str], Optional[str]]:
         """
         从搜索关键字中拆分中年份、季、集、类型
         """
@@ -601,7 +602,7 @@ class StringUtils:
         return reparse
 
     @staticmethod
-    def get_domain_address(address: str, prefix: bool = True) -> Tuple[Optional[str], Optional[int]]:
+    def get_domain_address(address: str, prefix: bool = True) -> tuple[Optional[str], Optional[int]]:
         """
         从地址中获取域名和端口号
         """
@@ -625,7 +626,7 @@ class StringUtils:
         return domain, port
 
     @staticmethod
-    def str_series(array: List[int]) -> str:
+    def str_series(array: list[int]) -> str:
         """
         将季集列表转化为字符串简写
         """
@@ -657,7 +658,7 @@ class StringUtils:
         return ",".join(result)
 
     @staticmethod
-    def format_ep(nums: List[int]) -> str:
+    def format_ep(nums: list[int]) -> str:
         """
         将剧集列表格式化为连续区间
         """

--- a/app/utils/system.py
+++ b/app/utils/system.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import List, Union, Tuple
+from typing import Union
 
 import docker
 import psutil
@@ -86,7 +86,7 @@ class SystemUtils:
             return "Linux"
 
     @staticmethod
-    def copy(src: Path, dest: Path) -> Tuple[int, str]:
+    def copy(src: Path, dest: Path) -> tuple[int, str]:
         """
         复制
         """
@@ -98,7 +98,7 @@ class SystemUtils:
             return -1, str(err)
 
     @staticmethod
-    def move(src: Path, dest: Path) -> Tuple[int, str]:
+    def move(src: Path, dest: Path) -> tuple[int, str]:
         """
         移动
         """
@@ -113,7 +113,7 @@ class SystemUtils:
             return -1, str(err)
 
     @staticmethod
-    def link(src: Path, dest: Path) -> Tuple[int, str]:
+    def link(src: Path, dest: Path) -> tuple[int, str]:
         """
         硬链接
         """
@@ -131,7 +131,7 @@ class SystemUtils:
             return -1, str(err)
 
     @staticmethod
-    def softlink(src: Path, dest: Path) -> Tuple[int, str]:
+    def softlink(src: Path, dest: Path) -> tuple[int, str]:
         """
         软链接
         """
@@ -191,7 +191,7 @@ class SystemUtils:
             return None
 
     @staticmethod
-    def list_files(directory: Path, extensions: list, min_filesize: int = 0) -> List[Path]:
+    def list_files(directory: Path, extensions: list, min_filesize: int = 0) -> list[Path]:
         """
         获取目录下所有指定扩展名的文件（包括子目录）
         """
@@ -251,7 +251,7 @@ class SystemUtils:
         return False
 
     @staticmethod
-    def list_sub_files(directory: Path, extensions: list) -> List[Path]:
+    def list_sub_files(directory: Path, extensions: list) -> list[Path]:
         """
         列出当前目录下的所有指定扩展名的文件(不包括子目录)
         """
@@ -272,7 +272,7 @@ class SystemUtils:
         return files
 
     @staticmethod
-    def list_sub_directory(directory: Path) -> List[Path]:
+    def list_sub_directory(directory: Path) -> list[Path]:
         """
         列出当前目录下的所有子目录（不递归）
         """
@@ -314,7 +314,7 @@ class SystemUtils:
         return total_size
 
     @staticmethod
-    def space_usage(dir_list: Union[Path, List[Path]]) -> Tuple[float, float]:
+    def space_usage(dir_list: Union[Path, list[Path]]) -> tuple[float, float]:
         """
         计算多个目录的总可用空间/剩余空间（单位：Byte），并去除重复磁盘
         """
@@ -364,7 +364,7 @@ class SystemUtils:
         return psutil.disk_usage(str(path)).total
 
     @staticmethod
-    def processes() -> List[schemas.ProcessInfo]:
+    def processes() -> list[schemas.ProcessInfo]:
         """
         获取所有进程
         """
@@ -419,7 +419,7 @@ class SystemUtils:
         return psutil.cpu_percent()
 
     @staticmethod
-    def memory_usage() -> List[int]:
+    def memory_usage() -> list[int]:
         """
         获取内存使用量和使用率
         """
@@ -433,7 +433,7 @@ class SystemUtils:
         return Path("/var/run/docker.sock").exists()
 
     @staticmethod
-    def restart() -> Tuple[bool, str]:
+    def restart() -> tuple[bool, str]:
         """
         执行Docker重启操作
         """

--- a/app/utils/timer.py
+++ b/app/utils/timer.py
@@ -1,5 +1,4 @@
 import random
-from typing import List
 import datetime
 
 
@@ -10,7 +9,7 @@ class TimerUtils:
                          begin_hour: int = 7,
                          end_hour: int = 23,
                          min_interval: int = 20,
-                         max_interval: int = 40) -> List[datetime.datetime]:
+                         max_interval: int = 40) -> list[datetime.datetime]:
         """
         按执行次数生成随机定时器
         :param num_executions: 执行次数

--- a/database/versions/a40261701909_1_0_20.py
+++ b/database/versions/a40261701909_1_0_20.py
@@ -9,7 +9,6 @@ import json
 from pathlib import Path
 
 from alembic import op
-import sqlalchemy as sa
 
 from app.core.config import Settings
 


### PR DESCRIPTION

"UP035",# https://docs.astral.sh/ruff/rules/deprecated-import/
"UP006", # https://docs.astral.sh/ruff/rules/non-pep585-annotation/
"F401", # https://docs.astral.sh/ruff/rules/unused-import/
"F541", # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders/

只用了上面四条规则
1. 有模块移动到了新的位置，这条规则替换了旧的导入方式  
2. 将 typing.List 换成了 list 等等
3. 规则 2 应用后移除无用的导入
4. 如果一个 f-string 写了 f 但是有没有实际信息填入（没有{}）则移除 f

都是一些语法上的调整，无关代码格式，请酌情合并吧