### PR TITLE
resolve: jxxghp/MoviePilot-Frontend#247

### DIFF
--- a/app/chain/download.py
+++ b/app/chain/download.py
@@ -256,7 +256,7 @@ class DownloadChain(ChainBase):
             download_dir = Path(save_path)
         else:
             # 根据媒体信息查询下载目录配置
-            dir_info = self.directoryhelper.get_dir(_media)
+            dir_info = self.directoryhelper.get_dir(_media, storage="local")
             # 拼装子目录
             if dir_info:
                 # 一级目录

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -392,12 +392,18 @@ class TransferChain(ChainBase):
                     download_hash = download_file.download_hash
 
             # 查询整理目标目录
-            if not target_directory and not target_path:
+            if not target_directory:
                 if src_match:
                     # 按源目录匹配，以便找到更合适的目录配置
-                    target_directory = self.directoryhelper.get_dir(file_mediainfo,
+                    target_directory = self.directoryhelper.get_dir(media=file_mediainfo,
                                                                     storage=file_item.storage,
                                                                     src_path=file_path,
+                                                                    target_storage=target_storage)
+                elif target_path:
+                    # 指定目标路径，`手动整理`场景下使用，忽略源目录匹配，使用指定目录匹配
+                    target_directory = self.directoryhelper.get_dir(media=file_mediainfo,
+                                                                    storage=target_storage,
+                                                                    target_path=target_path,
                                                                     target_storage=target_storage)
                 else:
                     # 未指定目标路径，根据媒体信息获取目标目录

--- a/app/helper/directory.py
+++ b/app/helper/directory.py
@@ -50,8 +50,8 @@ class DirectoryHelper:
         return [d for d in self.get_library_dirs() if d.library_storage == "local"]
 
     def get_dir(self, media: MediaInfo,
-                storage: str = "local", fileitem: schemas.FileItem = None, src_path: Path = None,
-                target_storage: str = "local", dest_path: Path = None
+                storage: str = None, src_path: Path = None,
+                target_storage: str = None, dest_path: Path = None
                 ) -> Optional[schemas.TransferDirectoryConf]:
         """
         根据媒体信息获取下载目录、媒体库目录配置
@@ -69,7 +69,7 @@ class DirectoryHelper:
         media_type = media.type.value
         dirs = self.get_dirs()
         # 已匹配的目录
-        matched_dirs = []
+        matched_dirs: List[schemas.TransferDirectoryConf] = []
         # 按照配置顺序查找
         for d in dirs:
             # 没有启用整理的目录
@@ -81,17 +81,11 @@ class DirectoryHelper:
             # 目标存储类型不匹配
             if target_storage and d.library_storage != target_storage:
                 continue
-            # 有文件项时，源存储不匹配
-            if fileitem and fileitem.storage != d.storage:
-                continue
-            # 有文件项时，文件项不匹配下载目录
-            if fileitem and not Path(fileitem.path).is_relative_to(d.download_path):
-                continue
             # 有源目录时，源目录不匹配下载目录
             if src_path and not src_path.is_relative_to(d.download_path):
                 continue
             # 有目标目录时，目标目录不匹配媒体库目录
-            if dest_path and not dest_path.is_relative_to(d.library_path):
+            if dest_path and dest_path != Path(d.library_path):
                 continue
             # 目录类型为全部的，符合条件
             if not d.media_type:


### PR DESCRIPTION
resolve jxxghp/MoviePilot-Frontend#247
### 处理逻辑:
`目录配置` 为`假`(目前仅`目录监控`有传入)， 进行目录匹配
- 源目录匹配 使用文件路径匹配, `同盘优先`使用`文件自身`的`存储类型`
- `媒体目录`匹配 处理`手动整理`的场景, 使用用户选择的`目的路径`和`目的存储`匹配
- - 有返回值使用分类策略创建目录, 用户指定的分类优先
- - None使用用户设定的`自定义目录`, 使用`手动整理`时设置的分类创建目录
- 自动匹配 处理 `手动整理` 目的路径留空和其他的场景