### PR TITLE
feat(modules): 增加子级 `type` 分类。

### DIFF
--- a/app/modules/__init__.py
+++ b/app/modules/__init__.py
@@ -2,8 +2,9 @@ from abc import abstractmethod, ABCMeta
 from typing import Generic, Tuple, Union, TypeVar, Type, Dict, Optional, Callable
 
 from app.helper.service import ServiceConfigHelper
-from app.schemas import Notification, MessageChannel, NotificationConf, MediaServerConf, DownloaderConf
-from app.schemas.types import ModuleType
+from app.schemas import Notification, NotificationConf, MediaServerConf, DownloaderConf
+from app.schemas.types import ModuleType, DownloaderType, MediaServerType, MessageChannel, StorageSchema, \
+    OtherModulesType
 
 
 class _ModuleBase(metaclass=ABCMeta):
@@ -40,6 +41,14 @@ class _ModuleBase(metaclass=ABCMeta):
     def get_type() -> ModuleType:
         """
         获取模块类型
+        """
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def get_subtype() -> Union[DownloaderType, MediaServerType, MessageChannel, StorageSchema, OtherModulesType]:
+        """
+        获取模块子类型（下载器、媒体服务器、消息通道、存储类型、其他杂项模块类型）
         """
         pass
 

--- a/app/modules/bangumi/__init__.py
+++ b/app/modules/bangumi/__init__.py
@@ -7,7 +7,7 @@ from app.core.meta import MetaBase
 from app.log import logger
 from app.modules import _ModuleBase
 from app.modules.bangumi.bangumi import BangumiApi
-from app.schemas.types import ModuleType
+from app.schemas.types import ModuleType, MediaRecognizeType
 from app.utils.http import RequestUtils
 
 
@@ -44,6 +44,13 @@ class BangumiModule(_ModuleBase):
         获取模块类型
         """
         return ModuleType.MediaRecognize
+
+    @staticmethod
+    def get_subtype() -> MediaRecognizeType:
+        """
+        获取模块子类型
+        """
+        return MediaRecognizeType.Bangumi
     
     @staticmethod
     def get_priority() -> int:

--- a/app/modules/douban/__init__.py
+++ b/app/modules/douban/__init__.py
@@ -15,7 +15,7 @@ from app.modules.douban.apiv2 import DoubanApi
 from app.modules.douban.douban_cache import DoubanCache
 from app.modules.douban.scraper import DoubanScraper
 from app.schemas import MediaPerson, APIRateLimitException
-from app.schemas.types import MediaType, ModuleType
+from app.schemas.types import MediaType, ModuleType, MediaRecognizeType
 from app.utils.common import retry
 from app.utils.http import RequestUtils
 from app.utils.limit import rate_limit_exponential
@@ -58,6 +58,13 @@ class DoubanModule(_ModuleBase):
         获取模块类型
         """
         return ModuleType.MediaRecognize
+
+    @staticmethod
+    def get_subtype() -> MediaRecognizeType:
+        """
+        获取模块子类型
+        """
+        return MediaRecognizeType.Douban
 
     @staticmethod
     def get_priority() -> int:

--- a/app/modules/emby/__init__.py
+++ b/app/modules/emby/__init__.py
@@ -7,7 +7,7 @@ from app.log import logger
 from app.modules import _MediaServerBase, _ModuleBase
 from app.modules.emby.emby import Emby
 from app.schemas.event import AuthCredentials, AuthInterceptCredentials
-from app.schemas.types import MediaType, ModuleType, ChainEventType
+from app.schemas.types import MediaType, ModuleType, ChainEventType, MediaServerType
 
 
 class EmbyModule(_ModuleBase, _MediaServerBase[Emby]):
@@ -29,6 +29,13 @@ class EmbyModule(_ModuleBase, _MediaServerBase[Emby]):
         获取模块类型
         """
         return ModuleType.MediaServer
+
+    @staticmethod
+    def get_subtype() -> MediaServerType:
+        """
+        获取模块子类型
+        """
+        return MediaServerType.Emby
 
     @staticmethod
     def get_priority() -> int:

--- a/app/modules/fanart/__init__.py
+++ b/app/modules/fanart/__init__.py
@@ -6,7 +6,7 @@ from cachetools import TTLCache, cached
 from app.core.context import MediaInfo, settings
 from app.log import logger
 from app.modules import _ModuleBase
-from app.schemas.types import MediaType, ModuleType
+from app.schemas.types import MediaType, ModuleType, OtherModulesType
 from app.utils.http import RequestUtils
 
 
@@ -342,6 +342,13 @@ class FanartModule(_ModuleBase):
         获取模块类型
         """
         return ModuleType.Other
+
+    @staticmethod
+    def get_subtype() -> OtherModulesType:
+        """
+        获取模块子类型
+        """
+        return OtherModulesType.Fanart
 
     @staticmethod
     def get_priority() -> int:

--- a/app/modules/filemanager/__init__.py
+++ b/app/modules/filemanager/__init__.py
@@ -18,7 +18,7 @@ from app.modules import _ModuleBase
 from app.modules.filemanager.storages import StorageBase
 from app.schemas import TransferInfo, ExistMediaInfo, TmdbEpisode, TransferDirectoryConf, FileItem, StorageUsage
 from app.schemas.event import TransferRenameEventData
-from app.schemas.types import MediaType, ModuleType, ChainEventType
+from app.schemas.types import MediaType, ModuleType, ChainEventType, OtherModulesType
 from app.utils.system import SystemUtils
 
 lock = Lock()
@@ -51,6 +51,13 @@ class FileManagerModule(_ModuleBase):
         获取模块类型
         """
         return ModuleType.Other
+
+    @staticmethod
+    def get_subtype() -> OtherModulesType:
+        """
+        获取模块子类型
+        """
+        return OtherModulesType.FileManager
 
     @staticmethod
     def get_priority() -> int:

--- a/app/modules/filter/__init__.py
+++ b/app/modules/filter/__init__.py
@@ -7,7 +7,7 @@ from app.helper.rule import RuleHelper
 from app.log import logger
 from app.modules import _ModuleBase
 from app.modules.filter.RuleParser import RuleParser
-from app.schemas.types import ModuleType
+from app.schemas.types import ModuleType, OtherModulesType
 from app.utils.string import StringUtils
 
 
@@ -166,6 +166,13 @@ class FilterModule(_ModuleBase):
         获取模块类型
         """
         return ModuleType.Other
+
+    @staticmethod
+    def get_subtype() -> OtherModulesType:
+        """
+        获取模块子类型
+        """
+        return OtherModulesType.Filter
 
     @staticmethod
     def get_priority() -> int:

--- a/app/modules/jellyfin/__init__.py
+++ b/app/modules/jellyfin/__init__.py
@@ -7,7 +7,7 @@ from app.log import logger
 from app.modules import _MediaServerBase, _ModuleBase
 from app.modules.jellyfin.jellyfin import Jellyfin
 from app.schemas.event import AuthCredentials, AuthInterceptCredentials
-from app.schemas.types import MediaType, ModuleType, ChainEventType
+from app.schemas.types import MediaType, ModuleType, ChainEventType, MediaServerType
 
 
 class JellyfinModule(_ModuleBase, _MediaServerBase[Jellyfin]):
@@ -29,6 +29,13 @@ class JellyfinModule(_ModuleBase, _MediaServerBase[Jellyfin]):
         获取模块类型
         """
         return ModuleType.MediaServer
+
+    @staticmethod
+    def get_subtype() -> MediaServerType:
+        """
+        获取模块子类型
+        """
+        return MediaServerType.Jellyfin
 
     @staticmethod
     def get_priority() -> int:

--- a/app/modules/plex/__init__.py
+++ b/app/modules/plex/__init__.py
@@ -7,7 +7,7 @@ from app.log import logger
 from app.modules import _ModuleBase, _MediaServerBase
 from app.modules.plex.plex import Plex
 from app.schemas.event import AuthCredentials, AuthInterceptCredentials
-from app.schemas.types import MediaType, ModuleType, ChainEventType
+from app.schemas.types import MediaType, ModuleType, ChainEventType, MediaServerType
 
 
 class PlexModule(_ModuleBase, _MediaServerBase[Plex]):
@@ -29,6 +29,13 @@ class PlexModule(_ModuleBase, _MediaServerBase[Plex]):
         获取模块类型
         """
         return ModuleType.MediaServer
+
+    @staticmethod
+    def get_subtype() -> MediaServerType:
+        """
+        获取模块子类型
+        """
+        return MediaServerType.Plex
 
     @staticmethod
     def get_priority() -> int:

--- a/app/modules/qbittorrent/__init__.py
+++ b/app/modules/qbittorrent/__init__.py
@@ -11,7 +11,7 @@ from app.log import logger
 from app.modules import _ModuleBase, _DownloaderBase
 from app.modules.qbittorrent.qbittorrent import Qbittorrent
 from app.schemas import TransferTorrent, DownloadingTorrent
-from app.schemas.types import TorrentStatus, ModuleType
+from app.schemas.types import TorrentStatus, ModuleType, DownloaderType
 from app.utils.string import StringUtils
 
 
@@ -34,6 +34,13 @@ class QbittorrentModule(_ModuleBase, _DownloaderBase[Qbittorrent]):
         获取模块类型
         """
         return ModuleType.Downloader
+
+    @staticmethod
+    def get_subtype() -> DownloaderType:
+        """
+        获取模块子类型
+        """
+        return DownloaderType.Qbittorrent
 
     @staticmethod
     def get_priority() -> int:

--- a/app/modules/slack/__init__.py
+++ b/app/modules/slack/__init__.py
@@ -32,6 +32,13 @@ class SlackModule(_ModuleBase, _MessageBase[Slack]):
         return ModuleType.Notification
 
     @staticmethod
+    def get_subtype() -> MessageChannel:
+        """
+        获取模块子类型
+        """
+        return MessageChannel.Slack
+
+    @staticmethod
     def get_priority() -> int:
         """
         获取模块优先级，数字越小优先级越高，只有同一接口下优先级才生效

--- a/app/modules/subtitle/__init__.py
+++ b/app/modules/subtitle/__init__.py
@@ -10,7 +10,7 @@ from app.core.context import Context
 from app.helper.torrent import TorrentHelper
 from app.log import logger
 from app.modules import _ModuleBase
-from app.schemas.types import ModuleType
+from app.schemas.types import ModuleType, OtherModulesType
 from app.utils.http import RequestUtils
 from app.utils.string import StringUtils
 from app.utils.system import SystemUtils
@@ -39,6 +39,13 @@ class SubtitleModule(_ModuleBase):
         获取模块类型
         """
         return ModuleType.Other
+
+    @staticmethod
+    def get_subtype() -> OtherModulesType:
+        """
+        获取模块子类型
+        """
+        return OtherModulesType.Subtitle
 
     @staticmethod
     def get_priority() -> int:

--- a/app/modules/synologychat/__init__.py
+++ b/app/modules/synologychat/__init__.py
@@ -30,6 +30,13 @@ class SynologyChatModule(_ModuleBase, _MessageBase[SynologyChat]):
         return ModuleType.Notification
 
     @staticmethod
+    def get_subtype() -> MessageChannel:
+        """
+        获取模块子类型
+        """
+        return MessageChannel.SynologyChat
+
+    @staticmethod
     def get_priority() -> int:
         """
         获取模块优先级，数字越小优先级越高，只有同一接口下优先级才生效

--- a/app/modules/telegram/__init__.py
+++ b/app/modules/telegram/__init__.py
@@ -35,6 +35,13 @@ class TelegramModule(_ModuleBase, _MessageBase[Telegram]):
         return ModuleType.Notification
 
     @staticmethod
+    def get_subtype() -> MessageChannel:
+        """
+        获取模块子类型
+        """
+        return MessageChannel.Telegram
+
+    @staticmethod
     def get_priority() -> int:
         """
         获取模块优先级，数字越小优先级越高，只有同一接口下优先级才生效

--- a/app/modules/themoviedb/__init__.py
+++ b/app/modules/themoviedb/__init__.py
@@ -14,7 +14,7 @@ from app.modules.themoviedb.scraper import TmdbScraper
 from app.modules.themoviedb.tmdb_cache import TmdbCache
 from app.modules.themoviedb.tmdbapi import TmdbApi
 from app.schemas import MediaPerson
-from app.schemas.types import MediaType, MediaImageType, ModuleType
+from app.schemas.types import MediaType, MediaImageType, ModuleType, MediaRecognizeType
 from app.utils.http import RequestUtils
 
 
@@ -48,6 +48,13 @@ class TheMovieDbModule(_ModuleBase):
         获取模块类型
         """
         return ModuleType.MediaRecognize
+
+    @staticmethod
+    def get_subtype() -> MediaRecognizeType:
+        """
+        获取模块子类型
+        """
+        return MediaRecognizeType.TMDB
 
     @staticmethod
     def get_priority() -> int:

--- a/app/modules/thetvdb/__init__.py
+++ b/app/modules/thetvdb/__init__.py
@@ -4,7 +4,7 @@ from app.core.config import settings
 from app.log import logger
 from app.modules import _ModuleBase
 from app.modules.thetvdb import tvdbapi
-from app.schemas.types import ModuleType
+from app.schemas.types import ModuleType, MediaRecognizeType
 from app.utils.http import RequestUtils
 
 
@@ -27,6 +27,13 @@ class TheTvDbModule(_ModuleBase):
         获取模块类型
         """
         return ModuleType.MediaRecognize
+
+    @staticmethod
+    def get_subtype() -> MediaRecognizeType:
+        """
+        获取模块子类型
+        """
+        return MediaRecognizeType.TVDB
 
     @staticmethod
     def get_priority() -> int:

--- a/app/modules/transmission/__init__.py
+++ b/app/modules/transmission/__init__.py
@@ -11,7 +11,7 @@ from app.log import logger
 from app.modules import _ModuleBase, _DownloaderBase
 from app.modules.transmission.transmission import Transmission
 from app.schemas import TransferTorrent, DownloadingTorrent
-from app.schemas.types import TorrentStatus, ModuleType
+from app.schemas.types import TorrentStatus, ModuleType, DownloaderType
 from app.utils.string import StringUtils
 
 
@@ -34,6 +34,13 @@ class TransmissionModule(_ModuleBase, _DownloaderBase[Transmission]):
         获取模块类型
         """
         return ModuleType.Downloader
+
+    @staticmethod
+    def get_subtype() -> DownloaderType:
+        """
+        获取模块子类型
+        """
+        return DownloaderType.Transmission
 
     @staticmethod
     def get_priority() -> int:

--- a/app/modules/vocechat/__init__.py
+++ b/app/modules/vocechat/__init__.py
@@ -31,6 +31,13 @@ class VoceChatModule(_ModuleBase, _MessageBase[VoceChat]):
         return ModuleType.Notification
 
     @staticmethod
+    def get_subtype() -> MessageChannel:
+        """
+        获取模块子类型
+        """
+        return MessageChannel.VoceChat
+
+    @staticmethod
     def get_priority() -> int:
         """
         获取模块优先级，数字越小优先级越高，只有同一接口下优先级才生效

--- a/app/modules/webpush/__init__.py
+++ b/app/modules/webpush/__init__.py
@@ -31,6 +31,13 @@ class WebPushModule(_ModuleBase, _MessageBase):
         return ModuleType.Notification
 
     @staticmethod
+    def get_subtype() -> MessageChannel:
+        """
+        获取模块子类型
+        """
+        return MessageChannel.WebPush
+
+    @staticmethod
     def get_priority() -> int:
         """
         获取模块优先级，数字越小优先级越高，只有同一接口下优先级才生效

--- a/app/modules/wechat/__init__.py
+++ b/app/modules/wechat/__init__.py
@@ -37,6 +37,13 @@ class WechatModule(_ModuleBase, _MessageBase[WeChat]):
         return ModuleType.Notification
 
     @staticmethod
+    def get_subtype() -> MessageChannel:
+        """
+        获取模块的子类型
+        """
+        return MessageChannel.Wechat
+
+    @staticmethod
     def get_priority() -> int:
         """
         获取模块优先级，数字越小优先级越高，只有同一接口下优先级才生效

--- a/app/schemas/types.py
+++ b/app/schemas/types.py
@@ -178,6 +178,50 @@ class MessageChannel(Enum):
     WebPush = "WebPush"
 
 
+# 下载器类型
+class DownloaderType(Enum):
+    # Qbittorrent
+    Qbittorrent = "Qbittorrent"
+    # Transmission
+    Transmission = "Transmission"
+    # Aria2
+    # Aria2 = "Aria2"
+
+
+# 媒体服务器类型
+class MediaServerType(Enum):
+    # Emby
+    Emby = "Emby"
+    # Jellyfin
+    Jellyfin = "Jellyfin"
+    # Plex
+    Plex = "Plex"
+
+
+# 识别器类型
+class MediaRecognizeType(Enum):
+    # 豆瓣
+    Douban = "豆瓣"
+    # TMDB
+    TMDB = "TheMovieDb"
+    # TVDB
+    TVDB = "TheTvDb"
+    # bangumi
+    Bangumi = "Bangumi"
+
+
+# 其他杂项模块类型
+class OtherModulesType(Enum):
+    # 字幕
+    Subtitle = "站点字幕"
+    # Fanart
+    Fanart = "Fanart"
+    # 文件整理
+    FileManager = "文件整理"
+    # 过滤器
+    Filter = "过滤器"
+
+
 # 用户配置Key字典
 class UserConfigKey(Enum):
     # 监控面板


### PR DESCRIPTION
- 在 `types` 里，针对各个模块的类型进行子级分类。
- 为每个模块统一添加 `get_subtype` 方法，这样一来，能更精准快速地区分与调用子类的每个模块，又能获取 ModuleType 所规定的分类以及对应存在的子模块类型支持列表，从而有效解决当下调用时需繁琐遍历每个 module 以获取 get_name 或 _channel 的问题。
- 解决因消息渠道前端返回所保存的 type 与后端规定值不一致，而需要频繁调用 _channel 私有方法才能获取分类所可能产生的问题。