### PR TITLE
fix: mtype为空且tmdbid在movie和tv中都存在时的识别错误问题

### DIFF
--- a/app/modules/themoviedb/__init__.py
+++ b/app/modules/themoviedb/__init__.py
@@ -118,11 +118,12 @@ class TheMovieDbModule(_ModuleBase):
 
         # 识别匹配
         if not cache_info or not cache:
+            info = None
             # 缓存没有或者强制不使用缓存
             if tmdbid:
                 # 直接查询详情
                 info = self.tmdb.get_info(mtype=mtype, tmdbid=tmdbid)
-            elif meta:
+            if not info and meta:
                 info = {}
                 # 简体名称
                 zh_name = zhconv.convert(meta.cn_name, "zh-hans") if meta.cn_name else None
@@ -173,7 +174,7 @@ class TheMovieDbModule(_ModuleBase):
                     info = self.tmdb.get_info(mtype=info.get("media_type"),
                                               tmdbid=info.get("id"))
             else:
-                logger.error("识别媒体信息时未提供元数据或tmdbid")
+                logger.error("识别媒体信息时未提供元数据或唯一且有效的tmdbid")
                 return None
 
             # 保存到缓存

--- a/app/modules/themoviedb/tmdbapi.py
+++ b/app/modules/themoviedb/tmdbapi.py
@@ -578,7 +578,7 @@ class TmdbApi:
                 genre_ids.append(genre.get('id'))
             return genre_ids
 
-        # 查询TMDB详ngeq
+        # 查询TMDB详情
         if mtype == MediaType.MOVIE:
             tmdb_info = self.__get_movie_detail(tmdbid)
             if tmdb_info:
@@ -588,13 +588,20 @@ class TmdbApi:
             if tmdb_info:
                 tmdb_info['media_type'] = MediaType.TV
         else:
-            tmdb_info = self.__get_tv_detail(tmdbid)
-            if tmdb_info:
+            tmdb_info_tv = self.__get_tv_detail(tmdbid)
+            tmdb_info_movie = self.__get_movie_detail(tmdbid)
+            if tmdb_info_tv and tmdb_info_movie:
+                tmdb_info = None
+                logger.warn(f"无法判断tmdb_id:{tmdbid} 是电影还是电视剧")
+            elif tmdb_info_tv:
+                tmdb_info = tmdb_info_tv
                 tmdb_info['media_type'] = MediaType.TV
+            elif tmdb_info_movie:
+                tmdb_info = tmdb_info_movie
+                tmdb_info['media_type'] = MediaType.MOVIE
             else:
-                tmdb_info = self.__get_movie_detail(tmdbid)
-                if tmdb_info:
-                    tmdb_info['media_type'] = MediaType.MOVIE
+                tmdb_info = None
+                logger.warn(f"tmdb_id:{tmdbid} 未查询到媒体信息")
 
         if tmdb_info:
             # 转换genreid


### PR DESCRIPTION
fix #3912
调整tmdb识别匹配逻辑。当未提供mtype时，原来的做法会将tmdbid先当作tv去匹配tmdb_info，匹配不到才会尝试movie。修改后movie和tv都去匹配，如果同一个tmdbid在movie和tv都有结果返回则放弃用tmdbid，进入meta的判断逻辑。
