### PR TITLE
fix(site): avoid err_msg cannot be updated when it's None

### DIFF
--- a/app/db/models/siteuserdata.py
+++ b/app/db/models/siteuserdata.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import Column, Integer, String, Sequence, Float, JSON, func
+from sqlalchemy import Column, Integer, String, Sequence, Float, JSON, func, or_
 from sqlalchemy.orm import Session
 
 from app.db import db_query, Base
@@ -81,7 +81,7 @@ class SiteUserData(Base):
                 func.max(SiteUserData.updated_day).label('latest_update_day')
             )
             .group_by(SiteUserData.domain)
-            .filter(SiteUserData.err_msg.is_(None))
+            .filter(or_(SiteUserData.err_msg.is_(None), SiteUserData.err_msg == ""))
             .subquery()
         )
 

--- a/app/db/site_oper.py
+++ b/app/db/site_oper.py
@@ -114,7 +114,8 @@ class SiteOper(DbOper):
             "domain": domain,
             "name": name,
             "updated_day": current_day,
-            "updated_time": current_time
+            "updated_time": current_time,
+            "err_msg": payload.get("err_msg") or ""
         })
         # 按站点+天判断是否存在数据
         siteuserdatas = SiteUserData.get_by_domain(self._db, domain=domain, workdate=current_day)


### PR DESCRIPTION
- 避免因 `db_update` 排除 None 导致 `err_msg` 无法更新，从而导致站点数据无法正常显示的问题

``` python
    @db_update
    def update(self, db: Session, payload: dict):
        payload = {k: v for k, v in payload.items() if v is not None}
        for key, value in payload.items():
            setattr(self, key, value)
        if inspect(self).detached:
            db.add(self)
```