### PR TITLE
Fixed parsing of Telegram entities

### DIFF
--- a/app/modules/telegram/telegram.py
+++ b/app/modules/telegram/telegram.py
@@ -206,6 +206,7 @@ class Telegram:
                 image_file = Path(settings.TEMP_PATH) / Path(image).name
                 image_file.write_bytes(req.content)
                 photo = InputFile(image_file)
+                caption =  re.sub(r'([_`])', r'\\\1', caption)
                 ret = self._bot.send_photo(chat_id=userid or self._telegram_chat_id,
                                            photo=photo,
                                            caption=caption,


### PR DESCRIPTION
在`app/modules/telegram/telegram.py`的函数`__send_request`中

如果字符串`caption`中包含不成对的:下划线'_', 星号'*', 反引号'`'


发送消息出去就会报错: `A request to the Telegram API was unsuccessful. Error code: 400. Description: Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 0, 3 秒后重试 ...`

比如: 当`caption`是
```
*开始播放电影 哆啦A梦：2112年哆啦A梦的诞生 (1995)*\n用户：brett_dean\n设备：iPhone  \nIP地址：xxx.xxx.xxx.xxx X国[XX] XX省 XX市 XX区\n剧情：《2112年哆啦A梦的诞生》（日语：2112年 ドラえもん誕生）是1995年3月4日公映的哆啦A梦附篇电影，由米谷良知导演，原作者藤子·F·不二雄，与《大雄的创世日记》同时上映。片长30分钟，主要叙述...\n时间：2024-xx-xx xx:xx:xx\n[查看详情](https://xxx.xxx.com/web/index.html#!/server/xxxxx/details?key=xxxx)
```
的时候，就会因为 `用户：brett_dean` 中含有下划线`_`而报错

所以发消息前要先转义一下，转义后即可正常发送:
![image](https://github.com/jxxghp/MoviePilot/assets/36684698/4ad797b1-b696-498f-846d-73afbf346b91)



---

>api说明: https://core.telegram.org/bots/api#markdown-style
>
>```bash
>Please note:
>To escape characters '_', '*', '`', '[' outside of an entity, prepend the characters '\' before them.
>```

---

另外这种发送`文字+媒体`的形式，文字最多只能有1024个，多了就会报错，和下面的纯文字可以发4096个不一样。
一般用也不到1024个字，吧
