### PR TITLE
fix: 修复了`整理模式`为`目录监控`时, 目标路径不符预期的问题

### DIFF
--- a/app/monitor.py
+++ b/app/monitor.py
@@ -386,9 +386,12 @@ class Monitor(metaclass=Singleton):
                     return
 
                 # 查询转移目的目录
-                if not self.directoryhelper.get_dir(mediainfo, src_path=Path(mon_path)):
+                dir_info = self.directoryhelper.get_dir(mediainfo, src_path=Path(mon_path))
+                if not dir_info:
                     logger.warn(f"{event_path.name} 未找到对应的目标目录")
                     return
+                # 获取目标路径
+                dest_path = Path(dir_info.library_path)
 
                 # 查找这个文件项
                 file_item = self.storagechain.get_file_item(storage=storage, path=event_path)
@@ -418,6 +421,7 @@ class Monitor(metaclass=Singleton):
                 transferinfo: TransferInfo = self.chain.transfer(fileitem=file_item,
                                                                  meta=file_meta,
                                                                  mediainfo=mediainfo,
+                                                                 target_path=dest_path,
                                                                  episodes_info=episodes_info)
 
                 if not transferinfo:


### PR DESCRIPTION
close: #2962
修复了未能将`library_path`传递给`transfer`(文件转移)模块的问题
以此修复`目录监控`模式下,文件都被错误的整理到第一顺位的`媒体库目录`