### PR TITLE
fix(transfer): add library type and category folder support

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -759,6 +759,8 @@ class TransferChain(ChainBase):
                                                epformat=epformat,
                                                min_filesize=min_filesize,
                                                scrape=scrape,
+                                               library_type_folder=library_type_folder,
+                                               library_category_folder=library_category_folder,
                                                force=force)
             return state, errmsg
 


### PR DESCRIPTION
- Add library_type_folder and library_category_folder parameters to the transfer function
- This enhances the transfer functionality by allowing sorting files into folders based on library type and category