### PR TITLE
修复浏览器内核下载报错

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -21,7 +21,7 @@ chown -R moviepilot:moviepilot \
     /var/log/nginx
 chown moviepilot:moviepilot /etc/hosts /tmp
 # 下载浏览器内核
-HTTPS_PROXY="${HTTPS_PROXY:-${https_proxy:-$PROXY_HOST}}" gosu moviepilot:moviepilot playwright install chromium
+HTTPS_PROXY="${HTTPS_PROXY:-${https_proxy:-$PROXY_HOST}}" && gosu moviepilot:moviepilot playwright install chromium
 # 启动前端nginx服务
 nginx
 # 启动docker http proxy nginx


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d143b547-9c81-44b6-b368-be2998090abf)
修复设置代理情况下，启动容器后内核下载报错