### PR TITLE
fix: cloud disk bug

### DIFF
--- a/app/modules/filemanager/storages/rclone.py
+++ b/app/modules/filemanager/storages/rclone.py
@@ -114,7 +114,7 @@ class Rclone(StorageBase):
                 return [self.__get_rcloneitem(item) for item in items]
         except Exception as err:
             logger.error(f"rclone浏览文件失败：{err}")
-        return None
+        return []
 
     def create_folder(self, fileitm: schemas.FileItem, name: str) -> Optional[schemas.FileItem]:
         """

--- a/app/modules/filemanager/storages/u115.py
+++ b/app/modules/filemanager/storages/u115.py
@@ -160,7 +160,7 @@ class U115Pan(StorageBase, metaclass=Singleton):
         浏览文件
         """
         if not self.__init_cloud():
-            return None
+            return []
         try:
             items = self.cloud.storage().list(dir_id=fileitem.fileid)
             return [schemas.FileItem(


### PR DESCRIPTION
- 解决前端调用时，没有认证参数或者失效时，后端返回的None，会引发pydantic的报错，从而导致的前端无法获取结果，卡在刷新页面