### PR TITLE
20250314 修改rss.py

### DIFF
--- a/app/helper/rss.py
+++ b/app/helper/rss.py
@@ -301,6 +301,8 @@ class RssHelper:
                         if pubdate:
                             # 转换为时间
                             pubdate = StringUtils.get_time(pubdate)
+                        # 获取豆瓣昵称
+                        nickname = DomUtils.tag_value(item, "dc:createor", default="")
                         # 返回对象
                         tmp_dict = {'title': title,
                                     'enclosure': enclosure,
@@ -308,6 +310,9 @@ class RssHelper:
                                     'description': description,
                                     'link': link,
                                     'pubdate': pubdate}
+                        # 如果豆瓣昵称不为空，返回数据增加豆瓣昵称，供doubansync插件获取
+                        if nickname:
+                            tmp_dict['nickname'] = nickname
                         ret_array.append(tmp_dict)
                     except Exception as e1:
                         logger.debug(f"解析RSS失败：{str(e1)} - {traceback.format_exc()}")


### PR DESCRIPTION
修改原因：管理员在mp添加多个豆瓣id时，不同的豆瓣用户订阅内容，发送通知时统一为“豆瓣想看”,无法区分 修改后：增加豆瓣昵称获取，便于推送订阅通知消息时，区分豆瓣用户名称