### PR TITLE
app/core/context: 限制评分人数必须大于10

### DIFF
--- a/app/core/context.py
+++ b/app/core/context.py
@@ -402,7 +402,10 @@ class MediaInfo:
         # 合集ID
         self.collection_id = info.get('collection_id')
         # 评分
-        self.vote_average = round(float(info.get('vote_average')), 1) if info.get('vote_average') else 0
+        if info.get("vote_average") and info.get('vote_count') > 10:
+            self.vote_average = round(float(info.get("vote_average")), 1)
+        else:
+            self.vote_average = 0
         # 描述
         self.overview = info.get('overview')
         # 风格


### PR DESCRIPTION
当评分人数很低的时候，会导致冷门电影/电视评分失真。例如tmdb 628601。
在这里限制评分人数至少超过10人。低于10人的按0分计算。

本来想设置成100, 但是考虑到有些剧集可能评分人数比较少。因此设置成10。