### PR TITLE
fix: 修复mt的/api/torrent/genDlToken请求

### DIFF
--- a/app/modules/indexer/spider/mtorrent.py
+++ b/app/modules/indexer/spider/mtorrent.py
@@ -187,13 +187,12 @@ class MTorrentSpider:
         params = {
             'method': 'post',
             'cookie': False,
-            'params': {
-                'id': torrent_id
-            },
+            'params': f'id={torrent_id}',
             'header': {
                 'User-Agent': f'{self._ua}',
                 'Accept': 'application/json, text/plain, */*',
-                'x-api-key': self._apikey
+                'x-api-key': self._apikey,
+                'Content-Type': 'application/x-www-form-urlencoded'
             },
             'result': 'data'
         }


### PR DESCRIPTION
目前使用mt会报错  无法获取下载地址
查看 https://test2.m-team.cc/api/doc.html#/%E5%B8%B8%E8%A7%84%E6%8E%A5%E5%8F%A3/%E7%A8%AE%E5%AD%90/genDlToken 文档，请求数据类型为  application/x-www-form-urlencoded