### PR TITLE
TorrentSpider添加encoding key

### DIFF
--- a/app/modules/indexer/spider/__init__.py
+++ b/app/modules/indexer/spider/__init__.py
@@ -64,6 +64,8 @@ class TorrentSpider:
     torrents_info_array: list = []
     # 搜索超时, 默认: 15秒
     _timeout = 15
+    # 站点解析时是否需要编码
+    encoding: bool = False
 
     def __init__(self,
                  indexer: CommentedMap,
@@ -95,6 +97,7 @@ class TorrentSpider:
         self.domain = indexer.get('domain')
         self.result_num = int(indexer.get('result_num') or 100)
         self._timeout = int(indexer.get('timeout') or 15)
+        self.encoding = indexer.get('encoding', False)
         self.page = page
         if self.domain and not str(self.domain).endswith("/"):
             self.domain = self.domain + "/"
@@ -728,7 +731,10 @@ class TorrentSpider:
         self.torrents_info_array = []
         try:
             # 解析站点文本对象
-            html_doc = PyQuery(html_text)
+            if self.encoding:
+                html_doc = PyQuery(html_text.encode('utf-8'))
+            else:
+                html_doc = PyQuery(html_text)
             # 种子筛选器
             torrents_selector = self.list.get('selector', '')
             # 遍历种子html列表


### PR DESCRIPTION
TorrentSpider在使用PyQuery解析xml时，如果xml含有“encoding=xxx”字段，会因为xml的encoding问题报错，这个问题可以通过将传给PyQuery的html_text重新进行编码解决，即html_doc = PyQuery(html_text) -> html_doc = PyQuery(html_text.encode('utf-8'))
因此给indexer添加一个encoding字段，当其为True时进行encode，同时默认为False避免对已有代码产生影响