### PR TITLE
feat:将使用 DOH 域名解析的域名添加至 app.core.config.settings #2502

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -232,6 +232,8 @@ class Settings(BaseSettings):
     META_CACHE_EXPIRE: int = 0
     # 是否启用DOH解析域名
     DOH_ENABLE: bool = True
+    # 使用 DOH 解析的域名列表
+    DOH_DOMAINS:str =  'api.themoviedb.org,api.tmdb.org,webservice.fanart.tv,api.github.com,github.com,raw.githubusercontent.com,api.telegram.org'
     # 搜索多个名称
     SEARCH_MULTIPLE_NAME: bool = False
     # 订阅数据共享

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -233,7 +233,7 @@ class Settings(BaseSettings):
     # 是否启用DOH解析域名
     DOH_ENABLE: bool = True
     # 使用 DOH 解析的域名列表
-    DOH_DOMAINS:str =  'api.themoviedb.org,api.tmdb.org,webservice.fanart.tv,api.github.com,github.com,raw.githubusercontent.com,api.telegram.org'
+    DOH_DOMAINS: str = 'api.themoviedb.org,api.tmdb.org,webservice.fanart.tv,api.github.com,github.com,raw.githubusercontent.com,api.telegram.org'
     # 搜索多个名称
     SEARCH_MULTIPLE_NAME: bool = False
     # 订阅数据共享

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -233,7 +233,7 @@ class Settings(BaseSettings):
     # 是否启用DOH解析域名
     DOH_ENABLE: bool = True
     # 使用 DOH 解析的域名列表
-    DOH_DOMAINS: str = 'api.themoviedb.org,api.tmdb.org,webservice.fanart.tv,api.github.com,github.com,raw.githubusercontent.com,api.telegram.org'
+    DOH_DOMAINS: str = "api.themoviedb.org,api.tmdb.org,webservice.fanart.tv,api.github.com,github.com,raw.githubusercontent.com,api.telegram.org"
     # 搜索多个名称
     SEARCH_MULTIPLE_NAME: bool = False
     # 订阅数据共享

--- a/app/helper/doh.py
+++ b/app/helper/doh.py
@@ -15,16 +15,6 @@ from typing import Dict, Optional
 from app.core.config import settings
 from app.log import logger
 
-# 定义一个全局集合来存储注册的主机
-_registered_hosts = {
-    'api.themoviedb.org',
-    'api.tmdb.org',
-    'webservice.fanart.tv',
-    'api.github.com',
-    'github.com',
-    'raw.githubusercontent.com',
-    'api.telegram.org'
-}
 
 # 定义一个全局线程池执行器
 _executor = concurrent.futures.ThreadPoolExecutor()
@@ -46,7 +36,7 @@ def _patched_getaddrinfo(host, *args, **kwargs):
     """
     socket.getaddrinfo的补丁版本。
     """
-    if host not in _registered_hosts:
+    if host not in settings.DOH_DOMAINS.split(","):
         return _orig_getaddrinfo(host, *args, **kwargs)
 
     # 检查主机是否已解析

--- a/config/app.env
+++ b/config/app.env
@@ -13,6 +13,8 @@ SUPERUSER=admin
 BIG_MEMORY_MODE=false
 # 是否启用DOH域名解析，启用后对于api.themovie.org等域名通过DOH解析，避免域名DNS被污染
 DOH_ENABLE=true
+# 使用 DOH 解析的域名列表
+DOH_DOMAINS:str =  'api.themoviedb.org,api.tmdb.org,webservice.fanart.tv,api.github.com,github.com,raw.githubusercontent.com,api.telegram.org'
 # 元数据识别缓存过期时间，数字型，单位小时，0为系统默认（大内存模式为7天，滞则为3天），调大该值可减少themoviedb的访问次数
 META_CACHE_EXPIRE=0
 # 自动检查和更新站点资源包（索引、认证等）

--- a/config/app.env
+++ b/config/app.env
@@ -13,8 +13,8 @@ SUPERUSER=admin
 BIG_MEMORY_MODE=false
 # 是否启用DOH域名解析，启用后对于api.themovie.org等域名通过DOH解析，避免域名DNS被污染
 DOH_ENABLE=true
-# 使用 DOH 解析的域名列表
-DOH_DOMAINS:str =  'api.themoviedb.org,api.tmdb.org,webservice.fanart.tv,api.github.com,github.com,raw.githubusercontent.com,api.telegram.org'
+# 使用 DOH 解析的域名列表，多个域名使用`,`分隔
+DOH_DOMAINS=api.themoviedb.org,api.tmdb.org,webservice.fanart.tv,api.github.com,github.com,raw.githubusercontent.com,api.telegram.org
 # 元数据识别缓存过期时间，数字型，单位小时，0为系统默认（大内存模式为7天，滞则为3天），调大该值可减少themoviedb的访问次数
 META_CACHE_EXPIRE=0
 # 自动检查和更新站点资源包（索引、认证等）


### PR DESCRIPTION
应该在配置站点设置的时候增加一个设置，将开启 DOH 域名解析的站点的域名加入列表，但由于这部分代码不开源，因此只是简单实现了自定义域名的部分