### PR TITLE
RequestUtils 重构

### DIFF
--- a/app/modules/emby/emby.py
+++ b/app/modules/emby/emby.py
@@ -18,16 +18,10 @@ class Emby:
     def __init__(self):
         self._host = settings.EMBY_HOST
         if self._host:
-            if not self._host.endswith("/"):
-                self._host += "/"
-            if not self._host.startswith("http"):
-                self._host = "http://" + self._host
+            self._host = RequestUtils.standardize_base_url(self._host)
         self._playhost = settings.EMBY_PLAY_HOST
         if self._playhost:
-            if not self._playhost.endswith("/"):
-                self._playhost += "/"
-            if not self._playhost.startswith("http"):
-                self._playhost = "http://" + self._playhost
+            self._playhost = RequestUtils.standardize_base_url(self._playhost)
         self._apikey = settings.EMBY_API_KEY
         self.user = self.get_user(settings.SUPERUSER)
         self.folders = self.get_emby_folders()

--- a/app/modules/jellyfin/jellyfin.py
+++ b/app/modules/jellyfin/jellyfin.py
@@ -15,16 +15,10 @@ class Jellyfin:
     def __init__(self):
         self._host = settings.JELLYFIN_HOST
         if self._host:
-            if not self._host.endswith("/"):
-                self._host += "/"
-            if not self._host.startswith("http"):
-                self._host = "http://" + self._host
+            self._host = RequestUtils.standardize_base_url(self._host)
         self._playhost = settings.JELLYFIN_PLAY_HOST
         if self._playhost:
-            if not self._playhost.endswith("/"):
-                self._playhost += "/"
-            if not self._playhost.startswith("http"):
-                self._playhost = "http://" + self._playhost
+            self._playhost = RequestUtils.standardize_base_url(self._playhost)
         self._apikey = settings.JELLYFIN_API_KEY
         self.user = self.get_user(settings.SUPERUSER)
         self.serverid = self.get_server_id()

--- a/app/modules/plex/plex.py
+++ b/app/modules/plex/plex.py
@@ -11,6 +11,7 @@ from app import schemas
 from app.core.config import settings
 from app.log import logger
 from app.schemas import MediaType
+from app.utils.http import RequestUtils
 
 
 class Plex:
@@ -19,16 +20,10 @@ class Plex:
     def __init__(self):
         self._host = settings.PLEX_HOST
         if self._host:
-            if not self._host.endswith("/"):
-                self._host += "/"
-            if not self._host.startswith("http"):
-                self._host = "http://" + self._host
+            self._host = RequestUtils.standardize_base_url(self._host)
         self._playhost = settings.PLEX_PLAY_HOST
         if self._playhost:
-            if not self._playhost.endswith("/"):
-                self._playhost += "/"
-            if not self._playhost.startswith("http"):
-                self._playhost = "http://" + self._playhost
+            self._playhost = RequestUtils.standardize_base_url(self._playhost)
         self._token = settings.PLEX_TOKEN
         if self._host and self._token:
             try:

--- a/app/modules/plex/plex.py
+++ b/app/modules/plex/plex.py
@@ -6,6 +6,7 @@ from urllib.parse import quote_plus
 from cachetools import TTLCache, cached
 from plexapi import media
 from plexapi.server import PlexServer
+from requests import Response, Session
 
 from app import schemas
 from app.core.config import settings
@@ -16,6 +17,7 @@ from app.utils.http import RequestUtils
 
 class Plex:
     _plex = None
+    _session = None
 
     def __init__(self):
         self._host = settings.PLEX_HOST
@@ -32,6 +34,7 @@ class Plex:
             except Exception as e:
                 self._plex = None
                 logger.error(f"Plex服务器连接失败：{str(e)}")
+            self._session = self.__adapt_plex_session()
 
     def is_inactive(self) -> bool:
         """
@@ -722,3 +725,71 @@ class Plex:
                 ))
             offset += num
         return ret_resume[:num]
+
+    def get_data(self, endpoint: str, **kwargs) -> Optional[Response]:
+        """
+        自定义从媒体服务器获取数据
+        :param endpoint: 端点
+        :param kwargs: 其他请求参数，如headers, cookies, proxies等
+        """
+        return self.__request(method="get", endpoint=endpoint, **kwargs)
+
+    def post_data(self, endpoint: str, **kwargs) -> Optional[Response]:
+        """
+        自定义从媒体服务器获取数据
+        :param endpoint: 端点
+        :param kwargs: 其他请求参数，如headers, cookies, proxies等
+        """
+        return self.__request(method="post", endpoint=endpoint, **kwargs)
+
+    def put_data(self, endpoint: str, **kwargs) -> Optional[Response]:
+        """
+        自定义从媒体服务器获取数据
+        :param endpoint: 端点
+        :param kwargs: 其他请求参数，如headers, cookies, proxies等
+        """
+        return self.__request(method="put", endpoint=endpoint, **kwargs)
+
+    def __request(self, method: str, endpoint: str, **kwargs) -> Optional[Response]:
+        """
+        自定义从媒体服务器获取数据
+        :param method: HTTP方法，如 get, post, put 等
+        :param endpoint: 端点
+        :param kwargs: 其他请求参数，如headers, cookies, proxies等
+        """
+        if not self._session:
+            return
+        try:
+            url = RequestUtils.adapt_request_url(host=self._host, endpoint=endpoint)
+            kwargs.setdefault("headers", self.__get_request_headers())
+            kwargs.setdefault("raise_exception", True)
+            request_method = getattr(RequestUtils(session=self._session), f"{method}_res", None)
+            if request_method:
+                return request_method(url=url, **kwargs)
+            else:
+                logger.error(f"方法 {method} 不存在")
+                return None
+        except Exception as e:
+            logger.error(f"连接Plex出错：" + str(e))
+            return None
+
+    @staticmethod
+    def __get_request_headers() -> dict:
+        """获取请求头"""
+        return {
+            "X-Plex-Token": settings.PLEX_TOKEN,
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        }
+
+    @staticmethod
+    def __adapt_plex_session() -> Session:
+        """
+        创建并配置一个针对Plex服务的requests.Session实例
+        这个会话包括特定的头部信息，用于处理所有的Plex请求
+        """
+        # 设置请求头部，通常包括验证令牌和接受/内容类型头部
+        headers = Plex.__get_request_headers()
+        session = Session()
+        session.headers = headers
+        return session

--- a/app/utils/http.py
+++ b/app/utils/http.py
@@ -6,6 +6,8 @@ import urllib3
 from requests import Session, Response
 from urllib3.exceptions import InsecureRequestWarning
 
+from app.log import logger
+
 urllib3.disable_warnings(InsecureRequestWarning)
 
 
@@ -71,7 +73,8 @@ class RequestUtils:
         kwargs.setdefault("stream", False)
         try:
             return req_method(method, url, **kwargs)
-        except requests.exceptions.RequestException:
+        except requests.exceptions.RequestException as e:
+            logger.debug(f"请求失败: {e}")
             if raise_exception:
                 raise
             return None

--- a/app/utils/http.py
+++ b/app/utils/http.py
@@ -1,4 +1,5 @@
 from typing import Union, Any, Optional
+from urllib.parse import urljoin
 
 import requests
 import urllib3
@@ -90,7 +91,7 @@ class RequestUtils:
         """
         发送POST请求
         :param url: 请求的URL
-        :param data: 请求的数据，表单格式
+        :param data: 请求的数据
         :param json: 请求的JSON数据
         :param kwargs: 其他请求参数，如headers, cookies, proxies等
         :return: HTTP响应对象，若发生RequestException则返回None
@@ -103,7 +104,7 @@ class RequestUtils:
         """
         发送PUT请求
         :param url: 请求的URL
-        :param data: 请求的数据，表单格式
+        :param data: 请求的数据
         :param kwargs: 其他请求参数，如headers, cookies, proxies等
         :return: HTTP响应对象，若发生RequestException则返回None
         """
@@ -121,7 +122,7 @@ class RequestUtils:
         发送GET请求并返回响应对象
         :param url: 请求的URL
         :param params: 请求的参数
-        :param data: 请求的数据，表单格式
+        :param data: 请求的数据
         :param json: 请求的JSON数据
         :param allow_redirects: 是否允许重定向
         :param raise_exception: 是否在发生异常时抛出异常，否则默认拦截异常返回None
@@ -150,7 +151,7 @@ class RequestUtils:
         """
         发送POST请求并返回响应对象
         :param url: 请求的URL
-        :param data: 请求的数据，表单格式
+        :param data: 请求的数据
         :param params: 请求的参数
         :param allow_redirects: 是否允许重定向
         :param files: 请求的文件
@@ -182,7 +183,7 @@ class RequestUtils:
         """
         发送PUT请求并返回响应对象
         :param url: 请求的URL
-        :param data: 请求的数据，表单格式
+        :param data: 请求的数据
         :param params: 请求的参数
         :param allow_redirects: 是否允许重定向
         :param files: 请求的文件
@@ -222,3 +223,32 @@ class RequestUtils:
             return [{"name": k, "value": v} for k, v in cookie_dict.items()]
         return cookie_dict
 
+    @staticmethod
+    def standardize_base_url(host: str) -> str:
+        """
+        标准化提供的主机地址，确保它以http://或https://开头，并且以斜杠(/)结尾
+        :param host: 提供的主机地址字符串
+        :return: 标准化后的主机地址字符串
+        """
+        if not host:
+            return host
+        if not host.endswith("/"):
+            host += "/"
+        if not host.startswith("http://") and not host.startswith("https://"):
+            host = "http://" + host
+        return host
+
+    @staticmethod
+    def adapt_request_url(host: str, endpoint: str) -> Optional[str]:
+        """
+        基于传入的host，适配请求的URL，确保每个请求的URL是完整的，用于在发送请求前自动处理和修正请求的URL。
+        :param host: 主机头
+        :param endpoint: 端点
+        :return: 完整的请求URL字符串
+        """
+        if not host and not endpoint:
+            return None
+        if endpoint.startswith(("http://", "https://")):
+            return endpoint
+        host = RequestUtils.standardize_base_url(host)
+        return urljoin(host, endpoint) if host else endpoint


### PR DESCRIPTION
- RequestUtils 重构，增加request，put，put_res 方法，统一 GET POST PUT 请求入口，同时支持kwargs
- RequestUtils 请求失败时，记录debug日志
- RequestUtils 增加standardize_base_url，adapt_request_url方法，用于适配host和endpoint的处理，支持emby，jellyfin，plex调用
- Plex 增加公共请求方法
- 已通过本地测试，**调整影响较大，请Review**