### PR TITLE
fix: `包含/排除规则` 在新增订阅搜索无效的问题

### DIFF
--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -361,7 +361,8 @@ class SubscribeChain(ChainBase):
                 torrent_meta = context.meta_info
                 torrent_info = context.torrent_info
                 torrent_mediainfo = context.media_info
-                # 过滤订阅 `包含` 和 `排除` 规则
+
+                # 匹配订阅附加参数
                 if not self.torrenthelper.filter_torrent(torrent_info=torrent_info,
                                                          filter_params=self.get_params(subscribe)):
                     continue

--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -361,6 +361,10 @@ class SubscribeChain(ChainBase):
                 torrent_meta = context.meta_info
                 torrent_info = context.torrent_info
                 torrent_mediainfo = context.media_info
+                # 过滤订阅 `包含` 和 `排除` 规则
+                if not self.torrenthelper.filter_torrent(torrent_info=torrent_info,
+                                                         filter_params=self.get_params(subscribe)):
+                    continue
                 # 洗版
                 if subscribe.best_version:
                     # 洗版时，非整季不要


### PR DESCRIPTION
fix: #2945
- 修复 `新增订阅搜索` 阶段 `包含/排除规则` 不生效的问题