### PR TITLE
`不整理`目录的`下载路径`可以被下载器获取

### DIFF
--- a/app/chain/download.py
+++ b/app/chain/download.py
@@ -256,7 +256,7 @@ class DownloadChain(ChainBase):
             download_dir = Path(save_path)
         else:
             # 根据媒体信息查询下载目录配置
-            dir_info = self.directoryhelper.get_dir(_media, storage="local")
+            dir_info = self.directoryhelper.get_dir(_media, storage="local", include_unsorted=True)
             # 拼装子目录
             if dir_info:
                 # 一级目录

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -407,7 +407,7 @@ class TransferChain(ChainBase):
                 else:
                     # 未指定目标路径，根据媒体信息获取目标目录
                     target_directory = self.directoryhelper.get_dir(file_mediainfo,
-                                                                    storage=target_storage,
+                                                                    storage=file_item.storage,
                                                                     target_storage=target_storage)
 
             # 执行整理

--- a/app/helper/directory.py
+++ b/app/helper/directory.py
@@ -49,13 +49,14 @@ class DirectoryHelper:
         """
         return [d for d in self.get_library_dirs() if d.library_storage == "local"]
 
-    def get_dir(self, media: MediaInfo,
+    def get_dir(self, media: MediaInfo, include_unsorted: bool = False,
                 storage: str = None, src_path: Path = None,
                 target_storage: str = None, dest_path: Path = None
                 ) -> Optional[schemas.TransferDirectoryConf]:
         """
         根据媒体信息获取下载目录、媒体库目录配置
         :param media: 媒体信息
+        :param include_unsorted: 包含不整理目录
         :param storage: 源存储类型
         :param target_storage: 目标存储类型
         :param fileitem: 文件项，使用文件路径匹配
@@ -68,14 +69,12 @@ class DirectoryHelper:
         # 电影/电视剧
         media_type = media.type.value
         dirs = self.get_dirs()
-        # 是否下载器匹配
-        not_downloader: bool = src_path or dest_path or target_storage
         # 已匹配的目录
         matched_dirs: List[schemas.TransferDirectoryConf] = []
         # 按照配置顺序查找
         for d in dirs:
             # 没有启用整理的目录
-            if not d.monitor_type and not_downloader:
+            if not d.monitor_type and not include_unsorted:
                 continue
             # 源存储类型不匹配
             if storage and d.storage != storage:

--- a/app/helper/directory.py
+++ b/app/helper/directory.py
@@ -68,12 +68,14 @@ class DirectoryHelper:
         # 电影/电视剧
         media_type = media.type.value
         dirs = self.get_dirs()
+        # 是否下载器匹配
+        not_downloader: bool = src_path or dest_path or target_storage
         # 已匹配的目录
         matched_dirs: List[schemas.TransferDirectoryConf] = []
         # 按照配置顺序查找
         for d in dirs:
             # 没有启用整理的目录
-            if not d.monitor_type:
+            if not d.monitor_type and not_downloader:
                 continue
             # 源存储类型不匹配
             if storage and d.storage != storage:


### PR DESCRIPTION
fix: #3233
修改自动匹配源存储器类型入参