### PR TITLE
feat(recommend): add RecommendChain

### DIFF
--- a/app/api/endpoints/bangumi.py
+++ b/app/api/endpoints/bangumi.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends
 
 from app import schemas
 from app.chain.bangumi import BangumiChain
+from app.chain.recommend import RecommendChain
 from app.core.context import MediaInfo
 from app.core.security import verify_token
 
@@ -17,10 +18,7 @@ def calendar(page: int = 1,
     """
     浏览Bangumi每日放送
     """
-    medias = BangumiChain().calendar()
-    if medias:
-        return [media.to_dict() for media in medias[(page - 1) * count: page * count]]
-    return []
+    return RecommendChain().bangumi_calendar(page=page, count=count)
 
 
 @router.get("/credits/{bangumiid}", summary="查询Bangumi演职员表", response_model=List[schemas.MediaPerson])

--- a/app/api/endpoints/douban.py
+++ b/app/api/endpoints/douban.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends
 
 from app import schemas
 from app.chain.douban import DoubanChain
+from app.chain.recommend import RecommendChain
 from app.core.context import MediaInfo
 from app.core.security import verify_token
 from app.schemas import MediaType
@@ -40,10 +41,7 @@ def movie_showing(page: int = 1,
     """
     浏览豆瓣正在热映
     """
-    movies = DoubanChain().movie_showing(page=page, count=count)
-    if movies:
-        return [media.to_dict() for media in movies]
-    return []
+    return RecommendChain().douban_movie_showing(page=page, count=count)
 
 
 @router.get("/movies", summary="豆瓣电影", response_model=List[schemas.MediaInfo])
@@ -55,11 +53,7 @@ def douban_movies(sort: str = "R",
     """
     浏览豆瓣电影信息
     """
-    movies = DoubanChain().douban_discover(mtype=MediaType.MOVIE,
-                                           sort=sort, tags=tags, page=page, count=count)
-    if movies:
-        return [media.to_dict() for media in movies]
-    return []
+    return RecommendChain().douban_movies(sort=sort, tags=tags, page=page, count=count)
 
 
 @router.get("/tvs", summary="豆瓣剧集", response_model=List[schemas.MediaInfo])
@@ -71,11 +65,7 @@ def douban_tvs(sort: str = "R",
     """
     浏览豆瓣剧集信息
     """
-    tvs = DoubanChain().douban_discover(mtype=MediaType.TV,
-                                        sort=sort, tags=tags, page=page, count=count)
-    if tvs:
-        return [media.to_dict() for media in tvs]
-    return []
+    return RecommendChain().douban_tvs(sort=sort, tags=tags, page=page, count=count)
 
 
 @router.get("/movie_top250", summary="豆瓣电影TOP250", response_model=List[schemas.MediaInfo])
@@ -85,10 +75,7 @@ def movie_top250(page: int = 1,
     """
     浏览豆瓣剧集信息
     """
-    movies = DoubanChain().movie_top250(page=page, count=count)
-    if movies:
-        return [media.to_dict() for media in movies]
-    return []
+    return RecommendChain().douban_movie_top250(page=page, count=count)
 
 
 @router.get("/tv_weekly_chinese", summary="豆瓣国产剧集周榜", response_model=List[schemas.MediaInfo])
@@ -98,10 +85,7 @@ def tv_weekly_chinese(page: int = 1,
     """
     中国每周剧集口碑榜
     """
-    tvs = DoubanChain().tv_weekly_chinese(page=page, count=count)
-    if tvs:
-        return [media.to_dict() for media in tvs]
-    return []
+    return RecommendChain().douban_tv_weekly_chinese(page=page, count=count)
 
 
 @router.get("/tv_weekly_global", summary="豆瓣全球剧集周榜", response_model=List[schemas.MediaInfo])
@@ -111,10 +95,7 @@ def tv_weekly_global(page: int = 1,
     """
     全球每周剧集口碑榜
     """
-    tvs = DoubanChain().tv_weekly_global(page=page, count=count)
-    if tvs:
-        return [media.to_dict() for media in tvs]
-    return []
+    return RecommendChain().douban_tv_weekly_global(page=page, count=count)
 
 
 @router.get("/tv_animation", summary="豆瓣动画剧集", response_model=List[schemas.MediaInfo])
@@ -124,10 +105,7 @@ def tv_animation(page: int = 1,
     """
     热门动画剧集
     """
-    tvs = DoubanChain().tv_animation(page=page, count=count)
-    if tvs:
-        return [media.to_dict() for media in tvs]
-    return []
+    return RecommendChain().douban_tv_animation(page=page, count=count)
 
 
 @router.get("/movie_hot", summary="豆瓣热门电影", response_model=List[schemas.MediaInfo])
@@ -137,10 +115,7 @@ def movie_hot(page: int = 1,
     """
     热门电影
     """
-    movies = DoubanChain().movie_hot(page=page, count=count)
-    if movies:
-        return [media.to_dict() for media in movies]
-    return []
+    return RecommendChain().douban_movie_hot(page=page, count=count)
 
 
 @router.get("/tv_hot", summary="豆瓣热门电视剧", response_model=List[schemas.MediaInfo])
@@ -150,10 +125,7 @@ def tv_hot(page: int = 1,
     """
     热门电视剧
     """
-    tvs = DoubanChain().tv_hot(page=page, count=count)
-    if tvs:
-        return [media.to_dict() for media in tvs]
-    return []
+    return RecommendChain().douban_tv_hot(page=page, count=count)
 
 
 @router.get("/credits/{doubanid}/{type_name}", summary="豆瓣演员阵容", response_model=List[schemas.MediaPerson])

--- a/app/api/endpoints/tmdb.py
+++ b/app/api/endpoints/tmdb.py
@@ -3,6 +3,7 @@ from typing import List, Any
 from fastapi import APIRouter, Depends
 
 from app import schemas
+from app.chain.recommend import RecommendChain
 from app.chain.tmdb import TmdbChain
 from app.core.security import verify_token
 from app.schemas.types import MediaType
@@ -108,14 +109,10 @@ def tmdb_movies(sort_by: str = "popularity.desc",
     """
     浏览TMDB电影信息
     """
-    movies = TmdbChain().tmdb_discover(mtype=MediaType.MOVIE,
-                                       sort_by=sort_by,
-                                       with_genres=with_genres,
-                                       with_original_language=with_original_language,
-                                       page=page)
-    if not movies:
-        return []
-    return [movie.to_dict() for movie in movies]
+    return RecommendChain().tmdb_movies(sort_by=sort_by,
+                                        with_genres=with_genres,
+                                        with_original_language=with_original_language,
+                                        page=page)
 
 
 @router.get("/tvs", summary="TMDB剧集", response_model=List[schemas.MediaInfo])
@@ -127,26 +124,19 @@ def tmdb_tvs(sort_by: str = "popularity.desc",
     """
     浏览TMDB剧集信息
     """
-    tvs = TmdbChain().tmdb_discover(mtype=MediaType.TV,
-                                    sort_by=sort_by,
-                                    with_genres=with_genres,
-                                    with_original_language=with_original_language,
-                                    page=page)
-    if not tvs:
-        return []
-    return [tv.to_dict() for tv in tvs]
+    return RecommendChain().tmdb_tvs(sort_by=sort_by,
+                                     with_genres=with_genres,
+                                     with_original_language=with_original_language,
+                                     page=page)
 
 
 @router.get("/trending", summary="TMDB流行趋势", response_model=List[schemas.MediaInfo])
 def tmdb_trending(page: int = 1,
                   _: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
-    浏览TMDB剧集信息
+    TMDB流行趋势
     """
-    infos = TmdbChain().tmdb_trending(page=page)
-    if not infos:
-        return []
-    return [info.to_dict() for info in infos]
+    return RecommendChain().tmdb_trending(page=page)
 
 
 @router.get("/{tmdbid}/{season}", summary="TMDB季所有集", response_model=List[schemas.TmdbEpisode])

--- a/app/chain/recommend.py
+++ b/app/chain/recommend.py
@@ -4,7 +4,9 @@ from app.chain import ChainBase
 from app.chain.bangumi import BangumiChain
 from app.chain.douban import DoubanChain
 from app.chain.tmdb import TmdbChain
+from app.log import logger
 from app.schemas import MediaType
+from app.utils.common import log_execution_time
 from app.utils.singleton import Singleton
 
 
@@ -19,6 +21,7 @@ class RecommendChain(ChainBase, metaclass=Singleton):
         self.doubanchain = DoubanChain()
         self.bangumichain = BangumiChain()
 
+    @log_execution_time(logger=logger)
     def tmdb_movies(self, sort_by: str = "popularity.desc", with_genres: str = "",
                     with_original_language: str = "", page: int = 1) -> Any:
         """
@@ -31,6 +34,7 @@ class RecommendChain(ChainBase, metaclass=Singleton):
                                               page=page)
         return [movie.to_dict() for movie in movies] if movies else []
 
+    @log_execution_time(logger=logger)
     def tmdb_tvs(self, sort_by: str = "popularity.desc", with_genres: str = "",
                  with_original_language: str = "", page: int = 1) -> Any:
         """
@@ -43,6 +47,7 @@ class RecommendChain(ChainBase, metaclass=Singleton):
                                            page=page)
         return [tv.to_dict() for tv in tvs] if tvs else []
 
+    @log_execution_time(logger=logger)
     def tmdb_trending(self, page: int = 1) -> Any:
         """
         TMDB流行趋势
@@ -50,6 +55,7 @@ class RecommendChain(ChainBase, metaclass=Singleton):
         infos = self.tmdbchain.tmdb_trending(page=page)
         return [info.to_dict() for info in infos] if infos else []
 
+    @log_execution_time(logger=logger)
     def bangumi_calendar(self, page: int = 1, count: int = 30) -> Any:
         """
         Bangumi每日放送
@@ -57,6 +63,7 @@ class RecommendChain(ChainBase, metaclass=Singleton):
         medias = self.bangumichain.calendar()
         return [media.to_dict() for media in medias[(page - 1) * count: page * count]] if medias else []
 
+    @log_execution_time(logger=logger)
     def movie_showing(self, page: int = 1, count: int = 30) -> Any:
         """
         豆瓣正在热映
@@ -64,6 +71,7 @@ class RecommendChain(ChainBase, metaclass=Singleton):
         movies = self.doubanchain.movie_showing(page=page, count=count)
         return [media.to_dict() for media in movies] if movies else []
 
+    @log_execution_time(logger=logger)
     def douban_movies(self, sort: str = "R", tags: str = "", page: int = 1, count: int = 30) -> Any:
         """
         豆瓣最新电影
@@ -72,6 +80,7 @@ class RecommendChain(ChainBase, metaclass=Singleton):
                                                   sort=sort, tags=tags, page=page, count=count)
         return [media.to_dict() for media in movies] if movies else []
 
+    @log_execution_time(logger=logger)
     def douban_tvs(self, sort: str = "R", tags: str = "", page: int = 1, count: int = 30) -> Any:
         """
         豆瓣最新电视剧
@@ -80,6 +89,7 @@ class RecommendChain(ChainBase, metaclass=Singleton):
                                                sort=sort, tags=tags, page=page, count=count)
         return [media.to_dict() for media in tvs] if tvs else []
 
+    @log_execution_time(logger=logger)
     def movie_top250(self, page: int = 1, count: int = 30) -> Any:
         """
         豆瓣电影TOP250
@@ -87,6 +97,7 @@ class RecommendChain(ChainBase, metaclass=Singleton):
         movies = self.doubanchain.movie_top250(page=page, count=count)
         return [media.to_dict() for media in movies] if movies else []
 
+    @log_execution_time(logger=logger)
     def tv_weekly_chinese(self, page: int = 1, count: int = 30) -> Any:
         """
         豆瓣国产剧集榜
@@ -94,6 +105,7 @@ class RecommendChain(ChainBase, metaclass=Singleton):
         tvs = self.doubanchain.tv_weekly_chinese(page=page, count=count)
         return [media.to_dict() for media in tvs] if tvs else []
 
+    @log_execution_time(logger=logger)
     def tv_weekly_global(self, page: int = 1, count: int = 30) -> Any:
         """
         豆瓣全球剧集榜
@@ -101,6 +113,7 @@ class RecommendChain(ChainBase, metaclass=Singleton):
         tvs = self.doubanchain.tv_weekly_global(page=page, count=count)
         return [media.to_dict() for media in tvs] if tvs else []
 
+    @log_execution_time(logger=logger)
     def tv_animation(self, page: int = 1, count: int = 30) -> Any:
         """
         豆瓣热门动漫
@@ -108,6 +121,7 @@ class RecommendChain(ChainBase, metaclass=Singleton):
         tvs = self.doubanchain.tv_animation(page=page, count=count)
         return [media.to_dict() for media in tvs] if tvs else []
 
+    @log_execution_time(logger=logger)
     def movie_hot(self, page: int = 1, count: int = 30) -> Any:
         """
         豆瓣热门电影
@@ -115,6 +129,7 @@ class RecommendChain(ChainBase, metaclass=Singleton):
         movies = self.doubanchain.movie_hot(page=page, count=count)
         return [media.to_dict() for media in movies] if movies else []
 
+    @log_execution_time(logger=logger)
     def tv_hot(self, page: int = 1, count: int = 30) -> Any:
         """
         豆瓣热门电视剧

--- a/app/chain/recommend.py
+++ b/app/chain/recommend.py
@@ -64,12 +64,12 @@ class RecommendChain(ChainBase, metaclass=Singleton):
         self.bangumi_calendar()
         self.douban_movies()
         self.douban_tvs()
-        self.movie_top250()
-        self.tv_weekly_chinese()
-        self.tv_weekly_global()
-        self.tv_animation()
-        self.movie_hot()
-        self.tv_hot()
+        self.douban_movie_top250()
+        self.douban_tv_weekly_chinese()
+        self.douban_tv_weekly_global()
+        self.douban_tv_animation()
+        self.douban_movie_hot()
+        self.douban_tv_hot()
 
     @log_execution_time(logger=logger)
     @cached_with_empty_check
@@ -119,7 +119,7 @@ class RecommendChain(ChainBase, metaclass=Singleton):
 
     @log_execution_time(logger=logger)
     @cached_with_empty_check
-    def movie_showing(self, page: int = 1, count: int = 30) -> Any:
+    def douban_movie_showing(self, page: int = 1, count: int = 30) -> Any:
         """
         豆瓣正在热映
         """
@@ -148,7 +148,7 @@ class RecommendChain(ChainBase, metaclass=Singleton):
 
     @log_execution_time(logger=logger)
     @cached_with_empty_check
-    def movie_top250(self, page: int = 1, count: int = 30) -> Any:
+    def douban_movie_top250(self, page: int = 1, count: int = 30) -> Any:
         """
         豆瓣电影TOP250
         """
@@ -157,7 +157,7 @@ class RecommendChain(ChainBase, metaclass=Singleton):
 
     @log_execution_time(logger=logger)
     @cached_with_empty_check
-    def tv_weekly_chinese(self, page: int = 1, count: int = 30) -> Any:
+    def douban_tv_weekly_chinese(self, page: int = 1, count: int = 30) -> Any:
         """
         豆瓣国产剧集榜
         """
@@ -166,7 +166,7 @@ class RecommendChain(ChainBase, metaclass=Singleton):
 
     @log_execution_time(logger=logger)
     @cached_with_empty_check
-    def tv_weekly_global(self, page: int = 1, count: int = 30) -> Any:
+    def douban_tv_weekly_global(self, page: int = 1, count: int = 30) -> Any:
         """
         豆瓣全球剧集榜
         """
@@ -175,7 +175,7 @@ class RecommendChain(ChainBase, metaclass=Singleton):
 
     @log_execution_time(logger=logger)
     @cached_with_empty_check
-    def tv_animation(self, page: int = 1, count: int = 30) -> Any:
+    def douban_tv_animation(self, page: int = 1, count: int = 30) -> Any:
         """
         豆瓣热门动漫
         """
@@ -184,7 +184,7 @@ class RecommendChain(ChainBase, metaclass=Singleton):
 
     @log_execution_time(logger=logger)
     @cached_with_empty_check
-    def movie_hot(self, page: int = 1, count: int = 30) -> Any:
+    def douban_movie_hot(self, page: int = 1, count: int = 30) -> Any:
         """
         豆瓣热门电影
         """
@@ -193,7 +193,7 @@ class RecommendChain(ChainBase, metaclass=Singleton):
 
     @log_execution_time(logger=logger)
     @cached_with_empty_check
-    def tv_hot(self, page: int = 1, count: int = 30) -> Any:
+    def douban_tv_hot(self, page: int = 1, count: int = 30) -> Any:
         """
         豆瓣热门电视剧
         """

--- a/app/chain/recommend.py
+++ b/app/chain/recommend.py
@@ -18,7 +18,7 @@ recommend_ttl = 6 * 3600
 recommend_cache = TTLCache(maxsize=256, ttl=recommend_ttl)
 
 
-# 推荐缓存装饰器，避免偶发网络获取数据为空时，页面由于缓存长时间渲染异常问题
+# 推荐缓存装饰器，避免偶发网络获取数据为空时，页面由于缓存为空长时间渲染异常问题
 def cached_with_empty_check(func: Callable):
     """
     缓存装饰器，用于缓存函数的返回结果，仅在结果非空时进行缓存

--- a/app/chain/recommend.py
+++ b/app/chain/recommend.py
@@ -1,0 +1,123 @@
+from typing import Any
+
+from app.chain import ChainBase
+from app.chain.bangumi import BangumiChain
+from app.chain.douban import DoubanChain
+from app.chain.tmdb import TmdbChain
+from app.schemas import MediaType
+from app.utils.singleton import Singleton
+
+
+class RecommendChain(ChainBase, metaclass=Singleton):
+    """
+    推荐处理链，单例运行
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.tmdbchain = TmdbChain()
+        self.doubanchain = DoubanChain()
+        self.bangumichain = BangumiChain()
+
+    def tmdb_movies(self, sort_by: str = "popularity.desc", with_genres: str = "",
+                    with_original_language: str = "", page: int = 1) -> Any:
+        """
+        TMDB热门电影
+        """
+        movies = self.tmdbchain.tmdb_discover(mtype=MediaType.MOVIE,
+                                              sort_by=sort_by,
+                                              with_genres=with_genres,
+                                              with_original_language=with_original_language,
+                                              page=page)
+        return [movie.to_dict() for movie in movies] if movies else []
+
+    def tmdb_tvs(self, sort_by: str = "popularity.desc", with_genres: str = "",
+                 with_original_language: str = "", page: int = 1) -> Any:
+        """
+        TMDB热门电视剧
+        """
+        tvs = self.tmdbchain.tmdb_discover(mtype=MediaType.TV,
+                                           sort_by=sort_by,
+                                           with_genres=with_genres,
+                                           with_original_language=with_original_language,
+                                           page=page)
+        return [tv.to_dict() for tv in tvs] if tvs else []
+
+    def tmdb_trending(self, page: int = 1) -> Any:
+        """
+        TMDB流行趋势
+        """
+        infos = self.tmdbchain.tmdb_trending(page=page)
+        return [info.to_dict() for info in infos] if infos else []
+
+    def bangumi_calendar(self, page: int = 1, count: int = 30) -> Any:
+        """
+        Bangumi每日放送
+        """
+        medias = self.bangumichain.calendar()
+        return [media.to_dict() for media in medias[(page - 1) * count: page * count]] if medias else []
+
+    def movie_showing(self, page: int = 1, count: int = 30) -> Any:
+        """
+        豆瓣正在热映
+        """
+        movies = self.doubanchain.movie_showing(page=page, count=count)
+        return [media.to_dict() for media in movies] if movies else []
+
+    def douban_movies(self, sort: str = "R", tags: str = "", page: int = 1, count: int = 30) -> Any:
+        """
+        豆瓣最新电影
+        """
+        movies = self.doubanchain.douban_discover(mtype=MediaType.MOVIE,
+                                                  sort=sort, tags=tags, page=page, count=count)
+        return [media.to_dict() for media in movies] if movies else []
+
+    def douban_tvs(self, sort: str = "R", tags: str = "", page: int = 1, count: int = 30) -> Any:
+        """
+        豆瓣最新电视剧
+        """
+        tvs = self.doubanchain.douban_discover(mtype=MediaType.TV,
+                                               sort=sort, tags=tags, page=page, count=count)
+        return [media.to_dict() for media in tvs] if tvs else []
+
+    def movie_top250(self, page: int = 1, count: int = 30) -> Any:
+        """
+        豆瓣电影TOP250
+        """
+        movies = self.doubanchain.movie_top250(page=page, count=count)
+        return [media.to_dict() for media in movies] if movies else []
+
+    def tv_weekly_chinese(self, page: int = 1, count: int = 30) -> Any:
+        """
+        豆瓣国产剧集榜
+        """
+        tvs = self.doubanchain.tv_weekly_chinese(page=page, count=count)
+        return [media.to_dict() for media in tvs] if tvs else []
+
+    def tv_weekly_global(self, page: int = 1, count: int = 30) -> Any:
+        """
+        豆瓣全球剧集榜
+        """
+        tvs = self.doubanchain.tv_weekly_global(page=page, count=count)
+        return [media.to_dict() for media in tvs] if tvs else []
+
+    def tv_animation(self, page: int = 1, count: int = 30) -> Any:
+        """
+        豆瓣热门动漫
+        """
+        tvs = self.doubanchain.tv_animation(page=page, count=count)
+        return [media.to_dict() for media in tvs] if tvs else []
+
+    def movie_hot(self, page: int = 1, count: int = 30) -> Any:
+        """
+        豆瓣热门电影
+        """
+        movies = self.doubanchain.movie_hot(page=page, count=count)
+        return [media.to_dict() for media in movies] if movies else []
+
+    def tv_hot(self, page: int = 1, count: int = 30) -> Any:
+        """
+        豆瓣热门电视剧
+        """
+        tvs = self.doubanchain.tv_hot(page=page, count=count)
+        return [media.to_dict() for media in tvs] if tvs else []

--- a/app/utils/common.py
+++ b/app/utils/common.py
@@ -1,5 +1,6 @@
 import time
-from typing import Any
+from functools import wraps
+from typing import Any, Callable
 
 from app.schemas import ImmediateException
 
@@ -36,3 +37,27 @@ def retry(ExceptionToCheck: Any,
         return f_retry
 
     return deco_retry
+
+
+def log_execution_time(logger: Any = None):
+    """
+    记录函数执行时间的装饰器
+    :param logger: 日志记录器对象，用于记录异常信息
+    """
+
+    def decorator(func: Callable):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            start_time = time.time()
+            result = func(*args, **kwargs)
+            end_time = time.time()
+            msg = f"{func.__name__} execution time: {end_time - start_time:.2f} seconds"
+            if logger:
+                logger.debug(msg)
+            else:
+                print(msg)
+            return result
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
#### 1. 新增公共装饰器
- **`log_execution_time`**: 新增通用装饰器，用于记录方法执行耗时，便于性能监控与调试
#### 2. 推荐逻辑重构
- **`RecommendChain`**: 
  - 整合 TMDB、豆瓣、Bangumi 等推荐相关接口，统一调用逻辑
  - 新增缓存方案：
    - 新增自定义缓存装饰器，避免偶发网络获取数据为空时，页面由于缓存为空长时间渲染异常问题
    - 推荐内容缓存有效期默认为 **6小时**，减少频繁的外部接口请求
  - 支持主动更新推荐缓存，提升前端响应速度
  - 缓解不同地区 CDN 节点可能存在的限流问题
#### 3. 进一步计划
1. **定时任务**：
   - 增加定时任务，定期调用 `refresh_recommend`，确保缓存内容及时更新
2. **图片资源优化**：
   - 当启用全局图片时，`refresh_recommend` 将支持后台预下载推荐图片资源，进一步提升加载效率
   - 考虑对全局图片资源按不同域名进行细分优化，支持更精细的管理策略
