### PR TITLE
fix plugin auth_level

### DIFF
--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -158,6 +158,11 @@ class PluginManager(metaclass=Singleton):
             if pid and plugin_id != pid:
                 continue
             try:
+                # 如果插件具有认证级别且当前认证级别不足，则不进行实例化
+                if hasattr(plugin, "auth_level"):
+                    plugin.auth_level = plugin.auth_level
+                    if self.siteshelper.auth_level < plugin.auth_level:
+                        continue
                 # 存储Class
                 self._plugins[plugin_id] = plugin
                 # 未安装的不加载

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -94,6 +94,10 @@ class Scheduler(metaclass=Singleton):
                         link=settings.MP_DOMAIN('#/site')
                     )
                 )
+                PluginManager().init_config()
+                for plugin_id in PluginManager().get_running_plugin_ids():
+                    self.update_plugin_job(plugin_id)
+
             else:
                 self._auth_count += 1
                 logger.error(f"用户认证失败：{msg}，共失败 {self._auth_count} 次")


### PR DESCRIPTION
如果插件具有认证级别且当前认证级别不足，则不进行实例化，避免无意义的实例以及插件后台任务，同时避免部分插件因为认证级别不足时实例化出现未知问题。