### PR TITLE
fix: - 修复订阅识别词在下载阶段不生效的问题

### DIFF
--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -326,19 +326,16 @@ class ChainBase(metaclass=ABCMeta):
 
     def filter_torrents(self, rule_groups: List[str],
                         torrent_list: List[TorrentInfo],
-                        season_episodes: Dict[int, list] = None,
                         mediainfo: MediaInfo = None) -> List[TorrentInfo]:
         """
         过滤种子资源
         :param rule_groups:  过滤规则组名称列表
         :param torrent_list:  资源列表
-        :param season_episodes:  季集数过滤 {season:[episodes]}
         :param mediainfo:  识别的媒体信息
         :return: 过滤后的资源列表，添加资源优先级
         """
         return self.run_module("filter_torrents", rule_groups=rule_groups,
-                               torrent_list=torrent_list, season_episodes=season_episodes,
-                               mediainfo=mediainfo)
+                               torrent_list=torrent_list, mediainfo=mediainfo)
 
     def download(self, content: Union[Path, str], download_dir: Path, cookie: str,
                  episodes: Set[int] = None, category: str = None,

--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -584,6 +584,8 @@ class SubscribeChain(ChainBase, metaclass=Singleton):
                                 # 重新识别元数据
                                 torrent_meta = MetaInfo(title=torrent_info.title, subtitle=torrent_info.description,
                                                         custom_words=custom_words_list)
+                                # 更新识别元数据缓存
+                                context.meta_info = torrent_meta
                                 # 媒体信息需要重新识别
                                 torrent_mediainfo = None
 
@@ -1145,16 +1147,17 @@ class SubscribeChain(ChainBase, metaclass=Singleton):
         # 默认过滤规则
         default_rule = self.systemconfig.get(SystemConfigKey.SubscribeDefaultParams) or {}
         return {
-            "include": subscribe.include or default_rule.get("include"),
-            "exclude": subscribe.exclude or default_rule.get("exclude"),
-            "quality": subscribe.quality or default_rule.get("quality"),
-            "resolution": subscribe.resolution or default_rule.get("resolution"),
-            "effect": subscribe.effect or default_rule.get("effect"),
-            "tv_size": default_rule.get("tv_size"),
-            "movie_size": default_rule.get("movie_size"),
-            "min_seeders": default_rule.get("min_seeders"),
-            "min_seeders_time": default_rule.get("min_seeders_time"),
-        }
+            key: value for key, value in {
+                "include": subscribe.include or default_rule.get("include"),
+                "exclude": subscribe.exclude or default_rule.get("exclude"),
+                "quality": subscribe.quality or default_rule.get("quality"),
+                "resolution": subscribe.resolution or default_rule.get("resolution"),
+                "effect": subscribe.effect or default_rule.get("effect"),
+                "tv_size": default_rule.get("tv_size"),
+                "movie_size": default_rule.get("movie_size"),
+                "min_seeders": default_rule.get("min_seeders"),
+                "min_seeders_time": default_rule.get("min_seeders_time"),
+            }.items() if value is not None}
 
     def subscribe_files_info(self, subscribe: Subscribe) -> Optional[SubscrbieInfo]:
         """

--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -384,7 +384,7 @@ class SubscribeChain(ChainBase, metaclass=Singleton):
                     self.message.put('没有找到订阅！', title="订阅搜索", role="system")
             logger.debug(f"search Lock released at {datetime.now()}")
 
-    def update_subscribe_priority(self, subscribe: Subscribe, meta: MetaInfo,
+    def update_subscribe_priority(self, subscribe: Subscribe, meta: MetaBase,
                                   mediainfo: MediaInfo, downloads: List[Context]):
         """
         更新订阅已下载资源的优先级
@@ -407,7 +407,7 @@ class SubscribeChain(ChainBase, metaclass=Singleton):
             # 正在洗版，更新资源优先级
             logger.info(f'{mediainfo.title_year} 正在洗版，更新资源优先级为 {priority}')
 
-    def finish_subscribe_or_not(self, subscribe: Subscribe, meta: MetaInfo, mediainfo: MediaInfo,
+    def finish_subscribe_or_not(self, subscribe: Subscribe, meta: MetaBase, mediainfo: MediaInfo,
                                 downloads: List[Context] = None,
                                 lefts: Dict[Union[int | str], Dict[int, NotExistMediaInfo]] = None,
                                 force: bool = False):
@@ -1266,7 +1266,7 @@ class SubscribeChain(ChainBase, metaclass=Singleton):
         subscribe_info.episodes = episodes
         return subscribe_info
 
-    def check_and_handle_existing_media(self, subscribe: Subscribe, meta: MetaInfo,
+    def check_and_handle_existing_media(self, subscribe: Subscribe, meta: MetaBase,
                                         mediainfo: MediaInfo, mediakey: str):
         """
         检查媒体是否已经存在，并根据情况执行相应的操作

--- a/app/schemas/transfer.py
+++ b/app/schemas/transfer.py
@@ -48,9 +48,9 @@ class TransferTask(BaseModel):
     """
     文件整理任务
     """
-    fileitem: FileItem = None
-    meta: Any = None
-    mediainfo: Optional[Any] = None
+    fileitem: Optional[FileItem] = None
+    meta: Optional[MetaInfo] = None
+    mediainfo: Optional[MediaInfo] = None
     target_directory: Optional[TransferDirectoryConf] = None
     target_storage: Optional[str] = None
     target_path: Optional[Path] = None


### PR DESCRIPTION
- 将`季集匹配`从`优先级规则组匹配模块`移至`种子帮助类`
- - `FilterModule.__match_season_episodes()` ==> `TorrentHelper.match_season_episodes()`
- - 确保需要`订阅识别词` `偏移季集`的种子能够正确匹配
- `订阅刷新`中更新应用订阅识别词的`种子元数据`,
- 附加参数过滤空项
