### PR TITLE
Revert token validation in incoming_verify

### DIFF
--- a/app/api/endpoints/message.py
+++ b/app/api/endpoints/message.py
@@ -106,17 +106,18 @@ def wechat_verify(echostr: str, msg_signature: str, timestamp: Union[str, int], 
         return str(err)
 
 
-def vocechat_verify() -> Any:
+def vocechat_verify(token: str) -> Any:
     """
     VoceChat验证响应
     """
-    return {"status": "OK"}
+    if token == settings.API_TOKEN:
+        return {"status": "OK"}
+    return {"status": "API_TOKEN ERROR"}
 
 
 @router.get("/", summary="回调请求验证")
 def incoming_verify(token: str = None, echostr: str = None, msg_signature: str = None,
-                    timestamp: Union[str, int] = None, nonce: str = None, source: str = None,
-                    _: schemas.TokenPayload = Depends(verify_apitoken)) -> Any:
+                    timestamp: Union[str, int] = None, nonce: str = None, source: str = None) -> Any:
     """
     微信/VoceChat等验证响应
     """
@@ -124,7 +125,7 @@ def incoming_verify(token: str = None, echostr: str = None, msg_signature: str =
                 f"msg_signature={msg_signature}, timestamp={timestamp}, nonce={nonce}")
     if echostr and msg_signature and timestamp and nonce:
         return wechat_verify(echostr, msg_signature, timestamp, nonce, source)
-    return vocechat_verify()
+    return vocechat_verify(token)
 
 
 @router.post("/webpush/subscribe", summary="客户端webpush通知订阅", response_model=schemas.Response)


### PR DESCRIPTION
- 因为微信验证请求不会携带token，目前安装v2版本后在企微后台保存API修改会失败，故移除了incoming_verify对token的校验，确保微信验证请求不会被拦截。
![image](https://github.com/user-attachments/assets/8b2e1af3-148d-446c-9ebd-18b32808fad6)
https://developer.work.weixin.qq.com/document/10514#%E9%AA%8C%E8%AF%81url%E6%9C%89%E6%95%88%E6%80%A7
![image](https://github.com/user-attachments/assets/f73c6fce-cc9a-4405-bcc1-a14da94024ae)
- 在vocechat_verify中添加回token参数，在方法内部进行验证