### PR TITLE
fix jxxghp/MoviePilot-Plugins#38

### DIFF
--- a/app/utils/http.py
+++ b/app/utils/http.py
@@ -1,5 +1,5 @@
 from typing import Union, Any, Optional
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse, parse_qs, urlencode, urlunparse
 
 import requests
 import urllib3
@@ -255,3 +255,36 @@ class RequestUtils:
             return endpoint
         host = RequestUtils.standardize_base_url(host)
         return urljoin(host, endpoint) if host else endpoint
+
+    @staticmethod
+    def combine_url(host: str, path: Optional[str] = None, query: Optional[dict] = None) -> Optional[str]:
+        """
+        使用给定的主机头、路径和查询参数组合生成完整的URL。
+        :param host: str, 主机头，例如 https://example.com
+        :param path: Optional[str], 包含路径和可能已经包含的查询参数的端点，例如 /path/to/resource?current=1
+        :param query: Optional[dict], 可选，额外的查询参数，例如 {"key": "value"}
+        :return: str, 完整的请求URL字符串
+        """
+        try:
+            # 如果路径为空，则默认为 '/'
+            if path is None:
+                path = '/'
+            # 使用 urljoin 合并 host 和 path
+            url = urljoin(host, path)
+            # 解析当前 URL 的组成部分
+            url_parts = urlparse(url)
+            # 解析已存在的查询参数，并与额外的查询参数合并
+            query_params = parse_qs(url_parts.query)
+            if query:
+                for key, value in query.items():
+                    query_params[key] = value
+
+            # 重新构建查询字符串
+            query_string = urlencode(query_params, doseq=True)
+            # 构建完整的 URL
+            new_url_parts = url_parts._replace(query=query_string)
+            complete_url = urlunparse(new_url_parts)
+            return str(complete_url)
+        except Exception as e:
+            logger.debug(f"Error combining URL: {e}")
+            return None


### PR DESCRIPTION
- 完善Plex中的`get_remote_image_by_id`逻辑，如果配置了外网播放地址以及Token，则默认从Plex媒体服务器获取图片，否则返回有外网地址的图片资源
- 优化telegram发送`image`消息逻辑，临时文件名通过UUID随机生成，避免Url携带参数导致文件写入失败
- RequestUtils增加`combine_url`方法
  - 后续可以考虑增加`UrlUtils`再进一步重构