### PR TITLE
fix(filemanager): correct season_episode metadata mapping

### DIFF
--- a/app/modules/filemanager/__init__.py
+++ b/app/modules/filemanager/__init__.py
@@ -1185,7 +1185,7 @@ class FileManagerModule(_ModuleBase):
             # 集号
             "episode": meta.episode_seqs,
             # 季集 SxxExx
-            "season_episode": "%s%s" % (meta.season, meta.episodes),
+            "season_episode": "%s%s" % (meta.season, meta.episode),
             # 段/节
             "part": meta.part,
             # 剧集标题


### PR DESCRIPTION
- Update season_episode field in FileManagerModule to use meta.episode instead of meta.episodes
- This change ensures accurate season and episode information is displayed