### PR TITLE
chore(deps): add async_timeout~=5.0.1 for redis if Python < 3.11.3

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -66,3 +66,4 @@ aiofiles~=24.1.0
 jieba~=0.42.1
 rsa~=4.9
 redis~=5.2.1
+async_timeout~=5.0.1; python_full_version < "3.11.3"


### PR DESCRIPTION
- 添加 `redis` 的第三方包依赖，相关细节参考如下
- https://github.com/redis/redis-py/issues/2633

```
# the functionality is available in 3.11.x but has a major issue before
# 3.11.3. See https://github.com/redis/redis-py/issues/2633
if sys.version_info >= (3, 11, 3):
    from asyncio import timeout as async_timeout
else:
    from async_timeout import timeout as async_timeout
```