### PR TITLE
fix: 修复批量整理时`媒体库目录`匹配不正确的问题

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -395,18 +395,18 @@ class TransferChain(ChainBase):
             if not target_directory:
                 if src_match:
                     # 按源目录匹配，以便找到更合适的目录配置
-                    target_directory = self.directoryhelper.get_dir(media=file_mediainfo,
+                    dir_info = self.directoryhelper.get_dir(media=file_mediainfo,
                                                                     storage=file_item.storage,
                                                                     src_path=file_path,
                                                                     target_storage=target_storage)
                 elif target_path:
                     # 指定目标路径，`手动整理`场景下使用，忽略源目录匹配，使用指定目录匹配
-                    target_directory = self.directoryhelper.get_dir(media=file_mediainfo,
+                    dir_info = self.directoryhelper.get_dir(media=file_mediainfo,
                                                                     dest_path=target_path,
                                                                     target_storage=target_storage)
                 else:
                     # 未指定目标路径，根据媒体信息获取目标目录
-                    target_directory = self.directoryhelper.get_dir(file_mediainfo,
+                    dir_info = self.directoryhelper.get_dir(file_mediainfo,
                                                                     storage=file_item.storage,
                                                                     target_storage=target_storage)
 
@@ -414,7 +414,7 @@ class TransferChain(ChainBase):
             transferinfo: TransferInfo = self.transfer(fileitem=file_item,
                                                        meta=file_meta,
                                                        mediainfo=file_mediainfo,
-                                                       target_directory=target_directory,
+                                                       target_directory=target_directory or dir_info,
                                                        target_storage=target_storage,
                                                        target_path=target_path,
                                                        transfer_type=transfer_type,
@@ -693,8 +693,8 @@ class TransferChain(ChainBase):
                         epformat: EpisodeFormat = None,
                         min_filesize: int = 0,
                         scrape: bool = None,
-                        library_type_folder: bool = False,
-                        library_category_folder: bool = False,
+                        library_type_folder: bool = None,
+                        library_category_folder: bool = None,
                         force: bool = False) -> Tuple[bool, Union[str, list]]:
         """
         手动整理，支持复杂条件，带进度显示


### PR DESCRIPTION
fix: #3256