### PR TITLE
feat(encoding): enhance encoding detection with confidence threshold

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -219,8 +219,8 @@ class ConfigModel(BaseModel):
     BIG_MEMORY_MODE: bool = False
     # 全局图片缓存，将媒体图片缓存到本地
     GLOBAL_IMAGE_CACHE: bool = False
-    # 是否启用编码探测的兼容模式
-    ENCODING_DETECTION_COMPATIBLE_MODE: bool = True
+    # 是否启用编码探测的性能模式
+    ENCODING_DETECTION_PERFORMANCE_MODE: bool = False
     # 编码探测的最低置信度阈值
     ENCODING_DETECTION_MIN_CONFIDENCE: float = 0.8
     # 允许的图片缓存域名

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -219,6 +219,10 @@ class ConfigModel(BaseModel):
     BIG_MEMORY_MODE: bool = False
     # 全局图片缓存，将媒体图片缓存到本地
     GLOBAL_IMAGE_CACHE: bool = False
+    # 是否启用编码探测的兼容模式
+    ENCODING_DETECTION_COMPATIBLE_MODE: bool = True
+    # 编码探测的最低置信度阈值
+    ENCODING_DETECTION_MIN_CONFIDENCE: float = 0.8
     # 允许的图片缓存域名
     SECURITY_IMAGE_DOMAINS: List[str] = Field(
         default_factory=lambda: ["image.tmdb.org",

--- a/app/modules/indexer/parser/__init__.py
+++ b/app/modules/indexer/parser/__init__.py
@@ -345,7 +345,7 @@ class SiteParserBase(metaclass=ABCMeta):
                         f"{self._site_name} 检测到Cloudflare，请更新Cookie和UA")
                     return ""
                 return RequestUtils.get_decoded_html_content(res,
-                                                             settings.ENCODING_DETECTION_COMPATIBLE_MODE,
+                                                             settings.ENCODING_DETECTION_PERFORMANCE_MODE,
                                                              settings.ENCODING_DETECTION_MIN_CONFIDENCE)
 
         return ""

--- a/app/modules/indexer/parser/__init__.py
+++ b/app/modules/indexer/parser/__init__.py
@@ -344,11 +344,9 @@ class SiteParserBase(metaclass=ABCMeta):
                     logger.warn(
                         f"{self._site_name} 检测到Cloudflare，请更新Cookie和UA")
                     return ""
-                if re.search(r"charset=\"?utf-8\"?", res.text, re.IGNORECASE):
-                    res.encoding = "utf-8"
-                else:
-                    res.encoding = res.apparent_encoding
-                return res.text
+                return RequestUtils.get_decoded_html_content(res,
+                                                             settings.ENCODING_DETECTION_COMPATIBLE_MODE,
+                                                             settings.ENCODING_DETECTION_MIN_CONFIDENCE)
 
         return ""
 

--- a/app/modules/indexer/spider/__init__.py
+++ b/app/modules/indexer/spider/__init__.py
@@ -250,7 +250,7 @@ class TorrentSpider:
                 proxies=self.proxies
             ).get_res(searchurl, allow_redirects=True)
             page_source = RequestUtils.get_decoded_html_content(ret,
-                                                                settings.ENCODING_DETECTION_COMPATIBLE_MODE,
+                                                                settings.ENCODING_DETECTION_PERFORMANCE_MODE,
                                                                 settings.ENCODING_DETECTION_MIN_CONFIDENCE)
 
         # 解析

--- a/app/utils/http.py
+++ b/app/utils/http.py
@@ -278,18 +278,18 @@ class RequestUtils:
 
     @staticmethod
     def detect_encoding_from_html_response(response: Response,
-                                           compatible_mode: bool = False, confidence_threshold: float = 0.8):
+                                           performance_mode: bool = False, confidence_threshold: float = 0.8):
         """
         根据HTML响应内容探测编码信息
 
         :param response: HTTP 响应对象
-        :param compatible_mode: 是否使用兼容模式，默认为 False (性能模式)
+        :param performance_mode: 是否使用性能模式，默认为 False (兼容模式)
         :param confidence_threshold: chardet 检测置信度阈值，默认为 0.8
         :return: 解析得到的字符编码
         """
         fallback_encoding = None
         try:
-            if compatible_mode:
+            if not performance_mode:
                 # 兼容模式：使用chardet分析后，再处理 BOM 和 meta 信息
                 # 1. 使用 chardet 库进一步分析内容
                 detection = chardet.detect(response.content)
@@ -349,12 +349,12 @@ class RequestUtils:
 
     @staticmethod
     def get_decoded_html_content(response: Response,
-                                 compatible_mode: bool = False, confidence_threshold: float = 0.8) -> str:
+                                 performance_mode: bool = False, confidence_threshold: float = 0.8) -> str:
         """
         获取HTML响应的解码文本内容
 
         :param response: HTTP 响应对象
-        :param compatible_mode: 是否使用兼容模式，默认为 False (性能模式)
+        :param performance_mode: 是否使用性能模式，默认为 False (兼容模式)
         :param confidence_threshold: chardet 检测置信度阈值，默认为 0.8
         :return: 解码后的响应文本内容
         """
@@ -363,7 +363,7 @@ class RequestUtils:
                 return ""
             if response.content:
                 # 1. 获取编码信息
-                encoding = (RequestUtils.detect_encoding_from_html_response(response, compatible_mode,
+                encoding = (RequestUtils.detect_encoding_from_html_response(response, performance_mode,
                                                                             confidence_threshold)
                             or response.apparent_encoding)
                 # 2. 根据解析得到的编码进行解码


### PR DESCRIPTION
1. 新增编码探测置信度策略
   - 通过新增的配置项优化编码探测逻辑，支持性能模式和兼容模式的切换
   
2. 新增配置项
  - `ENCODING_DETECTION_PERFORMANCE_MODE`：控制是否启用性能模式。默认情况下使用兼容模式，通过依次执行 `chardet` 分析、BOM 检测、HTML meta 标签解析及响应头解析来探测编码，适用于复杂编码场景，但可能略微降低性能。启用性能模式时，探测流程优先从响应头、BOM 检测和 HTML meta 标签获取编码信息，再通过 `chardet` 分析作为补充，以提升效率
   - `ENCODING_DETECTION_MIN_CONFIDENCE`：设置编码检测的置信度阈值，用于过滤低置信度结果。默认为 0.8

3. 优化探测流程
   - 在性能模式下优先从响应头、BOM 检测、HTML meta 标签中提取编码信息，提高解析性能
   - 在兼容模式下优先使用 `chardet` 分析结果及其他探测方式，进一步提高编码探测准确性
   - 增加 `fallback_encoding`，确保在探测失败时返回 `utf-8` 或置信度较低的推测结果
  
4. 更多
   - 目前仅优化了 HTML 内容的编码探测流程，待后续根据用户反馈进一步调整 RSS（XML）相关的编码探测逻辑