### PR TITLE
fix(playwright): add check for HTTPS proxy

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -21,7 +21,11 @@ chown -R moviepilot:moviepilot \
     /var/log/nginx
 chown moviepilot:moviepilot /etc/hosts /tmp
 # 下载浏览器内核
-HTTPS_PROXY="${HTTPS_PROXY:-${https_proxy:-$PROXY_HOST}}" gosu moviepilot:moviepilot playwright install chromium
+if [[ "$HTTPS_PROXY" =~ ^https?:// ]] || [[ "$https_proxy" =~ ^https?:// ]] || [[ "$PROXY_HOST" =~ ^https?:// ]]; then
+  HTTPS_PROXY="${HTTPS_PROXY:-${https_proxy:-$PROXY_HOST}}" gosu moviepilot:moviepilot playwright install chromium
+else
+  gosu moviepilot:moviepilot playwright install chromium
+fi
 # 启动前端nginx服务
 nginx
 # 启动docker http proxy nginx


### PR DESCRIPTION
- 由于 playwright install 命令仅支持 HTTP 代理，增加相关校验以避免下载失败