### PR TITLE
feat: 完善订阅下载逻辑，进一步支持多种订阅状态

### DIFF
--- a/app/api/endpoints/subscribe.py
+++ b/app/api/endpoints/subscribe.py
@@ -207,8 +207,9 @@ def reset_subscribes(
     subscribe = Subscribe.get(db, subid)
     if subscribe:
         subscribe.update(db, {
-            "note": "",
-            "lack_episode": subscribe.total_episode
+            "note": [],
+            "lack_episode": subscribe.total_episode,
+            "state": "R"
         })
         return schemas.Response(success=True)
     return schemas.Response(success=False, message="订阅不存在")

--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -466,12 +466,12 @@ class SubscribeChain(ChainBase, metaclass=Singleton):
         # 是否完成订阅
         if not subscribe.best_version:
             # 订阅存在待定策略，不管是否已完成，均需更新订阅信息
-            if downloads and meta.type == MediaType.TV:
+            if meta.type == MediaType.TV:
                 # 电视剧更新已下载集数
                 self.__update_subscribe_note(subscribe=subscribe, downloads=downloads)
                 # 更新订阅剩余集数和时间
-                self.__update_lack_episodes(lefts=lefts, subscribe=subscribe,
-                                            mediainfo=mediainfo, update_date=True)
+                self.__update_lack_episodes(lefts=lefts, subscribe=subscribe, mediainfo=mediainfo,
+                                            update_date=bool(downloads))
             # 判断是否需要完成订阅
             if ((no_lefts and meta.type == MediaType.TV)
                     or (downloads and meta.type == MediaType.MOVIE)
@@ -480,10 +480,6 @@ class SubscribeChain(ChainBase, metaclass=Singleton):
             else:
                 # 未下载到内容且不完整
                 logger.info(f'{mediainfo.title_year} 未下载完整，继续订阅 ...')
-                if meta.type == MediaType.TV:
-                    # 更新订阅剩余集数
-                    self.__update_lack_episodes(lefts=lefts, subscribe=subscribe,
-                                                mediainfo=mediainfo, update_date=False)
         elif downloads:
             # 洗板，下载到了内容，更新资源优先级
             self.update_subscribe_priority(subscribe=subscribe, meta=meta,

--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -403,12 +403,16 @@ class SubscribeChain(ChainBase, metaclass=Singleton):
                         source=self.get_subscribe_source_keyword(subscribe)
                     )
 
+                    # 同步外部修改，更新订阅信息
+                    subscribe = self.subscribeoper.get(subscribe.id)
+
                     # 判断是否应完成订阅
-                    self.finish_subscribe_or_not(subscribe=subscribe, meta=meta, mediainfo=mediainfo,
-                                                 downloads=downloads, lefts=lefts)
+                    if subscribe:
+                        self.finish_subscribe_or_not(subscribe=subscribe, meta=meta, mediainfo=mediainfo,
+                                                     downloads=downloads, lefts=lefts)
                 finally:
                     # 如果状态为N则更新为R
-                    if subscribe.state == 'N':
+                    if subscribe and subscribe.state == 'N':
                         self.subscribeoper.update(subscribe.id, {'state': 'R'})
 
             # 手动触发时发送系统消息
@@ -794,9 +798,14 @@ class SubscribeChain(ChainBase, metaclass=Singleton):
                                                                      downloader=subscribe.downloader,
                                                                      source=self.get_subscribe_source_keyword(subscribe)
                                                                      )
+
+                # 同步外部修改，更新订阅信息
+                subscribe = self.subscribeoper.get(subscribe.id)
+
                 # 判断是否要完成订阅
-                self.finish_subscribe_or_not(subscribe=subscribe, meta=meta, mediainfo=mediainfo,
-                                             downloads=downloads, lefts=lefts)
+                if subscribe:
+                    self.finish_subscribe_or_not(subscribe=subscribe, meta=meta, mediainfo=mediainfo,
+                                                 downloads=downloads, lefts=lefts)
             logger.debug(f"match Lock released at {datetime.now()}")
 
     def check(self):


### PR DESCRIPTION
- 订阅重置支持重置订阅状态为 `R`
- 下载后重新获取订阅信息，从而同步外部修改，保持状态一致
- 为电影类型的订阅增加了更新已下载记录的支持
- 确保在订阅完成时优先更新状态，避免状态丢失
- 优化了剩余集数更新逻辑，避免重复更新订阅信息
- 支持通过订阅下载信息来判断订阅是否已下载，避免因订阅状态为 `待定` 时，订阅没有及时完成导致重复下载的问题
- 新增 `check_and_handle_existing_media`，统一 `RSS` 以及 `Search` 的媒体是否已经存在判断逻辑
