### PR TITLE
增加``PIP_PROXY``变量，支持用镜像站下载与更新依赖

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -146,6 +146,8 @@ class Settings(BaseSettings):
     GITHUB_TOKEN: Optional[str] = None
     # Github代理服务器，格式：https://mirror.ghproxy.com/
     GITHUB_PROXY: Optional[str] = ''
+    # pip镜像站点，格式：https://pypi.tuna.tsinghua.edu.cn/simple
+    PIP_PROXY: Optional[str] = ''
     # 大内存模式
     BIG_MEMORY_MODE: bool = False
 

--- a/app/helper/plugin.py
+++ b/app/helper/plugin.py
@@ -223,7 +223,7 @@ class PluginHelper(metaclass=Singleton):
         requirements_file = plugin_dir / "requirements.txt"
         if requirements_file.exists():
             PIP_PROXY = f" -i {settings.PIP_PROXY} " if settings.PIP_PROXY else ""
-            SystemUtils.execute(f"pip install -r {requirements_file} -i {PIP_PROXY}  > /dev/null 2>&1")
+            SystemUtils.execute(f"pip install -r {requirements_file} {PIP_PROXY}  > /dev/null 2>&1")
         # 安装成功后统计
         self.install_reg(pid)
 

--- a/app/helper/plugin.py
+++ b/app/helper/plugin.py
@@ -222,7 +222,8 @@ class PluginHelper(metaclass=Singleton):
         # 插件目录下如有requirements.txt则安装依赖
         requirements_file = plugin_dir / "requirements.txt"
         if requirements_file.exists():
-            SystemUtils.execute(f"pip install -r {requirements_file} > /dev/null 2>&1")
+            PIP_PROXY = f" -i {settings.PIP_PROXY} " if settings.PIP_PROXY else ""
+            SystemUtils.execute(f"pip install -r {requirements_file} -i {PIP_PROXY}  > /dev/null 2>&1")
         # 安装成功后统计
         self.install_reg(pid)
 

--- a/update
+++ b/update
@@ -119,8 +119,8 @@ function install_backend_and_download_resources() {
 if [[ "${MOVIEPILOT_AUTO_UPDATE}" = "true" ]] || [[ "${MOVIEPILOT_AUTO_UPDATE}" = "release" ]] || [[ "${MOVIEPILOT_AUTO_UPDATE}" = "dev" ]]; then
     if [[ -n "${PIP_PROXY}" ]] || [[ -n "${GITHUB_PROXY}" ]]; then
         CURL_OPTIONS="-sL"
-        PIP_OPTIONS=${PIP_OPTIONS:+"-i ${PIP_PROXY}"} || PIP_OPTIONS=""
-        GITHUB_PROXY=${GITHUB_PROXY:+"-i ${GITHUB_PROXY}"} || GITHUB_PROXY=""
+        PIP_OPTIONS=${PIP_PROXY:+-i ${PIP_PROXY}}
+        GITHUB_PROXY=${GITHUB_PROXY:-""}
         # 判断不同的代理组合
         if [ -z "${PIP_OPTIONS}" ] && [ -n "${GITHUB_PROXY}" ]; then
             INFO "不使用代理更新环境依赖，使用Github镜像代理更新程序"

--- a/update
+++ b/update
@@ -117,12 +117,7 @@ function install_backend_and_download_resources() {
 }
 
 if [[ "${MOVIEPILOT_AUTO_UPDATE}" = "true" ]] || [[ "${MOVIEPILOT_AUTO_UPDATE}" = "release" ]] || [[ "${MOVIEPILOT_AUTO_UPDATE}" = "dev" ]]; then
-    if [ -n "${PROXY_HOST}" ]; then
-        CURL_OPTIONS="-sL -x ${PROXY_HOST}"
-        PIP_OPTIONS="--proxy=${PROXY_HOST}"
-        GITHUB_PROXY=""
-        INFO "使用全局代理更新程序与环境依赖"
-    elif [[ -n "${PIP_PROXY}" ]] || [[ -n "${GITHUB_PROXY}" ]]; then
+    if [[ -n "${PIP_PROXY}" ]] || [[ -n "${GITHUB_PROXY}" ]]; then
         CURL_OPTIONS="-sL"
         PIP_OPTIONS=${PIP_OPTIONS:+"-i ${PIP_PROXY}"} || PIP_OPTIONS=""
         GITHUB_PROXY=${GITHUB_PROXY:+"-i ${GITHUB_PROXY}"} || GITHUB_PROXY=""
@@ -134,6 +129,11 @@ if [[ "${MOVIEPILOT_AUTO_UPDATE}" = "true" ]] || [[ "${MOVIEPILOT_AUTO_UPDATE}" 
         else
             INFO "使用Pip镜像代理更新环境依赖，使用Github镜像代理更新程序"
         fi
+    elif [ -n "${PROXY_HOST}" ]; then
+        CURL_OPTIONS="-sL -x ${PROXY_HOST}"
+        PIP_OPTIONS="--proxy=${PROXY_HOST}"
+        GITHUB_PROXY=""
+        INFO "使用全局代理更新程序与环境依赖"
     else
         CURL_OPTIONS="-sL"
         INFO "不使用任何代理更新程序与环境依赖"

--- a/update
+++ b/update
@@ -121,10 +121,22 @@ if [[ "${MOVIEPILOT_AUTO_UPDATE}" = "true" ]] || [[ "${MOVIEPILOT_AUTO_UPDATE}" 
         CURL_OPTIONS="-sL -x ${PROXY_HOST}"
         PIP_OPTIONS="--proxy=${PROXY_HOST}"
         GITHUB_PROXY=""
-        INFO "使用代理更新程序"
+        INFO "使用全局代理更新程序与环境依赖"
+    elif [[ -n "${PIP_PROXY}" ]] || [[ -n "${GITHUB_PROXY}" ]]; then
+        CURL_OPTIONS="-sL"
+        PIP_OPTIONS=${PIP_OPTIONS:+"-i ${PIP_PROXY}"} || PIP_OPTIONS=""
+        GITHUB_PROXY=${GITHUB_PROXY:+"-i ${GITHUB_PROXY}"} || GITHUB_PROXY=""
+        # 判断不同的代理组合
+        if [ -z "${PIP_OPTIONS}" ] && [ -n "${GITHUB_PROXY}" ]; then
+            INFO "不使用代理更新环境依赖，使用Github镜像代理更新程序"
+        elif [ -n "${PIP_OPTIONS}" ] && [ -z "${GITHUB_PROXY}" ]; then
+            INFO "使用Pip镜像代理更新环境依赖，不使用代理更新程序"
+        else
+            INFO "使用Pip镜像代理更新环境依赖，使用Github镜像代理更新程序"
+        fi
     else
         CURL_OPTIONS="-sL"
-        INFO "不使用代理更新程序"
+        INFO "不使用任何代理更新程序与环境依赖"
     fi
     if [ -n "${GITHUB_TOKEN}" ]; then
         CURL_HEADERS="--oauth2-bearer ${GITHUB_TOKEN}"


### PR DESCRIPTION
意图解决不使用全局代理或全局代理后，也无法解决插件依赖下载的问题。

针对于存在依赖下载超时的情况的时候，可以使用各大镜像源，也可自己使用CloudFlare Workers自搭建镜像源，推荐使用CF自搭建，国内源有更新延迟的问题。

附CF版自搭建PYPI镜像站项目：
https://github.com/hamidrezafarzin/Cloudflare-PyPI-Mirror-Worker