### PR TITLE
fix docker container log duplicate printing

### DIFF
--- a/app/log.py
+++ b/app/log.py
@@ -246,12 +246,12 @@ class LoggerManager:
         else:
             # 使用默认日志文件
             logfile = self._default_log_file
-
-        # 获取调用者的模块的logger
-        _logger = self._loggers.get(logfile)
-        if not _logger:
-            _logger = self.__setup_logger(log_file=logfile)
-            self._loggers[logfile] = _logger
+        with LoggerManager._lock:  # 添加锁
+            # 获取调用者的模块的logger
+            _logger = self._loggers.get(logfile)
+            if not _logger:
+                _logger = self.__setup_logger(log_file=logfile)
+                self._loggers[logfile] = _logger
         # 调用logger的方法打印日志
         if hasattr(_logger, method):
             log_method = getattr(_logger, method)


### PR DESCRIPTION
之前docker容器日志，重启完mp后，一旦插件开始工作打印log，容器日志就会重复打印 ，如下所示

INFO: subscribe.py - 故都春晓图 (2024) 未下载完整，继续订阅 ...
INFO:moviepilot:subscribe.py - 故都春晓图 (2024) 未下载完整，继续订阅 ...