### PR TITLE
fix #2755

### DIFF
--- a/app/modules/emby/__init__.py
+++ b/app/modules/emby/__init__.py
@@ -173,14 +173,21 @@ class EmbyModule(_ModuleBase, _MediaServerBase[Emby]):
             return server.get_librarys(username=username, hidden=hidden)
         return None
 
-    def mediaserver_items(self, server: str, library_id: str, start_index: int = 0, limit: int = 100) \
-            -> Optional[Generator]:
+    def mediaserver_items(self, server: str, library_id: Union[str, int], start_index: int = 0,
+                          limit: Optional[int] = -1) -> Optional[Generator]:
         """
-        媒体库项目列表
+        获取媒体服务器项目列表，支持分页和不分页逻辑，默认不分页获取所有数据
+
+        :param server: 媒体服务器名称
+        :param library_id: 媒体库ID，用于标识要获取的媒体库
+        :param start_index: 起始索引，用于分页获取数据。默认为 0，即从第一个项目开始获取
+        :param limit: 每次请求的最大项目数，用于分页。如果为 None 或 -1，则表示一次性获取所有数据，默认为 -1
+
+        :return: 返回一个生成器对象，用于逐步获取媒体服务器中的项目
         """
         server: Emby = self.get_instance(server)
         if server:
-            return server.get_items(library_id, start_index, limit)
+            yield from server.get_items(library_id, start_index, limit)
         return None
 
     def mediaserver_iteminfo(self, server: str, item_id: str) -> Optional[schemas.MediaServerItem]:

--- a/app/modules/emby/emby.py
+++ b/app/modules/emby/emby.py
@@ -692,7 +692,7 @@ class Emby:
         try:
             res = RequestUtils().get_res(url, params)
             if not res or res.status_code != 200:
-                yield None
+                return None
             items = res.json().get("Items") or []
             for item in items:
                 if not item:

--- a/app/modules/emby/emby.py
+++ b/app/modules/emby/emby.py
@@ -313,7 +313,7 @@ class Emby:
         if not self._host or not self._apikey:
             return None
         url = f"{self._host}emby/Items"
-        params={
+        params = {
             "IncludeItemTypes": "Series",
             "Fields": "ProductionYear",
             "StartIndex": 0,
@@ -601,7 +601,8 @@ class Emby:
         # 刷新根目录
         return "/"
 
-    def __format_item_info(self, item) -> Optional[schemas.MediaServerItem]:
+    @staticmethod
+    def __format_item_info(item) -> Optional[schemas.MediaServerItem]:
         """
         格式化item
         """
@@ -610,7 +611,8 @@ class Emby:
             if not user_data:
                 user_state = None
             else:
-                resume = item.get("UserData", {}).get("PlaybackPositionTicks") and item.get("UserData", {}).get("PlaybackPositionTicks") > 0
+                resume = item.get("UserData", {}).get("PlaybackPositionTicks") and item.get("UserData", {}).get(
+                    "PlaybackPositionTicks") > 0
                 last_played_date = item.get("UserData", {}).get("LastPlayedDate")
                 if last_played_date is not None and "." in last_played_date:
                     last_played_date = last_played_date.split(".")[0]
@@ -624,7 +626,6 @@ class Emby:
                 )
             tmdbid = item.get("ProviderIds", {}).get("Tmdb")
             return schemas.MediaServerItem(
-                id=item.get("Id"),
                 server="emby",
                 library=item.get("ParentId"),
                 item_id=item.get("Id"),
@@ -664,26 +665,30 @@ class Emby:
             logger.error(f"连接/Users/{self.user}/Items/{itemid}出错：" + str(e))
         return None
 
-    def get_items(self, parent: str, start_index: int = 0, limit: int = 100) -> Generator:
+    def get_items(self, parent: Union[str, int], start_index: int = 0, limit: Optional[int] = -1) \
+            -> Optional[Generator]:
         """
-        获取媒体服务器所有媒体库列表
-        :param parent: 父媒体库ID
-        :param start_index: 开始索引，用于分页
-        :param limit: 每次请求返回的项目数量
-        :return: 生成器 schemas.MediaServerItem
+        获取媒体服务器项目列表，支持分页和不分页逻辑，默认不分页获取所有数据
+
+        :param parent: 媒体库ID，用于标识要获取的媒体库
+        :param start_index: 起始索引，用于分页获取数据。默认为 0，即从第一个项目开始获取
+        :param limit: 每次请求的最大项目数，用于分页。如果为 None 或 -1，则表示一次性获取所有数据，默认为 -1
+
+        :return: 返回一个生成器对象，用于逐步获取媒体服务器中的项目
         """
-        if not parent:
-            yield None
-        if not self._host or not self._apikey:
-            yield None
+        if not parent or not self._host or not self._apikey:
+            return None
         url = f"{self._host}emby/Users/{self.user}/Items"
         params = {
             "ParentId": parent,
             "api_key": self._apikey,
-            "Fields": "ProviderIds,OriginalTitle,ProductionYear,Path,UserDataPlayCount,UserDataLastPlayedDate,ParentId",
-            "StartIndex": start_index,
-            "Limit": limit
+            "Fields": "ProviderIds,OriginalTitle,ProductionYear,Path,UserDataPlayCount,UserDataLastPlayedDate,ParentId"
         }
+        if limit is not None and limit != -1:
+            params.update({
+                "StartIndex": start_index,
+                "Limit": limit
+            })
         try:
             res = RequestUtils().get_res(url, params)
             if not res or res.status_code != 200:
@@ -700,7 +705,6 @@ class Emby:
 
         except Exception as e:
             logger.error(f"连接Users/Items出错：" + str(e))
-        yield None
 
     def get_webhook_message(self, form: any, args: dict) -> Optional[schemas.WebhookEventInfo]:
         """

--- a/app/modules/jellyfin/__init__.py
+++ b/app/modules/jellyfin/__init__.py
@@ -171,14 +171,21 @@ class JellyfinModule(_ModuleBase, _MediaServerBase[Jellyfin]):
             return server.get_librarys(username=username, hidden=hidden)
         return None
 
-    def mediaserver_items(self, server: str, library_id: str, start_index: int = 0, limit: int = 100) \
-            -> Optional[Generator]:
+    def mediaserver_items(self, server: str, library_id: Union[str, int], start_index: int = 0,
+                          limit: Optional[int] = -1) -> Optional[Generator]:
         """
-        媒体库项目列表
+        获取媒体服务器项目列表，支持分页和不分页逻辑，默认不分页获取所有数据
+
+        :param server: 媒体服务器名称
+        :param library_id: 媒体库ID，用于标识要获取的媒体库
+        :param start_index: 起始索引，用于分页获取数据。默认为 0，即从第一个项目开始获取
+        :param limit: 每次请求的最大项目数，用于分页。如果为 None 或 -1，则表示一次性获取所有数据，默认为 -1
+
+        :return: 返回一个生成器对象，用于逐步获取媒体服务器中的项目
         """
         server: Jellyfin = self.get_instance(server)
         if server:
-            return server.get_items(library_id, start_index, limit)
+            yield from server.get_items(library_id, start_index, limit)
         return None
 
     def mediaserver_iteminfo(self, server: str, item_id: str) -> Optional[schemas.MediaServerItem]:

--- a/app/modules/jellyfin/jellyfin.py
+++ b/app/modules/jellyfin/jellyfin.py
@@ -752,7 +752,7 @@ class Jellyfin:
         try:
             res = RequestUtils().get_res(url, params)
             if not res or res.status_code != 200:
-                yield None
+                return None
             items = res.json().get("Items") or []
             for item in items:
                 if not item:

--- a/app/modules/plex/__init__.py
+++ b/app/modules/plex/__init__.py
@@ -159,14 +159,21 @@ class PlexModule(_ModuleBase, _MediaServerBase[Plex]):
             return server.get_librarys(hidden)
         return None
 
-    def mediaserver_items(self, server: str, library_id: str, start_index: int = 0, limit: int = 100) \
-            -> Optional[Generator]:
+    def mediaserver_items(self, server: str, library_id: Union[str, int], start_index: int = 0,
+                          limit: Optional[int] = -1) -> Optional[Generator]:
         """
-        媒体库项目列表
+        获取媒体服务器项目列表，支持分页和不分页逻辑，默认不分页获取所有数据
+
+        :param server: 媒体服务器名称
+        :param library_id: 媒体库ID，用于标识要获取的媒体库
+        :param start_index: 起始索引，用于分页获取数据。默认为 0，即从第一个项目开始获取
+        :param limit: 每次请求的最大项目数，用于分页。如果为 None 或 -1，则表示一次性获取所有数据，默认为 -1
+
+        :return: 返回一个生成器对象，用于逐步获取媒体服务器中的项目
         """
         server: Plex = self.get_instance(server)
         if server:
-            return server.get_items(library_id, start_index, limit)
+            yield from server.get_items(library_id, start_index, limit)
         return None
 
     def mediaserver_iteminfo(self, server: str, item_id: str) -> Optional[schemas.MediaServerItem]:

--- a/app/modules/plex/plex.py
+++ b/app/modules/plex/plex.py
@@ -392,23 +392,7 @@ class Plex:
             return None
         try:
             item = self.__fetch_item(itemid)
-            ids = self.__get_ids(item.guids)
-            path = None
-            if item.locations:
-                path = item.locations[0]
-            return schemas.MediaServerItem(
-                server="plex",
-                library=item.librarySectionID,
-                item_id=item.key,
-                item_type=item.type,
-                title=item.title,
-                original_title=item.originalTitle,
-                year=item.year,
-                tmdbid=ids['tmdb_id'],
-                imdbid=ids['imdb_id'],
-                tvdbid=ids['tvdb_id'],
-                path=path,
-            )
+            return self.__build_media_server_item(item)
         except Exception as err:
             logger.error(f"获取项目详情出错：{str(err)}")
         return None
@@ -454,6 +438,48 @@ class Plex:
             item_id = int(item_id)
         return self._plex.fetchItem(item_id)
 
+    def __build_media_server_item(self, item) -> Optional[schemas.MediaServerItem]:
+        """
+        构造MediaServerItem
+        :param item: Plex媒体项目
+        :return: MediaServerItem
+        """
+        if not item:
+            return None
+        ids = self.__get_ids(item.guids)
+        path = item.locations[0] if item.locations else None
+        playback_position = getattr(item, "viewOffset", None) or 0
+        duration = getattr(item, "duration", None) or 0
+        percentage = (playback_position / duration * 100) if duration > 0 else None
+        played = getattr(item, "isPlayed", None) or False
+        play_count = getattr(item, "viewCount", None) or 0
+        last_played_date = getattr(item, "lastViewedAt", None)
+
+        user_state = schemas.MediaServerItemUserState(
+            played=played,
+            resume=playback_position > 0,
+            last_played_date=last_played_date.isoformat() if last_played_date and hasattr(last_played_date,
+                                                                                          'isoformat') else None,
+            play_count=play_count,
+            percentage=percentage,
+        )
+
+        return schemas.MediaServerItem(
+            id=item.ratingKey,
+            server="plex",
+            library=item.librarySectionID,
+            item_id=item.key,
+            item_type=item.type,
+            title=item.title,
+            original_title=item.originalTitle,
+            year=item.year,
+            tmdbid=ids.get("tmdb_id"),
+            imdbid=ids.get("imdb_id"),
+            tvdbid=ids.get("tvdb_id"),
+            path=path,
+            user_state=user_state,
+        )
+
     def get_items(self, parent: str, start_index: int = 0, limit: int = 100) -> Generator:
         """
         获取媒体服务器所有媒体库列表
@@ -473,41 +499,9 @@ class Plex:
                     try:
                         if not item:
                             continue
-                        ids = self.__get_ids(item.guids)
-                        path = None
-                        if item.locations:
-                            path = item.locations[0]
-                        playback_position = item.viewOffset if hasattr(item, 'viewOffset') else 0
-                        duration = item.duration if hasattr(item, 'duration') else 0
-                        percentage = (playback_position / duration * 100) if duration > 0 else None
-                        played = item.isPlayed if hasattr(item, 'isPlayed') else False
-                        play_count = item.viewCount if hasattr(item, 'viewCount') else 0
-                        last_played_date = item.lastViewedAt if hasattr(item, 'lastViewedAt') else None
-                        user_state = schemas.MediaServerItemUserState(
-                            played=played,
-                            resume=playback_position > 0,
-                            last_played_date=last_played_date.isoformat() if last_played_date else None,
-                            play_count=play_count,
-                            percentage=percentage,
-                        )
-
-                        yield schemas.MediaServerItem(
-                            id=item.ratingKey,
-                            server="plex",
-                            library=item.librarySectionID,
-                            item_id=item.key,
-                            item_type=item.type,
-                            title=item.title,
-                            original_title=item.originalTitle,
-                            year=item.year,
-                            tmdbid=ids['tmdb_id'],
-                            imdbid=ids['imdb_id'],
-                            tvdbid=ids['tvdb_id'],
-                            path=path,
-                            user_state=user_state,
-                        )
+                        yield self.__build_media_server_item(item)
                     except Exception as e:
-                        logger.error(f"处理媒体项目时出错：{str(e)}, 跳过此项目。")
+                        logger.error(f"处理媒体项目时出错：{str(e)}, 跳过此项目")
                         continue
         except Exception as err:
             logger.error(f"获取媒体库列表出错：{str(err)}")

--- a/app/schemas/mediaserver.py
+++ b/app/schemas/mediaserver.py
@@ -72,7 +72,6 @@ class MediaServerLibrary(BaseModel):
     link: Optional[str] = None
 
 
-
 class MediaServerItemUserState(BaseModel):
     # 已播放
     played: Optional[bool] = None
@@ -84,6 +83,7 @@ class MediaServerItemUserState(BaseModel):
     play_count: Optional[int] = None
     # 播放进度
     percentage: Optional[float] = None
+
 
 class MediaServerItem(BaseModel):
     """


### PR DESCRIPTION
- 修复了 #2755 中 Plex 同步时的异常报错问题
- 移除了 #2755 中对 `MediaServerItem.id` 的赋值，该赋值导致了 Jellyfin 同步时写入数据库失败
- 重构了 #2755 中的分页逻辑，支持分页和不分页，默认调整为不分页，并修正了 `Generator` 的异常处理，原 PR 的分页逻辑中，调用处并未进行调整，导致同一媒体库最多只能同步100条数据
- 另外，Plex SDK 实际上已默认支持内部分页处理，但在 Jellyfin 和 Emby 的数据获取中存在内部过滤的情况（如排除合集），导致分页数据可能出现错误。由于时间有限，暂未深入调整 Jellyfin 和 Emby 的分页逻辑，期待后续有其他开发者进一步优化