### PR TITLE
fix(cache): check cache existence when skip_none is False

### DIFF
--- a/app/core/cache.py
+++ b/app/core/cache.py
@@ -500,6 +500,21 @@ def cached(region: Optional[str] = None, maxsize: int = 1000, ttl: int = 1800,
             return False
         return True
 
+    def is_valid_cache_value(cache_key: str, cached_value: Any, cache_region: str) -> bool:
+        """
+        判断指定的值是否为一个有效的缓存值
+
+        :param cache_key: 缓存的键
+        :param cached_value: 缓存的值
+        :param cache_region: 缓存的区
+        :return: 若值是有效的缓存值返回 True，否则返回 False
+        """
+        # 如果 skip_none 为 False，且 value 为 None，需要判断缓存实际是否存在
+        if not skip_none and cached_value is None:
+            if not cache_backend.exists(key=cache_key, region=cache_region):
+                return False
+        return True
+
     def decorator(func):
 
         # 获取缓存区
@@ -511,7 +526,7 @@ def cached(region: Optional[str] = None, maxsize: int = 1000, ttl: int = 1800,
             cache_key = cache_backend.get_cache_key(func, args, kwargs)
             # 尝试获取缓存
             cached_value = cache_backend.get(cache_key, region=cache_region)
-            if should_cache(cached_value):
+            if should_cache(cached_value) and is_valid_cache_value(cache_key, cached_value, cache_region):
                 return cached_value
             # 执行函数并缓存结果
             result = func(*args, **kwargs)

--- a/app/modules/fanart/__init__.py
+++ b/app/modules/fanart/__init__.py
@@ -420,16 +420,19 @@ class FanartModule(_ModuleBase):
         return result
 
     @classmethod
-    @cached(maxsize=settings.CACHE_CONF["fanart"], ttl=settings.CACHE_CONF["meta"], skip_none=False)
+    @cached(maxsize=settings.CACHE_CONF["fanart"], ttl=settings.CACHE_CONF["meta"])
     def __request_fanart(cls, media_type: MediaType, queryid: Union[str, int]) -> Optional[dict]:
         if media_type == MediaType.MOVIE:
             image_url = cls._movie_url % queryid
         else:
             image_url = cls._tv_url % queryid
         try:
-            ret = RequestUtils(proxies=cls._proxies, timeout=10).get_res(image_url)
+            ret = RequestUtils(proxies=cls._proxies, timeout=10).get_res(image_url, raise_exception=True)
             if ret:
                 return ret.json()
+            else:
+                logger.debug(f"未能获取到 {queryid} 的Fanart图片")
+                return {}
         except Exception as err:
             logger.error(f"获取{queryid}的Fanart图片失败：{str(err)}")
-        return None
+            return None


### PR DESCRIPTION
- 细化 `fanart` 图片请求的缓存逻辑，网络连接异常时不再缓存失败的请求结果，针对请求返回 `404` 等情况，保持原有的缓存逻辑
- 缓存装饰器中，当 `skip_none=False` 时，新增缓存键存在性检查，提高缓存策略的精细化控制
- fix #3789