### PR TITLE
fix 本地存储 upload 后将文件识别为文件夹的问题

### DIFF
--- a/app/modules/filemanager/storages/local.py
+++ b/app/modules/filemanager/storages/local.py
@@ -193,7 +193,7 @@ class LocalStorage(StorageBase):
         if code != 0:
             logger.error(f"移动文件失败：{message}")
             return None
-        return self.__get_diritem(target_path)
+        return self.get_item(target_path)
 
     def copy(self, fileitem: schemas.FileItem, target_file: Path) -> bool:
         """


### PR DESCRIPTION
在日志中发现
INFO:    media.py - 开始刮削：xxxx.xxx
INFO:    media.py - 已保存文件：xxxx.nfo/
INFO:    media.py - 已保存文件：xxxx.jpg/
INFO:    media.py - xxxx.xxx 刮削完成