### PR TITLE
feat(transfer): match source dir in subdirs or prioritize same drive

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -657,21 +657,16 @@ class TransferChain(ChainBase, metaclass=Singleton):
 
         # 查询整理目标目录
         if not task.target_directory:
-            if task.src_match:
-                # 按源目录匹配，以便找到更合适的目录配置
-                task.target_directory = self.directoryhelper.get_dir(media=task.mediainfo,
-                                                                     storage=task.fileitem.storage,
-                                                                     src_path=Path(task.fileitem.path),
-                                                                     target_storage=task.target_storage)
-            elif task.target_path:
+            if task.target_path:
                 # 指定目标路径，`手动整理`场景下使用，忽略源目录匹配，使用指定目录匹配
                 task.target_directory = self.directoryhelper.get_dir(media=task.mediainfo,
                                                                      dest_path=task.target_path,
                                                                      target_storage=task.target_storage)
             else:
-                # 未指定目标路径，根据媒体信息获取目标目录
+                # 启用源目录匹配时，根据源目录匹配下载目录，否则按源目录同盘优先原则，如无源目录，则根据媒体信息获取目标目录
                 task.target_directory = self.directoryhelper.get_dir(media=task.mediainfo,
                                                                      storage=task.fileitem.storage,
+                                                                     src_path=Path(task.fileitem.path),
                                                                      target_storage=task.target_storage)
 
         # 执行整理
@@ -788,8 +783,7 @@ class TransferChain(ChainBase, metaclass=Singleton):
                     ),
                     mediainfo=mediainfo,
                     downloader=torrent.downloader,
-                    download_hash=torrent.hash,
-                    src_match=True
+                    download_hash=torrent.hash
                 )
 
                 # 设置下载任务状态
@@ -879,8 +873,7 @@ class TransferChain(ChainBase, metaclass=Singleton):
                     library_type_folder: bool = None, library_category_folder: bool = None,
                     season: int = None, epformat: EpisodeFormat = None, min_filesize: int = 0,
                     downloader: str = None, download_hash: str = None,
-                    force: bool = False, src_match: bool = False,
-                    background: bool = True) -> Tuple[bool, str]:
+                    force: bool = False, background: bool = True) -> Tuple[bool, str]:
         """
         执行一个复杂目录的整理操作
         :param fileitem: 文件项
@@ -899,7 +892,6 @@ class TransferChain(ChainBase, metaclass=Singleton):
         :param downloader: 下载器
         :param download_hash: 下载记录hash
         :param force: 是否强制整理
-        :param src_match: 是否源目录匹配
         :param background: 是否后台运行
         返回：成功标识，错误信息
         """
@@ -1072,7 +1064,6 @@ class TransferChain(ChainBase, metaclass=Singleton):
                 target_storage=target_storage,
                 target_path=target_path,
                 transfer_type=transfer_type,
-                src_match=src_match,
                 scrape=scrape,
                 library_type_folder=library_type_folder,
                 library_category_folder=library_category_folder,

--- a/app/helper/directory.py
+++ b/app/helper/directory.py
@@ -68,10 +68,16 @@ class DirectoryHelper:
         # 电影/电视剧
         media_type = media.type.value
         dirs = self.get_dirs()
+
+        # 如果存在源目录，并源目录为任一下载目录的子目录时，则进行源目录匹配，否则，允许源目录按同盘优先的逻辑匹配
+        matching_dirs = [d for d in dirs if src_path.is_relative_to(d.download_path)] if src_path else []
+        # 根据是否有匹配的源目录，决定要考虑的目录集合
+        dirs_to_consider = matching_dirs if matching_dirs else dirs
+
         # 已匹配的目录
         matched_dirs: List[schemas.TransferDirectoryConf] = []
         # 按照配置顺序查找
-        for d in dirs:
+        for d in dirs_to_consider:
             # 没有启用整理的目录
             if not d.monitor_type and not include_unsorted:
                 continue
@@ -80,9 +86,6 @@ class DirectoryHelper:
                 continue
             # 目标存储类型不匹配
             if target_storage and d.library_storage != target_storage:
-                continue
-            # 有源目录时，源目录不匹配下载目录
-            if src_path and not src_path.is_relative_to(d.download_path):
                 continue
             # 有目标目录时，目标目录不匹配媒体库目录
             if dest_path and dest_path != Path(d.library_path):

--- a/app/monitor.py
+++ b/app/monitor.py
@@ -226,8 +226,7 @@ class Monitor(metaclass=Singleton):
                         basename=event_path.stem,
                         extension=event_path.suffix[1:],
                         size=file_size
-                    ),
-                    src_match=True
+                    )
                 )
             except Exception as e:
                 logger.error("目录监控发生错误：%s - %s" % (str(e), traceback.format_exc()))

--- a/app/schemas/transfer.py
+++ b/app/schemas/transfer.py
@@ -54,7 +54,6 @@ class TransferTask(BaseModel):
     target_storage: Optional[str] = None
     target_path: Optional[Path] = None
     transfer_type: Optional[str] = None
-    src_match: Optional[bool] = False
     scrape: Optional[bool] = False
     library_type_folder: Optional[bool] = False
     library_category_folder: Optional[bool] = False


### PR DESCRIPTION
- 统一源目录匹配逻辑
  1. 移除参数 `src_match`，对源目录匹配逻辑进行统一调整
  2. 调整后的匹配逻辑：  
     - 优先匹配子目录：当源目录存在，且为任一下载目录的子目录时，进行源目录匹配
     - 同盘优先匹配：若源目录不属于下载目录的子目录，则允许按“同盘优先”的逻辑进行匹配
- 修复的问题：
  1. 解决了手工整理、下载器监控、目录监控、历史纪录重新整理等场景中，因源目录匹配逻辑不一致而导致目标目录不一致引发的类似硬链接失败等一系列问题
  2. 优化匹配逻辑的统一性，确保多种场景下行为一致，实现下载目录解耦媒体库目录
- fix #3636  
- fix #3060  