### PR TITLE
修复特殊微信id无法处理消息的问题 #4246

### DIFF
--- a/app/chain/message.py
+++ b/app/chain/message.py
@@ -119,7 +119,7 @@ class MessageChain(ChainBase):
         userid = info.userid
         # 用户名
         username = info.username or userid
-        if not userid:
+        if userid is None or userid == '':
             logger.debug(f'未识别到用户ID：{body}{form}{args}')
             return
         # 消息内容


### PR DESCRIPTION
对userid进行更严格的类型检查以处理特殊的id

