### PR TITLE
fix mailto移除空格和尖括号

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -375,7 +375,7 @@ class Settings(BaseSettings):
     @property
     def VAPID(self):
         return {
-            "subject": f"mailto: <{self.SUPERUSER}@movie-pilot.org>",
+            "subject": f"mailto:{self.SUPERUSER}@movie-pilot.org",
             "publicKey": "BH3w49sZA6jXUnE-yt4jO6VKh73lsdsvwoJ6Hx7fmPIDKoqGiUl2GEoZzy-iJfn4SfQQcx7yQdHf9RknwrL_lSM",
             "privateKey": "JTixnYY0vEw97t9uukfO3UWKfHKJdT5kCQDiv3gu894"
         }


### PR DESCRIPTION
Apple 严格校验 mailto 必须为 `mailto:example@example.com`