### PR TITLE
fix cookiecloud同步只同步启用的站点 && 同步域名黑名单

### DIFF
--- a/app/chain/site.py
+++ b/app/chain/site.py
@@ -226,7 +226,7 @@ class SiteChain(ChainBase):
             indexer = self.siteshelper.get_indexer(domain)
             # 数据库的站点信息
             site_info = self.siteoper.get_by_domain(domain)
-            if site_info:
+            if site_info and site_info.is_active == 1:
                 # 站点已存在，检查站点连通性
                 status, msg = self.test(domain)
                 # 更新站点Cookie

--- a/app/chain/site.py
+++ b/app/chain/site.py
@@ -252,6 +252,11 @@ class SiteChain(ChainBase):
                 self.siteoper.update_cookie(domain=domain, cookies=cookie)
                 _update_count += 1
             elif indexer:
+                if settings.COOKIECLOUD_BLACKLIST and any(
+                        StringUtils.get_url_domain(domain) == StringUtils.get_url_domain(black_domain) for black_domain
+                        in str(settings.COOKIECLOUD_BLACKLIST).split(",")):
+                    logger.warn(f"站点 {domain} 已在黑名单中，不添加站点")
+                    continue
                 # 新增站点
                 domain_url = __indexer_domain(inx=indexer, sub_domain=domain)
                 res = RequestUtils(cookies=cookie,

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -199,6 +199,8 @@ class Settings(BaseSettings):
     COOKIECLOUD_PASSWORD: Optional[str] = None
     # CookieCloud同步间隔（分钟）
     COOKIECLOUD_INTERVAL: Optional[int] = 60 * 24
+    # CookieCloud同步黑名单，多个域名,分割
+    COOKIECLOUD_BLACKLIST: Optional[str] = None
     # OCR服务器地址
     OCR_HOST: str = "https://movie-pilot.org"
     # CookieCloud对应的浏览器UA


### PR DESCRIPTION
1.禁用的站点基本是关站的没必要再检查ck同步ck
2.浏览器cookiecloud配置域名黑名单可以，但是设备多，浏览器多，配置多，再重装个系统啥的，还得重新配置，要不mp加个黑明单过滤掉吧