### PR TITLE
feat: 新增 API_TOKEN 接口 `runscheduler2`，立即调用一次定时服务

### DIFF
--- a/app/api/endpoints/system.py
+++ b/app/api/endpoints/system.py
@@ -12,7 +12,7 @@ from app.chain.search import SearchChain
 from app.chain.system import SystemChain
 from app.core.config import settings, global_vars
 from app.core.module import ModuleManager
-from app.core.security import verify_token, verify_uri_token
+from app.core.security import verify_token, verify_uri_token, verify_apitoken
 from app.db.models import User
 from app.db.systemconfig_oper import SystemConfigOper
 from app.db.user_oper import get_current_active_superuser
@@ -363,5 +363,17 @@ def run_scheduler(jobid: str,
     """
     if not jobid:
         return schemas.Response(success=False, message="命令不能为空！")
+    Scheduler().start(jobid)
+    return schemas.Response(success=True)
+
+@router.get("/runscheduler2", summary="运行服务（API_TOKEN）", response_model=schemas.Response)
+def run_scheduler2(jobid: str,
+                    _: str = Depends(verify_apitoken)):
+    """
+    执行命令（API_TOKEN认证）
+    """
+    if not jobid:
+        return schemas.Response(success=False, message="命令不能为空！")
+
     Scheduler().start(jobid)
     return schemas.Response(success=True)

--- a/app/api/endpoints/system.py
+++ b/app/api/endpoints/system.py
@@ -366,9 +366,10 @@ def run_scheduler(jobid: str,
     Scheduler().start(jobid)
     return schemas.Response(success=True)
 
+
 @router.get("/runscheduler2", summary="运行服务（API_TOKEN）", response_model=schemas.Response)
 def run_scheduler2(jobid: str,
-                    _: str = Depends(verify_apitoken)):
+                   _: str = Depends(verify_apitoken)):
     """
     执行命令（API_TOKEN认证）
     """


### PR DESCRIPTION
### 新增 API_TOKEN 接口 `runscheduler2`

立即调用一次定时服务。

- path: `/api/v1/system/runscheduler2`
- params:
  * `token`: 校验 API_TOKEN
  * `jobid`: 定时服务名称

本接口同 `app.api.endpoints.dashboard.schedule2` (`/api/v1/dashboard/schedule2`) 对应，同样通过 API_TOKEN 校验。

可从 `/api/v1/dashboard/schedule2` 列出所有已开启定时服务，再通过本接口调用一次所需服务。例如，外部下载程序完成下载后需要立即整理目录，可设置钩子
```
curl 'http://moviepilot:3000/api/v1/system/runscheduler2?token=moviepilot&jobid=DirMonitor'
```