### PR TITLE
is_english_word 方法 更新

### DIFF
--- a/app/utils/string.py
+++ b/app/utils/string.py
@@ -142,7 +142,7 @@ class StringUtils:
         """
         判断是否为英文单词，有空格时返回False
         """
-        return word.isalpha()
+        return word.encode().isalpha()
 
     @staticmethod
     def str_int(text: str) -> int:


### PR DESCRIPTION
str.isalpha()方法对于中文也是返回True的，这个导致搜索的时候很多资源没有匹配上。

>>> "汉字".isalpha()
True
>>> "汉字".encode().isalpha()
False
>>>
>>> "汉字123".encode().isalpha()
False
>>> "123".encode().isalpha()
False
>>> "abc".encode().isalpha()
True
>>> "abc1".encode().isalpha()
False
