### PR TITLE
修复馒头请求参数错误的问题

### DIFF
--- a/app/chain/site.py
+++ b/app/chain/site.py
@@ -1,7 +1,6 @@
 import base64
 import re
 from datetime import datetime
-from time import time
 from typing import Optional, Tuple, Union, Dict
 from urllib.parse import urljoin
 
@@ -178,12 +177,9 @@ class SiteChain(ChainBase):
         domain = StringUtils.get_url_domain(site.url)
         url = f"https://api.{domain}/api/member/profile"
         headers = {
-            "Content-Type": "application/json",
             "User-Agent": user_agent,
             "Accept": "application/json, text/plain, */*",
-            "Authorization": site.token,
             "x-api-key": site.apikey,
-            "ts": str(int(time()))
         }
         res = RequestUtils(
             headers=headers,
@@ -193,27 +189,10 @@ class SiteChain(ChainBase):
         if res is None:
             return False, "无法打开网站！"
         if res.status_code == 200:
-            state = False
-            message = "鉴权已过期或无效"
             user_info = res.json() or {}
             if user_info.get("data"):
-                # 更新最后访问时间
-                del headers["x-api-key"]
-                res = RequestUtils(headers=headers,
-                                   timeout=site.timeout or 15,
-                                   proxies=settings.PROXY if site.proxy else None,
-                                   referer=f"{site.url}index"
-                                   ).post_res(url=f"https://api.{domain}/api/member/updateLastBrowse")
-                state = True
-                message = "连接成功，但更新状态失败"
-                if res and res.status_code == 200:
-                    update_info = res.json() or {}
-                    if "code" in update_info and int(update_info["code"]) == 0:
-                        message = "连接成功"
-            elif user_info.get("message"):
-                # 使用馒头的错误提示
-                message = user_info.get("message")
-            return state, message
+                return True, "连接成功"
+            return False, user_info.get("message", "鉴权已过期或无效")
         else:
             return False, f"错误：{res.status_code} {res.reason}"
 

--- a/app/modules/indexer/spider/mtorrent.py
+++ b/app/modules/indexer/spider/mtorrent.py
@@ -191,7 +191,6 @@ class MTorrentSpider:
                 'id': torrent_id
             },
             'header': {
-                'Content-Type': 'application/json',
                 'User-Agent': f'{self._ua}',
                 'Accept': 'application/json, text/plain, */*',
                 'x-api-key': self._apikey


### PR DESCRIPTION
1. 当没有请求体的时候，不要指定Content-Type: application/json，否则馒头会因为判断Content-Length为0而报请求参数错误
2. 馒头测试逻辑移除Authorization的使用，会触发馒头的风控警告