### PR TITLE
feat(common): 增加 `version_comparison` 方法

### DIFF
--- a/app/schemas/exception.py
+++ b/app/schemas/exception.py
@@ -29,3 +29,15 @@ class RateLimitExceededException(LimitException):
     这个异常通常用于本地限流逻辑（例如 RateLimiter），当系统检测到函数调用频率过高时，触发限流并抛出该异常。
     """
     pass
+
+
+class VersionComparisonException(ImmediateException):
+    """
+    用于汇报版本号比对的异常类。
+    当版本号不符合要求时，可以抛出此异常以停止操作并报告错误。
+    这个异常通常用于版本比对检查逻辑，
+    当系统检测到版本不符合要求时，触发异常并终止操作。
+    当插件设置的最低或最高支持版本高于当前主程序版本时，可以抛出此异常以停止插件加载。
+    """
+    pass
+

--- a/app/utils/common.py
+++ b/app/utils/common.py
@@ -44,7 +44,7 @@ def retry(ExceptionToCheck: Any,
 def version_comparison(standard_version) -> Optional[bool]:
     """
     版本比对
-    :param
+    :param standard_version: 指定版本号
     return: True - 当前版本大于等于输入版本，False - 当前版本输入标准版本, None - 版本比对失败
 
     - 可用于给插件或主程序进行版本比对使用，判断是否使用新特性，用于兼容旧版本主程序

--- a/app/utils/common.py
+++ b/app/utils/common.py
@@ -1,7 +1,10 @@
+import re
 import time
-from typing import Any
+from typing import Any, Optional
 
+from app.log import logger
 from app.schemas import ImmediateException
+from version import APP_VERSION
 
 
 def retry(ExceptionToCheck: Any,
@@ -36,3 +39,48 @@ def retry(ExceptionToCheck: Any,
         return f_retry
 
     return deco_retry
+
+
+def version_comparison(standard_version) -> Optional[bool]:
+    """
+    版本比对
+    :param
+    return: True - 当前版本大于等于输入版本，False - 当前版本输入标准版本, None - 版本比对失败
+
+    - 可用于给插件或主程序进行版本比对使用，判断是否使用新特性，用于兼容旧版本主程序
+    """
+    try:
+        app_version = APP_VERSION
+
+        def preprocess_version(version):
+            """
+            预处理版本号，去除首尾空字符串与换行符，去除开头大小写v，并拆分版本号
+            """
+            version = version.strip().lstrip('vV')
+            return re.split(r'[.-]', version)
+
+        def conversion_version(version_list):
+            """
+            英文字符转换为数字，stable=-1，rc=-2，beta=-3，alpha=-4，其余不符合的都为-5
+            """
+            version_map = {"stable": -1, "rc": -2, "beta": -3, "alpha": -4}
+            return [int(item) if item.isdigit() else version_map.get(item, -5) for item in version_list]
+
+        app_version_list = conversion_version(preprocess_version(version=app_version))
+        standard_version_list = conversion_version(preprocess_version(version=standard_version))
+
+        # 补全版本号位置，保持长度一致
+        max_length = max(len(app_version_list), len(standard_version_list))
+        app_version_list += [0] * (max_length - len(app_version_list))
+        standard_version_list += [0] * (max_length - len(standard_version_list))
+
+        for a, s in zip(app_version_list, standard_version_list):
+            if a > s:
+                return True
+            elif a < s:
+                return False
+        # 版本号相同
+        return True
+    except Exception as e:
+        logger.error(f"版本比对失败 - {str(e)}", exc_info=True)
+        return None

--- a/app/utils/common.py
+++ b/app/utils/common.py
@@ -77,18 +77,20 @@ def version_comparison(standard_version: str = APP_VERSION, app_version: str = A
 
                 for a, s in zip(app_version_list, standard_version_list):
                     # 最低版本
-                    if mode == "min" and a < s:
-                        raise VersionComparisonException(f"当前版本 {app_version} 小于标准版本 {standard_version}！")
+                    if mode == "min":
+                        if a < s:
+                            raise VersionComparisonException(f"当前版本 {app_version} 小于标准版本 {standard_version}！")
                     # 最高版本
-                    elif mode == "max" and a > s:
-                        raise VersionComparisonException(f"当前版本 {app_version} 大于标准版本 {standard_version}！")
+                    elif mode == "max":
+                        if a > s:
+                            raise VersionComparisonException(f"当前版本 {app_version} 大于标准版本 {standard_version}！")
                     # 匹配版本
-                    elif mode == "equal" and a != s:
-                        raise VersionComparisonException(
-                            f"当前版本 {app_version} 与指定标准版本 {standard_version} 不匹配！")
+                    elif mode == "equal":
+                        if a != s:
+                            raise VersionComparisonException(f"当前版本 {app_version} 与指定版本 {standard_version} 不匹配！")
                     # 异常的模式
                     else:
-                        raise VersionComparisonException(f"设置的版本比对模式 {mode} 不是有效的模式！")
+                        raise ValueError(f"设置的版本比对模式 {mode} 不是有效的模式！")
                 # 完成版本比对，允许执行函数
                 return f(*args, **kwargs)
 

--- a/app/utils/common.py
+++ b/app/utils/common.py
@@ -1,9 +1,8 @@
 import re
 import time
-from typing import Any, Optional
+from typing import Any
 
-from app.log import logger
-from app.schemas import ImmediateException
+from app.schemas import ImmediateException, VersionComparisonException
 from version import APP_VERSION
 
 
@@ -41,46 +40,66 @@ def retry(ExceptionToCheck: Any,
     return deco_retry
 
 
-def version_comparison(standard_version) -> Optional[bool]:
+def version_comparison(standard_version: str = APP_VERSION, app_version: str = APP_VERSION, mode: str = "min",
+                       logger: Any = None):
     """
     版本比对
-    :param standard_version: 指定版本号
-    return: True - 当前版本大于等于输入版本，False - 当前版本输入标准版本, None - 版本比对失败
-
-    - 可用于给插件或主程序进行版本比对使用，判断是否使用新特性，用于兼容旧版本主程序
+    :param standard_version: 标准版本号
+    :param app_version: 当前版本号
+    :param mode: 兼容识别最低版本，最高版本使用。可选值：max = 最高版本；min = 最低版本； equal = 匹配指定版本；默认为最低版本
+    :param logger: 日志对象
     """
-    try:
-        app_version = APP_VERSION
 
-        def preprocess_version(version):
-            """
-            预处理版本号，去除首尾空字符串与换行符，去除开头大小写v，并拆分版本号
-            """
-            version = version.strip().lstrip('vV')
-            return re.split(r'[.-]', version)
+    def deco_retry(f):
+        def f_retry(*args, **kwargs):
+            try:
+                def preprocess_version(version):
+                    """
+                    预处理版本号，去除首尾空字符串与换行符，去除开头大小写v，并拆分版本号
+                    """
+                    version = version.strip().lstrip('vV')
+                    return re.split(r'[.-]', version)
 
-        def conversion_version(version_list):
-            """
-            英文字符转换为数字，stable=-1，rc=-2，beta=-3，alpha=-4，其余不符合的都为-5
-            """
-            version_map = {"stable": -1, "rc": -2, "beta": -3, "alpha": -4}
-            return [int(item) if item.isdigit() else version_map.get(item, -5) for item in version_list]
+                def conversion_version(version_list):
+                    """
+                    英文字符转换为数字，stable=-1，rc=-2，beta=-3，alpha=-4，其余不符合的都为-5
+                    """
+                    version_map = {"stable": -1, "rc": -2, "beta": -3, "alpha": -4}
+                    return [int(item) if item.isdigit() else version_map.get(item, -5) for item in version_list]
 
-        app_version_list = conversion_version(preprocess_version(version=app_version))
-        standard_version_list = conversion_version(preprocess_version(version=standard_version))
+                app_version_list = conversion_version(preprocess_version(version=app_version))
+                standard_version_list = conversion_version(preprocess_version(version=standard_version))
 
-        # 补全版本号位置，保持长度一致
-        max_length = max(len(app_version_list), len(standard_version_list))
-        app_version_list += [0] * (max_length - len(app_version_list))
-        standard_version_list += [0] * (max_length - len(standard_version_list))
+                # 补全版本号位置，保持长度一致
+                max_length = max(len(app_version_list), len(standard_version_list))
+                app_version_list += [0] * (max_length - len(app_version_list))
+                standard_version_list += [0] * (max_length - len(standard_version_list))
 
-        for a, s in zip(app_version_list, standard_version_list):
-            if a > s:
-                return True
-            elif a < s:
-                return False
-        # 版本号相同
-        return True
-    except Exception as e:
-        logger.error(f"版本比对失败 - {str(e)}", exc_info=True)
-        return None
+                for a, s in zip(app_version_list, standard_version_list):
+                    # 最低版本
+                    if mode == "min" and a < s:
+                        raise VersionComparisonException(f"当前版本 {app_version} 小于标准版本 {standard_version}！")
+                    # 最高版本
+                    elif mode == "max" and a > s:
+                        raise VersionComparisonException(f"当前版本 {app_version} 大于标准版本 {standard_version}！")
+                    # 匹配版本
+                    elif mode == "equal" and a != s:
+                        raise VersionComparisonException(
+                            f"当前版本 {app_version} 与指定标准版本 {standard_version} 不匹配！")
+                    # 异常的模式
+                    else:
+                        raise VersionComparisonException(f"设置的版本比对模式 {mode} 不是有效的模式！")
+                # 完成版本比对，允许执行函数
+                return f(*args, **kwargs)
+
+            except VersionComparisonException as e:
+                logger.error(e) if logger else print(e)
+                raise
+            except Exception as e:
+                msg = f"版本比对失败 - {str(e)}"
+                logger.error(msg, exc_info=True) if logger else print(msg)
+                raise
+
+        return f_retry
+
+    return deco_retry


### PR DESCRIPTION
- 可用于给插件或主程序进行版本比对使用，判断是否使用新特性；适用场景：插件只支持某个版本以上；插件更新版本号比对更规范，贴近 `app` 版本号要求等。