### PR TITLE
合并`文件整理`处理流程中的入参

### DIFF
--- a/app/api/endpoints/transfer.py
+++ b/app/api/endpoints/transfer.py
@@ -97,7 +97,7 @@ def manual_transfer(transer_item: TransferItem,
                     # E01单集
                     transer_item.episode_detail = str(history.episodes).replace("E", "")
 
-    elif not transer_item.fileitem:
+    if not transer_item.fileitem:
         return schemas.Response(success=False, message=f"缺少参数")
     # 开始转移
     state, errormsg = TransferChain().manual_transfer(

--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -382,10 +382,7 @@ class ChainBase(metaclass=ABCMeta):
         return self.run_module("list_torrents", status=status, hashs=hashs, downloader=downloader)
 
     def transfer(self, fileitem: FileItem, meta: MetaBase, mediainfo: MediaInfo,
-                 target_directory: TransferDirectoryConf = None,
-                 target_storage: str = None, target_path: Path = None,
-                 transfer_type: str = None, scrape: bool = None,
-                 library_type_folder: bool = None, library_category_folder: bool = None,
+                 target_directory: TransferDirectoryConf,
                  episodes_info: List[TmdbEpisode] = None) -> Optional[TransferInfo]:
         """
         文件转移
@@ -393,22 +390,12 @@ class ChainBase(metaclass=ABCMeta):
         :param meta: 预识别的元数据
         :param mediainfo:  识别的媒体信息
         :param target_directory:  目标目录配置
-        :param target_storage:  目标存储
-        :param target_path:  目标路径
-        :param transfer_type:  转移模式
-        :param scrape: 是否刮削元数据
-        :param library_type_folder: 是否按类型创建目录
-        :param library_category_folder: 是否按类别创建目录
         :param episodes_info: 当前季的全部集信息
         :return: {path, target_path, message}
         """
         return self.run_module("transfer",
                                fileitem=fileitem, meta=meta, mediainfo=mediainfo,
                                target_directory=target_directory,
-                               target_path=target_path, target_storage=target_storage,
-                               transfer_type=transfer_type, scrape=scrape,
-                               library_type_folder=library_type_folder,
-                               library_category_folder=library_category_folder,
                                episodes_info=episodes_info)
 
     def transfer_completed(self, hashs: str, downloader: str = None) -> None:

--- a/app/modules/filemanager/__init__.py
+++ b/app/modules/filemanager/__init__.py
@@ -818,18 +818,6 @@ class FileManagerModule(_ModuleBase):
         return None, errmsg
 
     @staticmethod
-    def __get_dest_path(mediainfo: MediaInfo, target_path: Path,
-                        need_type_folder: bool = False, need_category_folder: bool = False):
-        """
-        获取目标路径
-        """
-        if need_type_folder:
-            target_path = target_path / mediainfo.type.value
-        if need_category_folder and mediainfo.category:
-            target_path = target_path / mediainfo.category
-        return target_path
-
-    @staticmethod
     def __get_dest_dir(mediainfo: MediaInfo, target_dir: TransferDirectoryConf) -> Path:
         """
         根据设置并装媒体库目录


### PR DESCRIPTION
`app/api/endpoints/transfer.ManualTransferItem`移至`app/schemas/transfer.TransferItem`
新增方法:
- `TransferItem.epformat`: 返回`EpisodeFormat`实例
- `TransferItem.to_transfer_directory_conf`: `return` `TransferItem实例`中`有效属性`转换并合并后的`TransferDirectoryConf`实例
受影响的插件: ~~[目录实时监控](https://github.com/thsrite/MoviePilot-Plugins/tree/main/plugins.v2/cloudlinkmonitor)~~ 已适配thsrite/MoviePilot-Plugins#168