### PR TITLE
fix 获取站点最新数据的时候排除掉错误的数据

### DIFF
--- a/app/db/models/siteuserdata.py
+++ b/app/db/models/siteuserdata.py
@@ -81,6 +81,7 @@ class SiteUserData(Base):
                 func.max(SiteUserData.updated_day).label('latest_update_day')
             )
             .group_by(SiteUserData.domain)
+            .filter(SiteUserData.err_msg == None)
             .subquery()
         )
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a6363820-a605-471e-991a-9f801a86f852)
实际上ck没过期，mp上可测试通过、查看种子、查看数据，但是latest最新数据都是0
![image](https://github.com/user-attachments/assets/9eacad2e-acec-480d-9cb5-b021fdd8b641)
