### PR TITLE
fix bug

### DIFF
--- a/app/modules/emby/__init__.py
+++ b/app/modules/emby/__init__.py
@@ -109,7 +109,7 @@ class EmbyModule(_ModuleBase, _MediaServerBase):
         :param itemid:  媒体服务器ItemID
         :return: 如不存在返回None，存在时返回信息，包括每季已存在所有集{type: movie/tv, seasons: {season: [episodes]}}
         """
-        for name, server in self._servers.values():
+        for name, server in self._servers.items():
             if mediainfo.type == MediaType.MOVIE:
                 if itemid:
                     movie = server.get_iteminfo(itemid)

--- a/app/modules/plex/plex.py
+++ b/app/modules/plex/plex.py
@@ -238,7 +238,7 @@ class Plex:
         if not self._plex:
             return None, {}
         if item_id:
-            videos = self._plex.fetchItem(item_id)
+            videos = self._plex.fetchItem(int(item_id))
         else:
             # 兼容年份为空的场景
             kwargs = {"year": year} if year else {}
@@ -392,7 +392,7 @@ class Plex:
         if not self._plex:
             return None
         try:
-            item = self._plex.fetchItem(itemid)
+            item = self._plex.fetchItem(int(itemid))
             ids = self.__get_ids(item.guids)
             path = None
             if item.locations:


### PR DESCRIPTION
- fix emby 获取 _server 实例
- fix flex api请求报错
> ERROR:   plex.py - 获取项目详情出错：Failed to parse: http://plex_base_url:3240079237
```python
    def fetchItem(self, ekey, cls=None, **kwargs):
        """ Load the specified key to find and build the first item with the
            specified tag and attrs. If no tag or attrs are specified then
            the first item in the result set is returned.

            Parameters:
                ekey (str or int): Path in Plex to fetch items from. If an int is passed
                    in, the key will be translated to /library/metadata/<key>. This allows
                    fetching an item only knowing its key-id.
                cls (:class:`~plexapi.base.PlexObject`): If you know the class of the
                    items to be fetched, passing this in will help the parser ensure
                    it only returns those items. By default we convert the xml elements
                    with the best guess PlexObjects based on tag and type attrs.
                etag (str): Only fetch items with the specified tag.
                **kwargs (dict): Optionally add XML attribute to filter the items.
                    See :func:`~plexapi.base.PlexObject.fetchItems` for more details
                    on how this is used.
        """
        if isinstance(ekey, int):    
            # ekey 为str时，不会自动拼接/library/metadata/
            ekey = f'/library/metadata/{ekey}'
```