### PR TITLE
fix: 修复前端传递了[""]这样的空list导致判空时逻辑异常的问题

### DIFF
--- a/app/api/endpoints/system.py
+++ b/app/api/endpoints/system.py
@@ -283,6 +283,9 @@ def set_setting(key: str, value: Union[list, dict, bool, int, str] = None,
         success, message = settings.update_setting(key=key, value=value)
         return schemas.Response(success=success, message=message)
     elif key in {item.value for item in SystemConfigKey}:
+        if isinstance(value, list):
+            value = list(filter(None, value))
+            value = value if value else None
         SystemConfigOper().set(key, value)
         return schemas.Response(success=True)
     else:

--- a/app/core/meta/releasegroup.py
+++ b/app/core/meta/releasegroup.py
@@ -97,6 +97,8 @@ class ReleaseGroupsMatcher(metaclass=Singleton):
         if not groups:
             # 自定义组
             custom_release_groups = self.systemconfig.get(SystemConfigKey.CustomReleaseGroups)
+            if isinstance(custom_release_groups, list):
+                custom_release_groups = list(filter(None, custom_release_groups))
             if custom_release_groups:
                 custom_release_groups_str = '|'.join(custom_release_groups)
                 groups = f"{self.__release_groups}|{custom_release_groups_str}"


### PR DESCRIPTION
词表已清空但是前端传递了存在空字符串的空list:
<img width="383" alt="image" src="https://github.com/user-attachments/assets/0f33a9ce-e7e3-4084-b240-427cb63fa27c" />

存储的时候会原样存储:
<img width="626" alt="image" src="https://github.com/user-attachments/assets/13075de2-9f25-4644-b363-704e64693449" />


最终在制作组匹配的时候这里的判断会为True:
<img width="794" alt="image" src="https://github.com/user-attachments/assets/35d94291-b208-484d-a6e5-3483260a6e18" />

最终导致制作组前面会多一个@符号:
<img width="797" alt="image" src="https://github.com/user-attachments/assets/7b6bdd5c-485a-422f-bc32-fb29666abba7" />
