### PR TITLE
添加为指定字幕添加.default后缀设置为默认字幕功能

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -255,6 +255,8 @@ class ConfigModel(BaseModel):
     )
     # 启用分词搜索
     TOKENIZED_SEARCH: bool = False
+    # 为指定默认字幕添加.default后缀,默认不启用
+    DEFAULT_SUB: Optional[str] = None
 
 
 class Settings(BaseSettings, ConfigModel, LogConfigModel):

--- a/app/modules/filemanager/__init__.py
+++ b/app/modules/filemanager/__init__.py
@@ -676,11 +676,15 @@ class FileManagerModule(_ModuleBase):
                         ".zh-tw": ".繁体中文"
                     }
                     new_sub_tag_list = [
-                        new_file_type if t == 0 else "%s%s(%s)" % (new_file_type,
-                                                                   new_sub_tag_dict.get(
-                                                                       new_file_type, ""
-                                                                   ),
-                                                                   t) for t in range(6)
+                        (".default" + new_file_type if (
+                            (settings.DEFAULT_SUB == "zh-cn" and new_file_type == ".chi.zh-cn") or
+                            (settings.DEFAULT_SUB == "zh-tw" and new_file_type == ".zh-tw") or
+                            (settings.DEFAULT_SUB == "eng" and new_file_type == ".eng")
+                        ) else new_file_type) if t == 0 else "%s%s(%s)" % (new_file_type,
+                                                                           new_sub_tag_dict.get(
+                                                                               new_file_type, ""
+                                                                           ),
+                                                                           t) for t in range(6)
                     ]
                     for new_sub_tag in new_sub_tag_list:
                         new_file: Path = target_file.with_name(target_file.stem + new_sub_tag + file_ext)

--- a/config/app.env
+++ b/config/app.env
@@ -63,3 +63,5 @@ OCR_HOST=https://movie-pilot.org
 PLUGIN_MARKET=https://github.com/jxxghp/MoviePilot-Plugins,https://github.com/thsrite/MoviePilot-Plugins,https://github.com/InfinityPacer/MoviePilot-Plugins,https://github.com/honue/MoviePilot-Plugins
 # 搜索多个名称，true/false，为true时搜索时会同时搜索中英文及原始名称，搜索结果会更全面，但会增加搜索时间；为false时其中一个名称搜索到结果或全部名称搜索完毕即停止
 SEARCH_MULTIPLE_NAME=true
+# 为指定字幕添加.default后缀设置为默认字幕，支持为'zh-cn'，'zh-tw'，'eng'添加默认字幕，未定义或设置为None则不添加
+DEFAULT_SUB=None


### PR DESCRIPTION
根据Emby、jellyfin的文件命名规则，为字幕添加.default后缀可以设置指定字幕文件为默认字幕，播放时可以不用手动选择外挂字幕文件了
[Emby命名规范](https://emby.media/support/articles/Subtitles.html)
[jellyfin命名规范](https://jellyfin.org/docs/general/server/media/external-files/)
[Plex](https://support.plex.tv/articles/200471133-adding-local-subtitles-to-your-media/)不支持这种后缀，添加上去没有用

目前是在配置文件内添加了一个配置项，默认不启用，如果启用的话需要设置环境变量DEFAULT_SUB为'zh-cn'，'zh-tw'，'eng'其中一个
处理后字幕的后缀名会变为如下格式：
.default.chi.zh-cn
.default.zh-tw
.default.eng