### PR TITLE
feat(subscribe): add Pending and Suspended subscription states

### DIFF
--- a/app/api/endpoints/subscribe.py
+++ b/app/api/endpoints/subscribe.py
@@ -124,6 +124,27 @@ def update_subscribe(
     return schemas.Response(success=True)
 
 
+@router.put("/status/{subid}", summary="更新订阅状态", response_model=schemas.Response)
+def update_subscribe_status(
+        subid: int,
+        state: str,
+        db: Session = Depends(get_db),
+        _: schemas.TokenPayload = Depends(verify_token)) -> Any:
+    """
+    更新订阅状态
+    """
+    subscribe = Subscribe.get(db, subid)
+    if not subscribe:
+        return schemas.Response(success=False, message="订阅不存在")
+    valid_states = ["R", "P", "S"]
+    if state not in valid_states:
+        return schemas.Response(success=False, message="无效的订阅状态")
+    subscribe.update(db, {
+        "state": state
+    })
+    return schemas.Response(success=True)
+
+
 @router.get("/media/{mediaid}", summary="查询订阅", response_model=schemas.Subscribe)
 def subscribe_mediaid(
         mediaid: str,

--- a/app/db/models/subscribe.py
+++ b/app/db/models/subscribe.py
@@ -54,7 +54,7 @@ class Subscribe(Base):
     lack_episode = Column(Integer)
     # 附加信息
     note = Column(JSON)
-    # 状态：N-新建， R-订阅中
+    # 状态：N-新建 R-订阅中 P-待定 S-暂停
     state = Column(String, nullable=False, index=True, default='N')
     # 最后更新时间
     last_update = Column(String)
@@ -98,7 +98,13 @@ class Subscribe(Base):
     @staticmethod
     @db_query
     def get_by_state(db: Session, state: str):
-        result = db.query(Subscribe).filter(Subscribe.state == state).all()
+        # 如果 state 为空或 None，返回所有订阅
+        if not state:
+            result = db.query(Subscribe).all()
+        else:
+            # 如果传入的状态不为空，拆分成多个状态
+            states = state.split(',')
+            result = db.query(Subscribe).filter(Subscribe.state.in_(states)).all()
         return list(result)
 
     @staticmethod


### PR DESCRIPTION
1. **订阅状态增强**：
   - 新增两个订阅状态：
     - `P`（Pending）：表示待定状态，信息需要进一步更新，允许搜索，但不允许完成
     - `S`（Suspended）：表示暂停状态，订阅不参与任何动作，暂时停止处理
   - 当前订阅状态包括：
     - `N`：新建（未处理）
     - `R`：已处理（订阅中）
     - `P`：待定（信息待进一步更新，允许搜索，不允许完成）
     - `S`：暂停（不参与任何动作，暂时停止处理）

2. **新增订阅状态更新 API**：
   - 新增 `PUT /api/v1/subscribe/status` 接口，用于更新订阅的状态
