### PR TITLE
将订阅规则过滤前置，避免因imdbid匹配而跳过

### DIFF
--- a/app/chain/search.py
+++ b/app/chain/search.py
@@ -221,6 +221,12 @@ class SearchChain(ChainBase):
                                      key=ProgressKey.Search)
                 if not torrent.title:
                     continue
+
+                # 匹配订阅附加参数
+                if filter_params and not self.torrenthelper.filter_torrent(torrent_info=torrent,
+                                                                           filter_params=filter_params):
+                    continue
+
                 # 识别元数据
                 torrent_meta = MetaInfo(title=torrent.title, subtitle=torrent.description,
                                         custom_words=custom_words)
@@ -232,11 +238,6 @@ class SearchChain(ChainBase):
                         and torrent.imdbid == mediainfo.imdb_id:
                     logger.info(f'{mediainfo.title} 通过IMDBID匹配到资源：{torrent.site_name} - {torrent.title}')
                     _match_torrents.append((torrent, torrent_meta))
-                    continue
-
-                # 匹配订阅附加参数
-                if filter_params and not self.torrenthelper.filter_torrent(torrent_info=torrent,
-                                                                           filter_params=filter_params):
                     continue
 
                 # 比对种子


### PR DESCRIPTION
fix #3190

bug发生时的log
```
【INFO】2024-11-21 21:53:34,099 - search.py - 过滤规则/剧集过滤完成，剩余 2 个资源
【INFO】2024-11-21 21:53:34,100 - search.py - 开始匹配结果 标题：豺狼的日子，原标题：The Day of the Jackal，别名：['Sjakalen', 'يوم إبن آوى', '자칼의 날', 'Dzień Szakala', 'A sakál napja', 'Chacal', 'התן', 'День Шакала', '豺狼的日子', 'The Day of the Jackal', '豺狼之日', 'El Chacal', 'Денят на Чакала', 'Ziua șacalului', 'Дан Шакала', 'روز شغال', 'O Dia do Chacal']
【INFO】2024-11-21 21:53:34,227 - search.py - 豺狼的日子 通过IMDBID匹配到资源：馒头 - The Day Of The Jackal S01E06 2160p NOW WEB-DL DDP5 1 Atmos H 265-FLUX
【INFO】2024-11-21 21:53:34,361 - torrent.py - The Day Of The Jackal S01E06 2160p NOW WEB-DL DDP5 1 Atmos H 265-FLUX 不匹配特效规则 [\s.]+HDR[\s.]+|HDR10|HDR10\+
【INFO】2024-11-21 21:53:34,362 - search.py - 匹配完成，共匹配到 1 个资源
【INFO】2024-11-21 21:53:34,366 - search.py - 搜索完成，共 1 个资源
【INFO】2024-11-21 21:53:34,369 - download.py - 开始匹配电视剧整季：{222766: {1: NotExistMediaInfo(season=1, episodes=[6, 7, 8, 9, 10], total_episode=10, start_episode=6)}}
【INFO】2024-11-21 21:53:34,370 - download.py - 缺失整季：{}
【INFO】2024-11-21 21:53:34,371 - download.py - 开始电视剧完整集匹配：{222766: {1: NotExistMediaInfo(season=1, episodes=[6, 7, 8, 9, 10], total_episode=10, start_episode=6)}}
【INFO】2024-11-21 21:53:34,373 - download.py - 开始下载 The Day Of The Jackal S01E06 2160p NOW WEB-DL DDP5 1 Atmos H 265-FLUX ...
```