### PR TITLE
fix: 手动整理，触发多线程并发刮削，导致的文件处理冲突问题

### DIFF
--- a/app/utils/resource_lock.py
+++ b/app/utils/resource_lock.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+import threading
+from collections import defaultdict
+
+from app.log import logger
+from app.utils.singleton import Singleton
+
+
+class ResourceLockManager(metaclass=Singleton):
+    """基于 resource_id 的锁管理器"""
+    def __init__(self):
+        self.locks = defaultdict(threading.Lock)  # 每个资源一个锁
+        self.global_lock = threading.RLock()  # 管理全局锁池的线程安全
+
+    def get_lock(self, resource_id):
+        """获取与 resource_id 关联的锁"""
+        with self.global_lock:  # 防止并发修改 locks
+            return self.locks[resource_id]
+
+    def clean_lock(self, resource_id):
+        """尝试清理锁"""
+        with self.global_lock:  # 防止并发修改 locks
+            lock = self.locks.get(resource_id)
+            if not lock:
+                return
+            if not lock.locked():
+                del self.locks[resource_id]
+                logger.debug(f"线程 {threading.current_thread().name} 清理了未占用的锁 {resource_id}")
+            else:
+                logger.debug(f"线程 {threading.current_thread().name} 无法清理仍被占用的锁 {resource_id}")
+
+
+class ResourceLockHandler:
+    """资源处理器，用于封装对单个 resource_id 的锁管理"""
+    def __init__(self, resource_id, blocking=True):
+        """
+        :param resource_id: 要处理的资源 ID
+        :param blocking: 是否阻塞等待获取锁
+        """
+        self.resource_id = resource_id
+        self.manager = ResourceLockManager()
+        self.lock = None
+        self.blocking = blocking
+        self.acquired = False
+
+    def __enter__(self):
+        """自动获取锁"""
+        self.lock = self.manager.get_lock(self.resource_id)
+        self.acquired = self.lock.acquire(blocking=self.blocking)
+        if self.acquired:
+            logger.debug(f"线程 {threading.current_thread().name} 获取了锁 {self.resource_id}")
+        else:
+            logger.debug(f"线程 {threading.current_thread().name} 无法获取锁 {self.resource_id}")
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """自动释放锁并清理"""
+        if self.acquired:  # 仅当成功获取锁时才释放和清理
+            self.lock.release()
+            self.lock = None
+            self.manager.clean_lock(self.resource_id)


### PR DESCRIPTION
现象：
手动整理 海贼王 目录，全部22季，开启刮削，每季整理完毕都会发布一个刮削事件，形成多线程刮削。
但由于整理的是 海贼王 的根目录，因此每个线程都会处理多季。随着整理进度增加，越靠后的处理的越多。

目录结构大概这样：
海贼王
├── E0001-E1028
│   └── 海贼王 (1999)
│       ├── Season 1 东海篇
│       │   ├── 海贼王 One Piece 1999 S01E01 WEB-DL 1080P H.264.strm
│       │   └── 海贼王 One Piece 1999 S01E01 WEB-DL 1080P H.264.strm
│       ├── Season 10 恐怖三桅帆船篇
│       │   ├── 海贼王 One Piece 1999 S10E337 WEB-DL 1080P H.264.strm
│       │   └── 海贼王 One Piece 1999 S10E338 WEB-DL 1080P H.264.strm
├── E1029-E1031
│   ├── [OPFansMaplesnow][one_piece][1029][1080p].strm
│   ├── [OPFansMaplesnow][one_piece][1030][1080p].strm
│   └── [OPFansMaplesnow][one_piece][1031][1080p].strm

日志：
[scrape-1.log](https://github.com/user-attachments/files/17791483/scrape-1.log)


解决方案：
刮削时添加资源锁，每个资源同时只有一个线程处理（配合检测到nfo跳过可以确保只处理一次），同时仍然保留多线程的能力。


麻烦作者看看要不要把资源锁改到系统模块里