### PR TITLE
fix(module): 补全 `indexer` 缺少的 `get_subtype` 方法

### DIFF
--- a/app/core/module.py
+++ b/app/core/module.py
@@ -1,11 +1,12 @@
 import traceback
-from typing import Generator, Optional, Tuple, Any
+from typing import Generator, Optional, Tuple, Any, Union
 
 from app.core.config import settings
 from app.core.event import eventmanager
 from app.helper.module import ModuleHelper
 from app.log import logger
-from app.schemas.types import EventType, ModuleType
+from app.schemas.types import EventType, ModuleType, DownloaderType, MediaServerType, MessageChannel, StorageSchema, \
+    OtherModulesType
 from app.utils.object import ObjectUtils
 from app.utils.singleton import Singleton
 
@@ -19,6 +20,8 @@ class ModuleManager(metaclass=Singleton):
     _modules: dict = {}
     # 运行态模块列表
     _running_modules: dict = {}
+    # 子模块类型集合
+    SubType = Union[DownloaderType, MediaServerType, MessageChannel, StorageSchema, OtherModulesType]
 
     def __init__(self):
         self.load_modules()
@@ -133,6 +136,17 @@ class ModuleManager(metaclass=Singleton):
         for _, module in self._running_modules.items():
             if hasattr(module, 'get_type') \
                     and module.get_type() == module_type:
+                yield module
+
+    def get_running_subtype_module(self, module_subtype: SubType) -> Generator:
+        """
+        获取指定子类型的模块
+        """
+        if not self._running_modules:
+            return []
+        for _, module in self._running_modules.items():
+            if hasattr(module, 'get_subtype') \
+                    and module.get_subtype() == module_subtype:
                 yield module
 
     def get_module(self, module_id: str) -> Any:

--- a/app/modules/indexer/__init__.py
+++ b/app/modules/indexer/__init__.py
@@ -18,7 +18,7 @@ from app.modules.indexer.spider.tnode import TNodeSpider
 from app.modules.indexer.spider.torrentleech import TorrentLeech
 from app.modules.indexer.spider.yema import YemaSpider
 from app.schemas import SiteUserData
-from app.schemas.types import MediaType, ModuleType
+from app.schemas.types import MediaType, ModuleType, OtherModulesType
 from app.utils.string import StringUtils
 
 
@@ -46,6 +46,13 @@ class IndexerModule(_ModuleBase):
         获取模块类型
         """
         return ModuleType.Indexer
+
+    @staticmethod
+    def get_subtype() -> OtherModulesType:
+        """
+        获取模块子类型
+        """
+        return OtherModulesType.Indexer
 
     @staticmethod
     def get_priority() -> int:

--- a/app/schemas/types.py
+++ b/app/schemas/types.py
@@ -220,6 +220,8 @@ class OtherModulesType(Enum):
     FileManager = "文件整理"
     # 过滤器
     Filter = "过滤器"
+    # 站点索引
+    Indexer = "站点索引"
 
 
 # 用户配置Key字典


### PR DESCRIPTION
- 补全 `indexer` 缺少 `get_subtype` 方法。
- 增加 `get_running_subtype_module` 方法，可结合 `types` 快速获取单个运行中的 `module` 。