### PR TITLE
feat(auth): add API_TOKEN validation and auto-generation

### DIFF
--- a/app/api/endpoints/plugin.py
+++ b/app/api/endpoints/plugin.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, Header
 
 from app import schemas
 from app.core.plugin import PluginManager
-from app.core.security import verify_token
+from app.core.security import verify_token, verify_apitoken
 from app.db.systemconfig_oper import SystemConfigOper
 from app.db.user_oper import get_current_active_superuser
 from app.helper.plugin import PluginHelper
@@ -23,6 +23,10 @@ def register_plugin_api(plugin_id: str = None):
             if r.path == api.get("path"):
                 router.routes.remove(r)
                 break
+        # 检查是否允许匿名访问，如果不允许匿名访问，则添加 API_TOKEN 验证
+        allow_anonymous = api.pop("allow_anonymous", False)
+        if not allow_anonymous:
+            api.setdefault("dependencies", []).append(Depends(verify_apitoken))
         router.add_api_route(**api)
 
 

--- a/app/api/endpoints/system.py
+++ b/app/api/endpoints/system.py
@@ -123,7 +123,7 @@ def set_env_setting(env: dict,
                 v = ''
             else:
                 v = str(v)
-            set_key(settings.CONFIG_PATH / "app.env", k, v)
+            set_key(SystemUtils.get_env_path(), k, v)
     return schemas.Response(success=True)
 
 
@@ -180,7 +180,7 @@ def set_setting(key: str, value: Union[list, dict, bool, int, str] = None,
             value = ''
         else:
             value = str(value)
-        set_key(settings.CONFIG_PATH / "app.env", key, value)
+        set_key(SystemUtils.get_env_path(), key, value)
     else:
         SystemConfigOper().set(key, value)
     return schemas.Response(success=True)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -117,7 +117,7 @@ class Settings(BaseSettings):
                           '.pcm', '.rmi', '.s3m', '.snd', '.spx', '.tak',
                           '.tta', '.vqf', '.wav', '.wma',
                           '.aifc', '.aiff', '.alac', '.adif', '.adts',
-                          '.flac',  '.midi', '.opus', '.sfalc']
+                          '.flac', '.midi', '.opus', '.sfalc']
     # 下载器临时文件后缀
     DOWNLOAD_TMPEXT: list = ['.!qB', '.part']
     # 下载器监视间隔（小时）
@@ -272,16 +272,16 @@ class Settings(BaseSettings):
         """
         if self.PROXY_HOST:
             parsed_url = urlparse(self.PROXY_HOST)
-            protocol = parsed_url.scheme or ""      # 协议
-            username = parsed_url.username or ""    # 用户名
-            password = parsed_url.password or ""    # 密码
-            host = parsed_url.hostname or ""        # 主机
-            port = parsed_url.port or ""            # 端口
-            path = parsed_url.path or ""            # 路径
-            netloc = parsed_url.netloc or ""        # 用户名:密码@主机:端口
-            query = parsed_url.query or ""          # 查询参数: ?key=value
-            params = parsed_url.params or ""        # 使用;分割的参数
-            fragment = parsed_url.fragment or ""    # 片段: #fragment
+            protocol = parsed_url.scheme or ""  # 协议
+            username = parsed_url.username or ""  # 用户名
+            password = parsed_url.password or ""  # 密码
+            host = parsed_url.hostname or ""  # 主机
+            port = parsed_url.port or ""  # 端口
+            path = parsed_url.path or ""  # 路径
+            netloc = parsed_url.netloc or ""  # 用户名:密码@主机:端口
+            query = parsed_url.query or ""  # 查询参数: ?key=value
+            params = parsed_url.params or ""  # 使用;分割的参数
+            fragment = parsed_url.fragment or ""  # 片段: #fragment
 
             if not port:
                 if protocol == "https":
@@ -414,6 +414,8 @@ class Settings(BaseSettings):
 
     class Config:
         case_sensitive = True
+        env_file = SystemUtils.get_env_path()
+        env_file_encoding = "utf-8"
 
 
 class GlobalVar(object):
@@ -451,10 +453,7 @@ class GlobalVar(object):
 
 
 # 实例化配置
-settings = Settings(
-    _env_file=Settings().CONFIG_PATH / "app.env",
-    _env_file_encoding="utf-8"
-)
+settings = Settings()
 
 # 全局标识
 global_vars = GlobalVar()

--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -426,7 +426,8 @@ class PluginManager(metaclass=Singleton):
             "endpoint": self.xxx,
             "methods": ["GET", "POST"],
             "summary": "API名称",
-            "description": "API说明"
+            "description": "API说明",
+            "allow_anonymous": false
         }]
         """
         ret_apis = []

--- a/app/log.py
+++ b/app/log.py
@@ -49,7 +49,7 @@ class LogSettings(BaseSettings):
 
     class Config:
         case_sensitive = True
-        env_file = SystemUtils.get_config_path() / "app.env"
+        env_file = SystemUtils.get_env_path()
         env_file_encoding = "utf-8"
 
 

--- a/app/log.py
+++ b/app/log.py
@@ -2,7 +2,7 @@ import inspect
 import logging
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 import click
 from pydantic import BaseSettings
@@ -14,6 +14,8 @@ class LogSettings(BaseSettings):
     """
     日志设置
     """
+    # 配置文件目录
+    CONFIG_DIR: Optional[str] = None
     # 是否为调试模式
     DEBUG: bool = False
     # 日志级别（DEBUG、INFO、WARNING、ERROR等）
@@ -28,11 +30,15 @@ class LogSettings(BaseSettings):
     LOG_FILE_FORMAT: str = "【%(levelname)s】%(asctime)s - %(message)s"
 
     @property
+    def CONFIG_PATH(self):
+        return SystemUtils.get_config_path(self.CONFIG_DIR)
+
+    @property
     def LOG_PATH(self):
         """
         获取日志存储路径
         """
-        return SystemUtils.get_config_path() / "logs"
+        return self.CONFIG_PATH / "logs"
 
     @property
     def LOG_MAX_FILE_SIZE_BYTES(self):

--- a/app/utils/system.py
+++ b/app/utils/system.py
@@ -5,7 +5,7 @@ import re
 import shutil
 import sys
 from pathlib import Path
-from typing import List, Union, Tuple
+from typing import List, Union, Tuple, Optional
 
 import docker
 import psutil
@@ -473,10 +473,14 @@ class SystemUtils:
         return os.stat(src).st_dev == os.stat(dest).st_dev
 
     @staticmethod
-    def get_config_path() -> Path:
+    def get_config_path(config_dir: Optional[str] = None) -> Path:
         """
         获取配置路径
         """
+        if not config_dir:
+            config_dir = os.getenv("CONFIG_DIR")
+        if config_dir:
+            return Path(config_dir)
         if SystemUtils.is_docker():
             return Path("/config")
         elif SystemUtils.is_frozen():

--- a/app/utils/system.py
+++ b/app/utils/system.py
@@ -487,3 +487,10 @@ class SystemUtils:
             return Path(sys.executable).parent / "config"
         else:
             return Path(__file__).parents[2] / "config"
+
+    @staticmethod
+    def get_env_path() -> Path:
+        """
+        获取配置路径
+        """
+        return SystemUtils.get_config_path() / "app.env"

--- a/config/app.env
+++ b/config/app.env
@@ -29,8 +29,8 @@ DOH_RESOLVERS=1.0.0.1,1.1.1.1,9.9.9.9,149.112.112.112
 META_CACHE_EXPIRE=0
 # 自动检查和更新站点资源包（索引、认证等）
 AUTO_UPDATE_RESOURCE=true
-# 【*】API密钥，建议更换复杂字符串，有Jellyseerr/Overseerr、媒体服务器Webhook等配置以及部分支持API_TOKEN的API中使用
-API_TOKEN=moviepilot
+# 【*】API密钥，未设置时系统将随机生成，建议使用复杂字符串，用于Jellyseerr/Overseerr、媒体服务器Webhook等配置以及部分支持API_TOKEN的API请求
+API_TOKEN=''
 # 登录页面电影海报，tmdb/bing，tmdb要求能正常连接api.themoviedb.org
 WALLPAPER=tmdb
 # TMDB图片地址，无需修改需保留默认值，如果默认地址连通性不好可以尝试修改为：`static-mdb.v.geilijiasu.com`


### PR DESCRIPTION
- `API_TOKEN` 初始值调整为空，并支持 `API_TOKEN` 校验与随机生成
- 插件 API 注册时，除明确标识 `allow_anonymous`，否则统一添加 `API_TOKEN` 校验，确保安全访问
- 部分重构，完善 `SystemUtils.get_config_path` 及 `SystemUtils.get_env_path`