### PR TITLE
fix: #2963

### DIFF
--- a/app/helper/directory.py
+++ b/app/helper/directory.py
@@ -65,16 +65,14 @@ class DirectoryHelper:
         dirs = self.get_dirs()
         # 按照配置顺序查找
         for d in dirs:
-            if not d.download_path:
-                continue
             # 下载目录
             download_path = Path(d.download_path)
             # 媒体库目录
             library_path = Path(d.library_path)
-            # 媒体类型
-            # 有目录时直接匹配
+            # 下载目录不匹配, 不符合条件, 通常处理`下载`匹配
             if src_path and download_path != src_path:
                 continue
+            # 媒体库目录不匹配, 不符合条件, 通常处理`整理`匹配
             if dest_path and library_path != dest_path:
                 continue
             # 本地目录

--- a/app/helper/directory.py
+++ b/app/helper/directory.py
@@ -65,7 +65,7 @@ class DirectoryHelper:
         dirs = self.get_dirs()
         # 按照配置顺序查找
         for d in dirs:
-            if not d.download_path or not d.library_path:
+            if not d.download_path:
                 continue
             # 下载目录
             download_path = Path(d.download_path)

--- a/app/helper/directory.py
+++ b/app/helper/directory.py
@@ -72,8 +72,8 @@ class DirectoryHelper:
             # 下载目录不匹配, 不符合条件, 通常处理`下载`匹配
             if src_path and download_path != src_path:
                 continue
-            # 媒体库目录不匹配, 不符合条件, 通常处理`整理`匹配
-            if dest_path and library_path != dest_path:
+            # 媒体库目录不匹配, 或监控方式为None(即不自动整理), 不符合条件, 通常处理`整理`匹配
+            if dest_path and library_path != dest_path or not d.monitor_type:
                 continue
             # 本地目录
             if local and d.storage != "local":


### PR DESCRIPTION
fix: #2963

- `if src_path and download_path != src_path`：已排除未设置下载目录的情况
- `if dest_path and library_path != dest_path`：已排除未设置媒体库目录的情况

因此，`if not d.download_path or not d.library_path` 条件不再需要。