### PR TITLE
fix: 修复手动整理时, 自定义目录有时不生效的问题

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -131,7 +131,8 @@ class TransferChain(ChainBase):
                         extension=file_path.suffix.lstrip('.'),
                     ),
                     mediainfo=mediainfo,
-                    download_hash=torrent.hash
+                    download_hash=torrent.hash,
+                    src_match=True
                 )
 
                 # 设置下载任务状态
@@ -149,7 +150,7 @@ class TransferChain(ChainBase):
                       transfer_type: str = None, scrape: bool = None,
                       season: int = None, epformat: EpisodeFormat = None,
                       min_filesize: int = 0, download_hash: str = None,
-                      force: bool = False) -> Tuple[bool, str]:
+                      force: bool = False, src_match: bool = False) -> Tuple[bool, str]:
         """
         执行一个复杂目录的整理操作
         :param fileitem: 文件项
@@ -165,6 +166,7 @@ class TransferChain(ChainBase):
         :param min_filesize: 最小文件大小(MB)
         :param download_hash: 下载记录hash
         :param force: 是否强制整理
+        :param src_match: 是否源目录匹配
         返回：成功标识，错误信息
         """
 
@@ -391,11 +393,15 @@ class TransferChain(ChainBase):
                 # 指定了`目标目录`
                 if target_path:
                     target_directory = self.directoryhelper.get_dir(media=file_mediainfo, 
-                                                                    storage=file_item.storage, dest_path=target_path)
+                                                                    storage=target_storage, dest_path=target_path)
+                # 源目录匹配
+                elif src_match:
+                    target_directory = self.directoryhelper.get_dir(media=file_mediainfo,
+                                                                    storage=file_item.storage, src_path=target_path)
                 # 未指定`目标目录`
                 else:
                     target_directory = self.directoryhelper.get_dir(media=file_mediainfo,
-                                                                    storage=file_item.storage, src_path=file_path)
+                                                                    storage=target_storage, src_path=file_path)
             # 执行整理
             transferinfo: TransferInfo = self.transfer(fileitem=file_item,
                                                        meta=file_meta,

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -131,8 +131,7 @@ class TransferChain(ChainBase):
                         extension=file_path.suffix.lstrip('.'),
                     ),
                     mediainfo=mediainfo,
-                    download_hash=torrent.hash,
-                    src_match=True
+                    download_hash=torrent.hash
                 )
 
                 # 设置下载任务状态
@@ -150,7 +149,7 @@ class TransferChain(ChainBase):
                       transfer_type: str = None, scrape: bool = None,
                       season: int = None, epformat: EpisodeFormat = None,
                       min_filesize: int = 0, download_hash: str = None,
-                      force: bool = False, src_match: bool = False) -> Tuple[bool, str]:
+                      force: bool = False) -> Tuple[bool, str]:
         """
         执行一个复杂目录的整理操作
         :param fileitem: 文件项
@@ -166,7 +165,6 @@ class TransferChain(ChainBase):
         :param min_filesize: 最小文件大小(MB)
         :param download_hash: 下载记录hash
         :param force: 是否强制整理
-        :param src_match: 是否源目录匹配
         返回：成功标识，错误信息
         """
 
@@ -390,15 +388,14 @@ class TransferChain(ChainBase):
 
             # 查询整理目标目录
             if not target_directory:
+                # 指定了`目标目录`
                 if target_path:
-                    target_directory = self.directoryhelper.get_dir(file_mediainfo,
-                                                                    storage=target_storage, dest_path=target_path)
-                elif src_match:
-                    target_directory = self.directoryhelper.get_dir(file_mediainfo,
-                                                                    storage=file_item.storage, src_path=file_path)
+                    target_directory = self.directoryhelper.get_dir(media=file_mediainfo, 
+                                                                    storage=file_item.storage, dest_path=target_path)
+                # 未指定`目标目录`
                 else:
-                    target_directory = self.directoryhelper.get_dir(file_mediainfo)
-
+                    target_directory = self.directoryhelper.get_dir(media=file_mediainfo,
+                                                                    storage=file_item.storage, src_path=file_path)
             # 执行整理
             transferinfo: TransferInfo = self.transfer(fileitem=file_item,
                                                        meta=file_meta,

--- a/app/helper/directory.py
+++ b/app/helper/directory.py
@@ -79,9 +79,8 @@ class DirectoryHelper:
             if src_path and not src_path.is_relative_to(download_path):
                 continue
             # 有目标目录时，目标目录不匹配媒体库目录
-            if dest_path:
-                if library_path != dest_path or not d.monitor_type:
-                    continue
+            if dest_path and library_path != dest_path:
+                continue
             # 目录类型为全部的，符合条件
             if not d.media_type:
                 return d

--- a/app/helper/directory.py
+++ b/app/helper/directory.py
@@ -49,15 +49,13 @@ class DirectoryHelper:
         return [d for d in self.get_library_dirs() if d.library_storage == "local"]
 
     def get_dir(self, media: MediaInfo, storage: str = "local",
-                src_path: Path = None, dest_path: Path = None, fileitem: schemas.FileItem = None
-                ) -> Optional[schemas.TransferDirectoryConf]:
+                src_path: Path = None, dest_path: Path = None) -> Optional[schemas.TransferDirectoryConf]:
         """
         根据媒体信息获取下载目录、媒体库目录配置
         :param media: 媒体信息
         :param storage: 存储类型
         :param src_path: 源目录，有值时直接匹配
         :param dest_path: 目标目录，有值时直接匹配
-        :param fileitem: 文件项，使用文件路径匹配
         """
         # 处理类型
         if not media:
@@ -80,12 +78,10 @@ class DirectoryHelper:
             # 有源目录时，源目录不匹配下载目录
             if src_path and not src_path.is_relative_to(download_path):
                 continue
-            # 有文件项时，文件项不匹配下载目录
-            if fileitem and not Path(fileitem.path).is_relative_to(download_path):
-                continue
             # 有目标目录时，目标目录不匹配媒体库目录
-            if dest_path and not dest_path.is_relative_to(library_path):
-                continue
+            if dest_path:
+                if library_path != dest_path or not d.monitor_type:
+                    continue
             # 目录类型为全部的，符合条件
             if not d.media_type:
                 return d


### PR DESCRIPTION
出现问题的场景为`自定义目录`为一个已设置`媒体库目录`的`子目录`
现判断逻辑修改如下:
- `源目录/下载目录`仅在`自动整理`时用于关联`媒体库目录`，支持子目录。
-` 媒体库目录`仅在用户`主动触发`时作为判断依据，不支持子目录。