### PR TITLE
feat:查询种子时匹配香港、台湾译名

### DIFF
--- a/app/chain/search.py
+++ b/app/chain/search.py
@@ -154,6 +154,8 @@ class SearchChain(ChainBase):
             keywords = list(dict.fromkeys([k for k in [mediainfo.title,
                                                        mediainfo.original_title,
                                                        mediainfo.en_title,
+                                                       mediainfo.hk_title,
+                                                       mediainfo.tw_title,
                                                        mediainfo.sg_title] if k]))
 
         # 执行搜索

--- a/app/core/context.py
+++ b/app/core/context.py
@@ -141,6 +141,10 @@ class MediaInfo:
     title: str = None
     # 英文标题
     en_title: str = None
+    # 香港标题
+    hk_title: str = None
+    # 台湾标题
+    tw_title: str = None
     # 新加坡标题
     sg_title: str = None
     # 年份
@@ -386,6 +390,10 @@ class MediaInfo:
         self.original_language = info.get('original_language')
         # 英文标题
         self.en_title = info.get('en_title')
+        # 香港标题
+        self.hk_title = info.get('hk_title')
+        # 台湾标题
+        self.tw_title = info.get('tw_title')
         # 新加坡标题
         self.sg_title = info.get('sg_title')
         if self.type == MediaType.MOVIE:

--- a/app/modules/themoviedb/tmdbapi.py
+++ b/app/modules/themoviedb/tmdbapi.py
@@ -653,9 +653,14 @@ class TmdbApi:
         else:
             en_title = __get_tmdb_lang_title(tmdb_info, "US")
             tmdb_info['en_title'] = en_title or org_title
+        
+        # 查找香港台湾译名
+        tmdb_info['hk_title'] = __get_tmdb_lang_title(tmdb_info, "HK")
+        tmdb_info['tw_title'] = __get_tmdb_lang_title(tmdb_info, "TW")
+
         # 查找新加坡名（用于替代中文名）
         tmdb_info['sg_title'] = __get_tmdb_lang_title(tmdb_info, "SG") or org_title
-
+                                                      
     def __get_movie_detail(self,
                            tmdbid: int,
                            append_to_response: str = "images,"


### PR DESCRIPTION
蜜柑、动漫花园部分字幕组、发布组采用台湾译名（baha等web-dl搬运），search匹配更多译名便于识别