### PR TITLE
fix #2952

### DIFF
--- a/app/modules/qbittorrent/qbittorrent.py
+++ b/app/modules/qbittorrent/qbittorrent.py
@@ -1,4 +1,5 @@
 import time
+import traceback
 from typing import Optional, Union, Tuple, List
 
 import qbittorrentapi
@@ -75,8 +76,13 @@ class Qbittorrent:
                                         REQUESTS_ARGS={'timeout': (15, 60)})
             try:
                 qbt.auth_log_in()
-            except qbittorrentapi.LoginFailed as e:
+            except (qbittorrentapi.LoginFailed, qbittorrentapi.Forbidden403Error) as e:
                 logger.error(f"qbittorrent 登录失败：{str(e)}")
+                return None
+            except Exception as e:
+                stack_trace = "".join(traceback.format_exception(None, e, e.__traceback__))[:2000]
+                logger.error(f"qbittorrent 登录失败：{str(e)}\n{stack_trace}")
+                return None
             return qbt
         except Exception as err:
             logger.error(f"qbittorrent 连接出错：{str(err)}")


### PR DESCRIPTION
- 打印登录未知异常时的堆栈日志

```log
qbittorrent 登录失败：Failed to connect to qBittorrent. Unknown Error: RecursionError('maximum recursion depth exceeded')
Traceback (most recent call last):
  File "D:\Work\InfinityPacer\MoviePilot\venv\Lib\site-packages\qbittorrentapi\request.py", line 591, in _auth_request
    return self._request_manager(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Work\InfinityPacer\MoviePilot\venv\Lib\site-packages\qbittorrentapi\request.py", line 664, in _request_manager
    return self._request(
           ^^^^^^^^^^^^^^
  File "D:\Work\InfinityPacer\MoviePilot\venv\Lib\site-packages\qbittorrentapi\request.py", line 816, in _request
    self._handle_error_responses(final_data, final_params, response)
  File "D:\Work\InfinityPacer\MoviePilot\venv\Lib\site-packages\qbittorrentapi\request.py", line 991, in _handle_error_responses
    raise Forbidden403Error(response.text, request=request, response=response)
qbittorrentapi.exceptions.Forbidden403Error: 身份认证失败次数过多，您的 IP 地址已被封禁。
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "D:\Work\InfinityPacer\MoviePil
```