### PR TITLE
build:非Github Action环境构建Docker镜像使用清华大学开源软件镜像源，便于本地构建镜像

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.11.4-slim-bookworm
+ARG GITHUB_ACTIONS_ENV
 ARG MOVIEPILOT_VERSION
 ENV LANG="C.UTF-8" \
     TZ="Asia/Shanghai" \
@@ -15,6 +16,10 @@ ENV LANG="C.UTF-8" \
     AUTH_SITE="iyuu" \
     IYUU_SIGN=""
 WORKDIR "/app"
+RUN if [ "$GITHUB_ACTIONS" != "true" ]; then \
+        sed -i '0,/http:\/\/deb.debian.org\/debian/s//https:\/\/mirrors.tuna.tsinghua.edu.cn\/debian/' /etc/apt/sources.list.d/debian.sources; \
+        pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple; \
+    fi
 RUN apt-get update -y \
     && apt-get upgrade -y \
     && apt-get -y install \


### PR DESCRIPTION
[Github文档 在变量中存储信息](https://docs.github.com/zh/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables)
> 当 GitHub Actions 运行工作流时，始终设置为 true。 您可以使用此变量来区分测试是在本地运行还是通过 GitHub Actions 运行。