### PR TITLE
修复 开启全局图片缓存后无法显示来自Bing的壁纸

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -238,6 +238,7 @@ class ConfigModel(BaseModel):
     SECURITY_IMAGE_DOMAINS: List[str] = Field(
         default_factory=lambda: ["image.tmdb.org",
                                  "static-mdb.v.geilijiasu.com",
+                                 "bing.com",
                                  "doubanio.com",
                                  "lain.bgm.tv",
                                  "raw.githubusercontent.com",


### PR DESCRIPTION
将bing.com加进安全域名中