### PR TITLE
fix unhashable type: 'dict'

### DIFF
--- a/app/modules/themoviedb/tmdbapi.py
+++ b/app/modules/themoviedb/tmdbapi.py
@@ -1052,7 +1052,8 @@ class TmdbApi:
             return []
         try:
             logger.debug(f"正在发现电影：{kwargs}...")
-            tmdbinfo = self.discover.discover_movies(kwargs)
+            params_tuple = tuple(kwargs.items())
+            tmdbinfo = self.discover.discover_movies(params_tuple)
             if tmdbinfo:
                 for info in tmdbinfo:
                     info['media_type'] = MediaType.MOVIE

--- a/app/modules/themoviedb/tmdbv3api/objs/discover.py
+++ b/app/modules/themoviedb/tmdbv3api/objs/discover.py
@@ -14,12 +14,13 @@ class Discover(TMDb):
     }
 
     @cached(cache=TTLCache(maxsize=1, ttl=43200))
-    def discover_movies(self, params):
+    def discover_movies(self, params_tuple):
         """
         Discover movies by different types of data like average rating, number of votes, genres and certifications.
         :param params: dict
         :return:
         """
+        params = dict(params_tuple)
         return self._request_obj(self._urls["movies"], urlencode(params), key="results", call_cached=False)
 
     @cached(cache=TTLCache(maxsize=1, ttl=43200))


### PR DESCRIPTION
发现电影discover_movies报错unhashable type: 'dict'

由于 cachetools 的 cached 装饰器无法处理字典类型的参数，因为字典是可变的，不可哈希。
在使用 cached 装饰器时，需要将字典转换为可哈希的类型（例如元组）。