### PR TITLE
fix(transfer): switch downloader monitor to foreground

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -796,7 +796,7 @@ class TransferChain(ChainBase, metaclass=Singleton):
                 state, errmsg = self.do_transfer(
                     fileitem=FileItem(
                         storage="local",
-                        path=str(file_path),
+                        path=str(file_path).replace("\\", "/"),
                         type="dir" if not file_path.is_file() else "file",
                         name=file_path.name,
                         size=file_path.stat().st_size,
@@ -804,7 +804,8 @@ class TransferChain(ChainBase, metaclass=Singleton):
                     ),
                     mediainfo=mediainfo,
                     downloader=torrent.downloader,
-                    download_hash=torrent.hash
+                    download_hash=torrent.hash,
+                    background=False,
                 )
 
                 # 设置下载任务状态


### PR DESCRIPTION
- 调整下载器监控为立即整理模式
    - 避免多文件种子直接整理根目录时，导致后续同一目录种子无法标记为“已整理”，从而出现反复循环的问题
    - 避免因队列排序问题，导致属于同一目录的种子整理失败，而实际上前一个种子已成功整理根目录的情况
- 调整 `Path` 传递逻辑，兼容 Windows 处理




