### PR TITLE
feat(qb): add support for ignoring category check via kwargs

### DIFF
--- a/app/modules/qbittorrent/__init__.py
+++ b/app/modules/qbittorrent/__init__.py
@@ -124,7 +124,8 @@ class QbittorrentModule(_ModuleBase, _DownloaderBase[Qbittorrent]):
             is_paused=is_paused,
             tag=tags,
             cookie=cookie,
-            category=category
+            category=category,
+            ignore_category_check=False
         )
         if not state:
             # 读取种子的名称

--- a/app/modules/qbittorrent/qbittorrent.py
+++ b/app/modules/qbittorrent/qbittorrent.py
@@ -251,6 +251,7 @@ class Qbittorrent:
         :param category: 种子分类
         :param download_dir: 下载路径
         :param cookie: 站点Cookie用于辅助下载种子
+        :param kwargs: 可选参数，如 ignore_category_check 以及 QB相关参数
         :return: bool
         """
         if not self.qbc or not content:
@@ -276,13 +277,16 @@ class Qbittorrent:
         else:
             tags = None
 
-        # 分类自动管理
-        if category and self._category:
-            is_auto = True
+        # 如果忽略分类检查，则直接使用传入的分类值，否则，仅在分类存在且启用了自动管理时才传递参数
+        ignore_category_check = kwargs.pop("ignore_category_check", True)
+        if ignore_category_check:
+            is_auto = self._category
         else:
-            is_auto = False
-            category = None
-
+            if category and self._category:
+                is_auto = True
+            else:
+                is_auto = False
+                category = None
         try:
             # 添加下载
             qbc_ret = self.qbc.torrents_add(urls=urls,


### PR DESCRIPTION
-  在 `qb` 模块新增了可选参数 `ignore_category_check`，默认值为 `True`。该参数用于控制是否忽略分类检查，直接使用传入的分类值
-  对于通过主程序 `download` 添加的种子，仍然保留现有逻辑：仅在分类存在且启用了自动管理时才传递分类参数
- 该 PR 将直接影响插件中的调用逻辑，默认将忽略分类检查，插件可根据需求显式传递 `ignore_category_check` 参数