### PR TITLE
refactor(module): unify config retrieval logic

### DIFF
--- a/app/modules/qbittorrent/__init__.py
+++ b/app/modules/qbittorrent/__init__.py
@@ -150,7 +150,7 @@ class QbittorrentModule(_ModuleBase, _DownloaderBase[Qbittorrent]):
                         if settings.TORRENT_TAG and settings.TORRENT_TAG not in torrent_tags:
                             logger.info(f"给种子 {torrent_hash} 打上标签：{settings.TORRENT_TAG}")
                             server.set_torrents_tag(ids=torrent_hash, tags=[settings.TORRENT_TAG])
-                        return downloader or self._default_server_name, torrent_hash, f"下载任务已存在"
+                        return downloader or self.get_default_config_name(), torrent_hash, f"下载任务已存在"
             return None, None, f"添加种子任务失败：{content}"
         else:
             # 获取种子Hash
@@ -162,7 +162,7 @@ class QbittorrentModule(_ModuleBase, _DownloaderBase[Qbittorrent]):
                     # 种子文件
                     torrent_files = server.get_files(torrent_hash)
                     if not torrent_files:
-                        return downloader or self._default_server_name, torrent_hash, "获取种子文件失败，下载任务可能在暂停状态"
+                        return downloader or self.get_default_config_name(), torrent_hash, "获取种子文件失败，下载任务可能在暂停状态"
 
                     # 不需要的文件ID
                     file_ids = []
@@ -187,11 +187,11 @@ class QbittorrentModule(_ModuleBase, _DownloaderBase[Qbittorrent]):
                         server.torrents_set_force_start(torrent_hash)
                     else:
                         server.start_torrents(torrent_hash)
-                    return downloader or self._default_server_name, torrent_hash, f"添加下载成功，已选择集数：{sucess_epidised}"
+                    return downloader or self.get_default_config_name(), torrent_hash, f"添加下载成功，已选择集数：{sucess_epidised}"
                 else:
                     if server.is_force_resume():
                         server.torrents_set_force_start(torrent_hash)
-                    return downloader or self._default_server_name, torrent_hash, "添加下载成功"
+                    return downloader or self.get_default_config_name(), torrent_hash, "添加下载成功"
 
     def list_torrents(self, status: TorrentStatus = None,
                       hashs: Union[list, str] = None,

--- a/app/modules/slack/__init__.py
+++ b/app/modules/slack/__init__.py
@@ -182,14 +182,8 @@ class SlackModule(_ModuleBase, _MessageBase[Slack]):
           ]
         }
         """
-        # 获取客户端
-        client_config = None
-        if source:
-            client_config = self.get_config(source)
-        else:
-            client_configs = self.get_configs()
-            if client_configs:
-                client_config = list(client_configs.values())[0]
+        # 获取服务配置
+        client_config = self.get_config(source)
         if not client_config:
             return None
         try:

--- a/app/modules/synologychat/__init__.py
+++ b/app/modules/synologychat/__init__.py
@@ -68,14 +68,8 @@ class SynologyChatModule(_ModuleBase, _MessageBase[SynologyChat]):
         :return: 渠道、消息体
         """
         try:
-            # 来源
-            client_config = None
-            if source:
-                client_config = self.get_config(source)
-            else:
-                client_configs = self.get_configs()
-                if client_configs:
-                    client_config = list(client_configs.values())[0]
+            # 获取服务配置
+            client_config = self.get_config(source)
             if not client_config:
                 return None
             client: SynologyChat = self.get_instance(client_config.name)

--- a/app/modules/telegram/__init__.py
+++ b/app/modules/telegram/__init__.py
@@ -95,14 +95,8 @@ class TelegramModule(_ModuleBase, _MessageBase[Telegram]):
                 }
             }
         """
-        # 获取渠道
-        client_config = None
-        if source:
-            client_config = self.get_config(source)
-        else:
-            client_configs = self.get_configs()
-            if client_configs:
-                client_config = list(client_configs.values())[0]
+        # 获取服务配置
+        client_config = self.get_config(source)
         if not client_config:
             return None
         client: Telegram = self.get_instance(client_config.name)

--- a/app/modules/transmission/__init__.py
+++ b/app/modules/transmission/__init__.py
@@ -153,7 +153,7 @@ class TransmissionModule(_ModuleBase, _DownloaderBase[Transmission]):
                             if settings.TORRENT_TAG and settings.TORRENT_TAG not in labels:
                                 labels.append(settings.TORRENT_TAG)
                                 server.set_torrent_tag(ids=torrent_hash, tags=labels)
-                        return downloader or self._default_server_name, torrent_hash, f"下载任务已存在"
+                        return downloader or self.get_default_config_name(), torrent_hash, f"下载任务已存在"
             return None, None, f"添加种子任务失败：{content}"
         else:
             torrent_hash = torrent.hashString
@@ -161,7 +161,7 @@ class TransmissionModule(_ModuleBase, _DownloaderBase[Transmission]):
                 # 选择文件
                 torrent_files = server.get_files(torrent_hash)
                 if not torrent_files:
-                    return downloader or self._default_server_name, torrent_hash, "获取种子文件失败，下载任务可能在暂停状态"
+                    return downloader or self.get_default_config_name(), torrent_hash, "获取种子文件失败，下载任务可能在暂停状态"
                 # 需要的文件信息
                 file_ids = []
                 unwanted_file_ids = []
@@ -182,9 +182,9 @@ class TransmissionModule(_ModuleBase, _DownloaderBase[Transmission]):
                 server.set_unwanted_files(torrent_hash, unwanted_file_ids)
                 # 开始任务
                 server.start_torrents(torrent_hash)
-                return downloader or self._default_server_name, torrent_hash, "添加下载任务成功"
+                return downloader or self.get_default_config_name(), torrent_hash, "添加下载任务成功"
             else:
-                return downloader or self._default_server_name, torrent_hash, "添加下载任务成功"
+                return downloader or self.get_default_config_name(), torrent_hash, "添加下载任务成功"
 
     def list_torrents(self, status: TorrentStatus = None,
                       hashs: Union[list, str] = None,

--- a/app/modules/vocechat/__init__.py
+++ b/app/modules/vocechat/__init__.py
@@ -84,14 +84,8 @@ class VoceChatModule(_ModuleBase, _MessageBase[VoceChat]):
               "target": { "gid": 2 } //发送给谁，gid代表是发送给频道，uid代表是发送给个人，此时的数据结构举例：{"uid":1}
             }
             """
-            # 获取渠道
-            client_config = None
-            if source:
-                client_config = self.get_config(source)
-            else:
-                client_configs = self.get_configs()
-                if client_configs:
-                    client_config = list(client_configs.values())[0]
+            # 获取服务配置
+            client_config = self.get_config(source)
             if not client_config:
                 return None
             # 报文体

--- a/app/modules/wechat/__init__.py
+++ b/app/modules/wechat/__init__.py
@@ -71,14 +71,8 @@ class WechatModule(_ModuleBase, _MessageBase[WeChat]):
         :return: 渠道、消息体
         """
         try:
-            # 获取客户端
-            client_config = None
-            if source:
-                client_config = self.get_config(source)
-            else:
-                client_configs = self.get_configs()
-                if client_configs:
-                    client_config = list(client_configs.values())[0]
+            # 获取服务配置
+            client_config = self.get_config(source)
             if not client_config:
                 return None
             client: WeChat = self.get_instance(client_config.name)


### PR DESCRIPTION
- 通过统一获取配置的逻辑，简化了配置管理以及降低用户配置难度
- `get_config` 和 `get_instance` 调整为支持可选服务名称，如果未提供服务名称，则系统将返回默认值
- 默认配置的获取逻辑调整如下：
     - 如果存在已设置为默认的配置，则返回该默认配置
     - 如果没有默认配置，则返回第一个配置的名称
     - 如果没有任何配置，返回 `None`