### PR TITLE
fix: 修正文件扩展名匹配模式中的边界问题

### DIFF
--- a/app/utils/system.py
+++ b/app/utils/system.py
@@ -211,7 +211,7 @@ class SystemUtils:
             min_filesize = 0
 
         files = []
-        pattern = r".*(" + "|".join(extensions) + ")$"
+        pattern = r".*\b(" + "|".join(extensions) + ")$"
 
         # 遍历目录及子目录
         for path in directory.rglob('**/*'):


### PR DESCRIPTION
列出文件时不要匹配到类似'.d1c2464f68b5514c1d6e30a55e5506782900850e.parts'的文件

添加`\b`，避免因匹配`.*.ts$`而匹配到`.*.parts$`，更新后变为`.*\b.ts$`

另一个办法是给`.`前面加一个转义，也即是`.*\.ts$`，也可以是`.*\b\.ts$`

修改前":
<img width="906" alt="修改前" src="https://github.com/user-attachments/assets/85083170-4390-4cb3-8d38-019c3eb9af40" />

---
修改后":
<img width="895" alt="修改后" src="https://github.com/user-attachments/assets/bc2dc066-8804-4c46-9606-5205175d7bad" />
