### PR TITLE
fix: 使用后台转移计算任务数量时某些fileitem.size是None

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -326,7 +326,7 @@ class JobManager:
             # 计算状态为完成的任务数
             if __mediaid__ not in self._job_view:
                 return 0
-            return sum([task.fileitem.size for task in self._job_view[__mediaid__].tasks if task.state == "completed"])
+            return sum([task.fileitem.size for task in self._job_view[__mediaid__].tasks if task.state == "completed" and task.fileitem.size is not None])
 
     def total(self) -> int:
         """


### PR DESCRIPTION
不太确定这个BUG是哪里造成的，先在求和的地方简单加一个判断过滤
```
INFO:    filemanager - 正在整理文件：【local】/media/下载/Strm/ANIOpen/2021-1/轉生成蜘蛛又怎樣！/[ANi]轉生成蜘蛛又怎樣！[16][1080P][Baha][WEB-DL].strm 到 【local】/media/媒体库/Strm/电视剧/日番/转生成蜘蛛又怎样！ (2021)/Season 1/转生成蜘蛛 又怎样！ S01E16 -1080p -ANi -Baha.strm，操作类型：link
INFO:    filemanager - /media/下载/Strm/ANIOpen/2021-1/轉生成蜘蛛又怎樣！/ 目录下没有找到字幕文件...
INFO:    filemanager - 文件 /media/下载/Strm/ANIOpen/2021-1/轉生成蜘蛛又怎樣！/[ANi]轉生成蜘蛛又怎樣！[16][1080P][Baha][WEB-DL].strm 整理成功
INFO:    transfer.py - [ANi]轉生成蜘蛛又怎樣！[16][1080P][Baha][WEB-DL].strm 入库成功：/media/媒体库/Strm/电视剧/日番/转生成蜘蛛又怎样！ (2021)/
ERROR:   transfer.py - 整理队列处理出现错误：unsupported operand type(s) for +: 'int' and 'NoneType' - Traceback (most recent call last):
  File "/app/app/chain/transfer.py", line 576, in __start_transfer
    state, err_msg = self.__handle_transfer(task=task, callback=item.callback)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/chain/transfer.py", line 717, in __handle_transfer
    return callback(task, transferinfo)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/chain/transfer.py", line 481, in __default_callback
    transferinfo.total_size = self.jobview.size(task.mediainfo,
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app/chain/transfer.py", line 329, in size
    return sum([task.fileitem.size for task in self._job_view[__mediaid__].tasks if task.state == "completed"])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'

INFO:    transfer.py - 整理队列处理完成，共整理 57 个文件，失败 0 个
```