### PR TITLE
Revert "chore(deps): update dependency python-115 to v0.0.9.8.8.3"

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -58,6 +58,6 @@ pystray~=0.19.5
 pyotp~=2.9.0
 Pinyin2Hanzi~=0.1.1
 pywebpush~=2.0.0
-python-115~=0.0.9.8.8.3
+python-115~=0.0.9.8.8.2
 aligo~=6.2.4
 aiofiles~=24.1.0


### PR DESCRIPTION
- 降级 115 相关依赖，避免依赖升级导致的版本兼容问题

This reverts commit d182a7079dfd532651aef01fde14b265e933144f.