### PR TITLE
fix #667 优化历史兼容极空间硬链接逻辑

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -360,11 +360,11 @@ class TransferChain(ChainBase):
                 # 硬链接检查
                 temp_transfer_type = transfer_type
                 if transfer_type == "link":
-                    if not SystemUtils.is_same_disk(file_path, transferinfo.target_path):
+                    if not SystemUtils.is_same_file(file_path, transferinfo.target_path):
                         logger.warn(
-                            f"{file_path} 与 {transferinfo.target_path} 不在同一磁盘/存储空间/映射目录，未能硬链接，请检查存储空间占用和整理耗时，确认是否为复制")
+                            f"{file_path} 与 {transferinfo.target_path} 不是同一硬链接文件，请检查存储空间占用和整理耗时，确认是否为复制")
                         self.messagehelper.put(
-                            f"{file_path} 与 {transferinfo.target_path} 不在同一磁盘/存储空间/映射目录，疑似硬链接失败，请检查是否为复制",
+                            f"{file_path} 与 {transferinfo.target_path} 不是同一硬链接文件，疑似硬链接失败，请检查是否为复制",
                             title="硬链接失败",
                             role="system")
                         temp_transfer_type = "copy"

--- a/app/utils/system.py
+++ b/app/utils/system.py
@@ -118,13 +118,14 @@ class SystemUtils:
         硬链接
         """
         try:
-            # link到当前目录并改名
-            tmp_path = src.parent / (dest.name + ".mp")
+            # 准备目标路径，增加后缀 .mp
+            tmp_path = dest.with_suffix(dest.suffix + ".mp")
+            # 检查目标路径是否已存在，如果存在则先unlink
             if tmp_path.exists():
                 tmp_path.unlink()
             tmp_path.hardlink_to(src)
-            # 移动到目标目录
-            shutil.move(tmp_path, dest)
+            # 硬链接完成，移除 .mp 后缀
+            tmp_path.rename(dest)
             return 0, ""
         except Exception as err:
             print(str(err))
@@ -465,6 +466,13 @@ class SystemUtils:
         except Exception as err:
             print(str(err))
             return False, f"重启时发生错误：{str(err)}"
+
+    @staticmethod
+    def is_same_file(src: Path, dest: Path) -> bool:
+        """判断是否为同一个文件"""
+        if not src.exists() or not dest.exists():
+            return False
+        return src.samefile(dest)
 
     @staticmethod
     def is_same_disk(src: Path, dest: Path) -> bool:


### PR DESCRIPTION
- 硬链接逻辑调整为目标文件增加.mp后缀，hardlink后再重命名
- 原有判断硬链接逻辑保留，调整为通过samefile判断，兼容同盘不同虚拟目录能够硬链接成功的系统