### PR TITLE
让电影里对 part 的识别生效

### DIFF
--- a/app/core/meta/metavideo.py
+++ b/app/core/meta/metavideo.py
@@ -309,11 +309,7 @@ class MetaVideo(MetaBase):
         """
         if not self.name:
             return
-        if not self.year \
-                and not self.begin_season \
-                and not self.begin_episode \
-                and not self.resource_pix \
-                and not self.resource_type:
+        if not self.year:
             return
         re_res = re.search(r"%s" % self._part_re, token, re.IGNORECASE)
         if re_res:


### PR DESCRIPTION
之前判断了 begin_episode  和 begin_season  导致 Part 对 movie 不生效。也不知道这算 bug 还是 feature。毕竟文档里 part 是在 movie 这一类的