### PR TITLE
fix(plugin): use positional arguments in `get_plugins`

### DIFF
--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -708,7 +708,7 @@ class PluginManager(metaclass=Singleton):
         # 已安装插件
         installed_apps = self.systemconfig.get(SystemConfigKey.UserInstalledPlugins) or []
         # 获取在线插件
-        online_plugins = self.pluginhelper.get_plugins(repo_url=market, package_version=package_version) or {}
+        online_plugins = self.pluginhelper.get_plugins(market, package_version) or {}
         if not online_plugins:
             if not package_version:
                 logger.warning(f"获取插件库失败：{market}，请检查 GitHub 网络连接")


### PR DESCRIPTION
- 统一使用位置参数以保持缓存一致性，防止更新时因网络不稳定提示无适用插件