### PR TITLE
自定义识别词新增`suboffset=EP+xx`字段，用于副标题集数偏移

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -91,6 +91,8 @@ class ConfigModel(BaseModel):
     SCRAP_SOURCE: str = "themoviedb"
     # 新增已入库媒体是否跟随TMDB信息变化
     SCRAP_FOLLOW_TMDB: bool = True
+    # 副标题集数偏移是否启用, 默认关闭
+    SUBTITLE_OFFSET_ENABLE: bool = False
     # TMDB图片地址
     TMDB_IMAGE_DOMAIN: str = "image.tmdb.org"
     # TMDB API地址

--- a/app/core/meta/metaanime.py
+++ b/app/core/meta/metaanime.py
@@ -176,6 +176,7 @@ class MetaAnime(MetaBase):
                 # 解析副标题，只要季和集
                 self.init_subtitle(self.org_string)
                 if not self._subtitle_flag and self.subtitle:
+                    self.subtitle_offset = True
                     self.init_subtitle(self.subtitle)
             if not self.type:
                 self.type = MediaType.TV

--- a/app/core/meta/metabase.py
+++ b/app/core/meta/metabase.py
@@ -67,6 +67,7 @@ class MetaBase(object):
 
     # 副标题解析
     _subtitle_flag = False
+    subtitle_offset = False
     _title_episodel_re = r"Episode\s+(\d{1,4})"
     _subtitle_season_re = r"(?<![全共]\s*)[第\s]+([0-9一二三四五六七八九十S\-]+)\s*季(?!\s*[全共])"
     _subtitle_season_all_re = r"[全共]\s*([0-9一二三四五六七八九十]+)\s*季|([0-9一二三四五六七八九十]+)\s*季\s*全"

--- a/app/core/meta/metavideo.py
+++ b/app/core/meta/metavideo.py
@@ -139,6 +139,7 @@ class MetaVideo(MetaBase):
         # 解析副标题，只要季和集
         self.init_subtitle(self.org_string)
         if not self._subtitle_flag and self.subtitle:
+            self.subtitle_offset = True
             self.init_subtitle(self.subtitle)
         # 去掉名字中不需要的干扰字符，过短的纯数字不要
         self.cn_name = self.__fix_name(self.cn_name)

--- a/app/core/metainfo.py
+++ b/app/core/metainfo.py
@@ -42,8 +42,10 @@ def MetaInfo(title: str, subtitle: str = None, custom_words: List[str] = None) -
         try:
             begin_ep = metainfo['subtitle_offset'].replace("EP", str(meta.begin_episode)) if meta.begin_episode else None
             end_ep = metainfo['subtitle_offset'].replace("EP", str(meta.end_episode)) if meta.end_episode else None
-            meta.begin_episode = int(eval(begin_ep)) if begin_ep else None
-            meta.end_episode = int(eval(end_ep)) if end_ep else None
+            if begin_ep:
+                meta.begin_episode = int(eval(begin_ep))
+            if end_ep:
+                meta.end_episode = int(eval(end_ep))
         except Exception as e:
             logger.error(f"应用副标题集数偏移失败：{e}")
     # 修正媒体信息

--- a/config/app.env
+++ b/config/app.env
@@ -48,7 +48,7 @@ FANART_ENABLE=true
 # 新增已入库媒体是否跟随TMDB信息变化，true/false，为false时即使TMDB信息变化时也会仍然按历史记录中已入库的信息进行刮削
 SCRAP_FOLLOW_TMDB=true
 # 是否启用自定义识别词对副标题集数偏移, 启用后{[tmdbid/doubanid=xxx;type=movie/tv;s=xxx;e=xxx]}中增加可选字段`sub_offset=EP+xx`
-SUBTITLE_OFFSET_ENABLE='True'
+SUBTITLE_OFFSET_ENABLE=false
 # 刮削来源 themoviedb/douban，使用themoviedb时需要确保能正常连接api.themoviedb.org，使用douban时会缺失部分信息
 SCRAP_SOURCE=themoviedb
 # 电影重命名格式，Jinja2语法，参考：https://jinja.palletsprojects.com/en/3.0.x/templates/

--- a/config/app.env
+++ b/config/app.env
@@ -47,6 +47,8 @@ RECOGNIZE_SOURCE=themoviedb
 FANART_ENABLE=true
 # 新增已入库媒体是否跟随TMDB信息变化，true/false，为false时即使TMDB信息变化时也会仍然按历史记录中已入库的信息进行刮削
 SCRAP_FOLLOW_TMDB=true
+# 是否启用自定义识别词对副标题集数偏移, 启用后{[tmdbid/doubanid=xxx;type=movie/tv;s=xxx;e=xxx]}中增加可选字段`sub_offset=EP+xx`
+SUBTITLE_OFFSET_ENABLE='True'
 # 刮削来源 themoviedb/douban，使用themoviedb时需要确保能正常连接api.themoviedb.org，使用douban时会缺失部分信息
 SCRAP_SOURCE=themoviedb
 # 电影重命名格式，Jinja2语法，参考：https://jinja.palletsprojects.com/en/3.0.x/templates/


### PR DESCRIPTION
- 在 MetaBase 类中新增 `subtitle_offset = False` 属性，用于判断是否需要进行偏移。
- 在 `find_metainfo.metainfo` 字典中新增 `subtitle_offset` 键，用于存储偏移值。
- 如果 `设定-系统-高级设置-实验室` 中未启用 `副标题集数偏移` 选项，则跳过相关处理。