### PR TITLE
feat: 历史记录查询增加对`title`字段的搜索

### DIFF
--- a/app/db/models/transferhistory.py
+++ b/app/db/models/transferhistory.py
@@ -57,6 +57,7 @@ class TransferHistory(Base):
             ).offset((page - 1) * count).limit(count).all()
         else:
             result = db.query(TransferHistory).filter(or_(
+                TransferHistory.title.like(f'%{title}%'),
                 TransferHistory.src.like(f'%{title}%'),
                 TransferHistory.dest.like(f'%{title}%'),
             )).order_by(
@@ -128,6 +129,7 @@ class TransferHistory(Base):
             return db.query(func.count(TransferHistory.id)).filter(TransferHistory.status == status).first()[0]
         else:
             return db.query(func.count(TransferHistory.id)).filter(or_(
+                TransferHistory.title.like(f'%{title}%'),
                 TransferHistory.src.like(f'%{title}%'),
                 TransferHistory.dest.like(f'%{title}%')
             )).first()[0]


### PR DESCRIPTION
目前 history/transfer 接口仅模糊匹配了`src`（源目录）、`dest`（目标目录），应该增加对`title`（标题）的查询