### PR TITLE
优化'种子季过滤'，将求子集改为求交集

### DIFF
--- a/app/modules/filter/__init__.py
+++ b/app/modules/filter/__init__.py
@@ -194,7 +194,7 @@ class FilterModule(_ModuleBase):
             torrent_seasons = [1]
         # 种子集
         torrent_episodes = meta.episode_list
-        if not set(torrent_seasons).issubset(set(seasons)):
+        if not set(torrent_seasons).intersection(set(seasons)):
             # 种子季不在过滤季中
             logger.debug(f"种子 {torrent.site_name} - {torrent.title} 包含季 {torrent_seasons} 不是需要的季 {list(seasons)}")
             return False


### PR DESCRIPTION
```
【INFO】2024-09-20 20:01:15,686 - search.py - 匹配完成，共匹配到 1 个资源
【INFO】2024-09-20 20:01:15,687 - search.py - 开始过滤规则过滤，当前规则：{'include': None, 'exclude': None, 'quality': None, 'resolution': None, 'effect': None, 'tv_size': None, 'movie_size': None, 'min_seeders': None, 'min_seeders_time': None} ...
【INFO】2024-09-20 20:01:15,689 - search.py - 过滤规则过滤完成，剩余 1 个资源
【INFO】2024-09-20 20:01:15,690 - search.py - 开始优先级规则/剧集过滤，当前规则： CNSUB & !DOLBY & H264 & !BLU > CNSUB & !DOLBY & !BLU > !DOLBY & H264 & !BLU > !DOLBY & !BLU  ...
【DEBUG】2024-09-20 20:01:15,692 - chain - 请求模块执行：filter_torrents ...
【DEBUG】2024-09-20 20:01:15,696 - filter - 种子 xxx - Life On Top S01-S02 2009 WEBRip 720P x264 AAC 包含季 [1, 2] 不是需要的季 [1]
【WARNING】2024-09-20 20:01:15,697 - search.py - 顶级生活 没有符合优先级规则的资源
【WARNING】2024-09-20 20:01:15,698 - subscribe.py - 订阅 顶级生活 未搜索到资源
```
种子里有1，2两个季度，需要的是1季度，这里下载可能会更好，而不是直接判断不符合


将`app/modules/filter/__init__.py`的`197行`的
```
if not set(torrent_seasons).issubset(set(seasons)):
```
改为
```
if not set(torrent_seasons).intersection(set(seasons)):
```
将求子集改为求交集


简单试了下：
```
seasons = [1]
torrent_seasons = [1, 2]

if not set(torrent_seasons).issubset(set(seasons)):
    print('求子集:不是需要的季')
else:
    print('求子集:是需要的季')
    
if not set(torrent_seasons).intersection(set(seasons)):
    print('求交集:不是需要的季')
else:
    print('求交集:是需要的季')
```
返回：
```
求子集:不是需要的季
求交集:是需要的季
```
