### PR TITLE
fix dirmonitor exclude_words

### DIFF
--- a/app/monitor.py
+++ b/app/monitor.py
@@ -298,7 +298,7 @@ class Monitor(metaclass=Singleton):
                     for keyword in transfer_exclude_words:
                         if not keyword:
                             continue
-                        if keyword and re.search(r"%s" % keyword, event_path, re.IGNORECASE):
+                        if keyword and re.search(r"%s" % keyword, str(event_path), re.IGNORECASE):
                             logger.info(f"{event_path} 命中整理屏蔽词 {keyword}，不处理")
                             return
 


### PR DESCRIPTION
 monitor.py - 目录监控发生错误：expected string or bytes-like object, got 'PosixPath' - Traceback (most recent call last):
  File "/app/app/monitor.py", line 301, in __handle_file
    if keyword and re.search(r"%s" % keyword, event_path, re.IGNORECASE):
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/re/__init__.py", line 176, in search
    return _compile(pattern, flags).search(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'PosixPath'