### PR TITLE
fix(mediaserver): resolve media_statistic

### DIFF
--- a/app/modules/jellyfin/__init__.py
+++ b/app/modules/jellyfin/__init__.py
@@ -154,7 +154,7 @@ class JellyfinModule(_ModuleBase, _MediaServerBase[Jellyfin]):
         media_statistics = []
         for server in servers:
             media_statistic = server.get_medias_count()
-            if not media_statistics:
+            if not media_statistic:
                 continue
             media_statistic.user_count = server.get_user_count()
             media_statistics.append(media_statistic)

--- a/app/modules/plex/__init__.py
+++ b/app/modules/plex/__init__.py
@@ -144,8 +144,9 @@ class PlexModule(_ModuleBase, _MediaServerBase[Plex]):
         media_statistics = []
         for server in servers:
             media_statistic = server.get_medias_count()
-            if not media_statistics:
+            if not media_statistic:
                 continue
+            media_statistic.user_count = 1
             media_statistics.append(media_statistic)
         return media_statistics
 


### PR DESCRIPTION
- 修复了 Plex 和 Jellyfin 媒体库统计错误的问题