### PR TITLE
fix(rclone): specify UTF-8 encoding when save config

### DIFF
--- a/app/modules/filemanager/storages/rclone.py
+++ b/app/modules/filemanager/storages/rclone.py
@@ -39,7 +39,7 @@ class Rclone(StorageBase):
         path = Path(filepath)
         if not path.parent.exists():
             path.parent.mkdir(parents=True)
-        path.write_text(conf.get('content'))
+        path.write_text(conf.get('content'), encoding='utf-8')
 
     @staticmethod
     def __get_hidden_shell():


### PR DESCRIPTION
- 写入配置时，显式使用 UTF-8

```
ERROR:   2024-11-15 17:43:48,179 chain - 运行模块 FileManagerModule.storage_usage 出错：'utf-8' codec can't decode byte 0xc7 in position 2: invalid continuation byte
Traceback (most recent call last):
  File "D:\Work\InfinityPacer\MoviePilot\app\chain\__init__.py", line 112, in run_module
    result = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "D:\Work\InfinityPacer\MoviePilot\app\modules\filemanager\__init__.py", line 319, in storage_usage
    return storage_oper.usage()
           ^^^^^^^^^^^^^^^^^^^^
  File "D:\Work\InfinityPacer\MoviePilot\app\modules\filemanager\storages\rclone.py", line 342, in usage
    lines = f.readlines()
            ^^^^^^^^^^^^^
  File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc7 in position 2: invalid continuation byte
```