### PR TITLE
fix: return last record when get downloadhistory by hash

### DIFF
--- a/app/db/models/downloadhistory.py
+++ b/app/db/models/downloadhistory.py
@@ -53,7 +53,7 @@ class DownloadHistory(Base):
     @staticmethod
     @db_query
     def get_by_hash(db: Session, download_hash: str):
-        return db.query(DownloadHistory).filter(DownloadHistory.download_hash == download_hash).first()
+        return db.query(DownloadHistory).filter(DownloadHistory.download_hash == download_hash).last()
 
     @staticmethod
     @db_query


### PR DESCRIPTION
如果下载记录存在重复的情况下应该默认获取最后一条，通常情况这是和实际情况符合。因为没有记录映射关系，这是最小改动了

相关issue：https://github.com/jxxghp/MoviePilot/issues/3307