### PR TITLE
perfec：匹配未简体化的中文标题，提高动漫识别准确性

### DIFF
--- a/app/core/meta/metaanime.py
+++ b/app/core/meta/metaanime.py
@@ -81,7 +81,6 @@ class MetaAnime(MetaBase):
                     _, self.cn_name, _, _, _, _ = StringUtils.get_keyword(self.cn_name)
                     if self.cn_name:
                         self.cn_name = re.sub(r'%s' % self._name_nostring_re, '', self.cn_name, flags=re.IGNORECASE).strip()
-                        self.cn_name = zhconv.convert(self.cn_name, "zh-hans")
                 if self.en_name:
                     self.en_name = re.sub(r'%s' % self._name_nostring_re, '', self.en_name, flags=re.IGNORECASE).strip().title()
                     self._name = StringUtils.str_title(self.en_name)

--- a/app/modules/douban/__init__.py
+++ b/app/modules/douban/__init__.py
@@ -2,6 +2,7 @@ import re
 from typing import List, Optional, Tuple, Union
 
 import cn2an
+import zhconv
 
 from app import schemas
 from app.core.config import settings
@@ -108,7 +109,7 @@ class DoubanModule(_ModuleBase):
             elif meta:
                 info = {}
                 # 使用中英文名分别识别，去重去空，但要保持顺序
-                names = list(dict.fromkeys([k for k in [meta.cn_name, meta.en_name] if k]))
+                names = list(dict.fromkeys([k for k in [meta.cn_name, zhconv.convert(meta.cn_name, "zh-hans"), meta.en_name] if k]))
                 for name in names:
                     if meta.begin_season:
                         logger.info(f"正在识别 {name} 第{meta.begin_season}季 ...")

--- a/app/modules/themoviedb/__init__.py
+++ b/app/modules/themoviedb/__init__.py
@@ -1,6 +1,7 @@
 from typing import Optional, List, Tuple, Union, Dict
 
 import cn2an
+import zhconv
 
 from app import schemas
 from app.core.config import settings
@@ -117,7 +118,7 @@ class TheMovieDbModule(_ModuleBase):
             elif meta:
                 info = {}
                 # 使用中英文名分别识别，去重去空，但要保持顺序
-                names = list(dict.fromkeys([k for k in [meta.cn_name, meta.en_name] if k]))
+                names = list(dict.fromkeys([k for k in [meta.cn_name, zhconv.convert(meta.cn_name, "zh-hans"), meta.en_name] if k]))
                 for name in names:
                     if meta.begin_season:
                         logger.info(f"正在识别 {name} 第{meta.begin_season}季 ...")


### PR DESCRIPTION
perfect：MetaAnime.cn_name 属性不再进行简化处理，在使用 TMDB 和豆瓣查询时再查询简体化名字
提高动漫识别准确性

# 测试动漫
- `[ANi] 學姊是男孩 - 09 [1080P][Baha][WEB-DL][AAC AVC][CHT].mp4`
- `[ANi]我家有個魚乾妹 [01][1080P][Baha][WEB-DL].mp4`
- `[HKGS]滿腦都是○○的我沒辦法談戀愛[01][1080P][WEB-DL].mkv`
- `[ANi]銀河騎士傳[01][1080P][Baha][WEB-DL].mp4`