### PR TITLE
优化微信文本消息发送：支持长文本分块发送及频率限制

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ config/sites/**
 *.log
 .vscode
 venv
+.DS_Store


### PR DESCRIPTION
[微信文档](https://developer.work.weixin.qq.com/document/path/90236)中有两个地方：


>| 参数    | 是否必须 | 说明                                                         |
>| ------- | -------- | ------------------------------------------------------------ |
>| content | 是       | 消息内容，最长不超过2048个字节，超过将截断**（支持id转译）** |                                                        |
>
>---
>
>**频率限制**：每应用不可超过账号上限数*200人次/天（注：若调用api一次发给1000人，算1000人次；若企业账号上限是500人，则每个应用每天可发送100000人次的消息）。每应用对同一个成员不可超过30次/分钟，1000次/小时，超过部分会被丢弃不下发

故使用`查询订阅`或`正在下载`时，有可能因为消息过长而被截断，具体表现就是`只发送前2048字节，多余的直接丢弃`:

<img src="https://github.com/jxxghp/MoviePilot/assets/36684698/af2cae78-43e4-46e5-9d66-ded7617d205e" width="200" />

<img src="https://github.com/jxxghp/MoviePilot/assets/36684698/571183a2-6dfb-4950-830a-cd5957060bd9" width="200" />

