### PR TITLE
改进 SystemUtils.list_files 遍历目录对特殊字符的兼容性（如'[]'）

### DIFF
--- a/app/utils/system.py
+++ b/app/utils/system.py
@@ -193,8 +193,8 @@ class SystemUtils:
             pattern = r".*"
 
         # 遍历目录及子目录
-        for matched_glob in glob(str(directory / '**'), recursive=recursive, include_hidden=True):
-            path = Path(matched_glob)
+        for matched_glob in glob('**', root_dir=directory, recursive=recursive, include_hidden=True):
+            path = directory.joinpath(matched_glob)
             if path.is_file() \
                     and re.match(pattern, path.name, re.IGNORECASE) \
                     and path.stat().st_size >= min_filesize * 1024 * 1024:
@@ -229,8 +229,8 @@ class SystemUtils:
         pattern = r".*(" + "|".join(extensions) + ")$"
 
         # 遍历目录及子目录
-        for matched_glob in glob(str(directory / '**'), recursive=recursive, include_hidden=True):
-            path = Path(matched_glob)
+        for matched_glob in glob('**', root_dir=directory, recursive=recursive, include_hidden=True):
+            path = directory.joinpath(matched_glob)
             if path.is_file() \
                     and re.match(pattern, path.name, re.IGNORECASE) \
                     and path.stat().st_size >= min_filesize * 1024 * 1024:


### PR DESCRIPTION
原 glob(str(directory / '**'), recursive=recursive, include_hidden=True) 获取子目录及文件的方式，对于特殊字符的目录会形成类似 '/tmp/test/[abc][01]/**' 的 pathname，会返回空列表。
修改为 glob('**', root_dir=directory, recursive=recursive, include_hidden=True)，显示指定root_dir，可以成功获取列表