### PR TITLE
fix(meta): 修复部分格式识别问题

### DIFF
--- a/app/core/meta/metavideo.py
+++ b/app/core/meta/metavideo.py
@@ -31,7 +31,7 @@ class MetaVideo(MetaBase):
     _part_re = r"(^PART[0-9ABI]{0,2}$|^CD[0-9]{0,2}$|^DVD[0-9]{0,2}$|^DISK[0-9]{0,2}$|^DISC[0-9]{0,2}$)"
     _roman_numerals = r"^(?=[MDCLXVI])M*(C[MD]|D?C{0,3})(X[CL]|L?X{0,3})(I[XV]|V?I{0,3})$"
     _source_re = r"^BLURAY$|^HDTV$|^UHDTV$|^HDDVD$|^WEBRIP$|^DVDRIP$|^BDRIP$|^BLU$|^WEB$|^BD$|^HDRip$|^REMUX$|^UHD$"
-    _effect_re = r"^SDR$|^HDR\d*$|^DOLBY$|^DOVI$|^DV$|^3D$|^REPACK$|^HLG$"
+    _effect_re = r"^SDR$|^HDR\d*$|^DOLBY$|^DOVI$|^DV$|^3D$|^REPACK$|^HLG$|^HDR10(\+|Plus)$"
     _resources_type_re = r"%s|%s" % (_source_re, _effect_re)
     _name_no_begin_re = r"^[\[【].+?[\]】]"
     _name_no_chinese_re = r".*版|.*字幕"
@@ -592,12 +592,12 @@ class MetaVideo(MetaBase):
             self._stop_name_flag = True
             self._last_token_type = "videoencode"
             if not self.video_encode:
-                if re_res.group(1):
-                    self.video_encode = re_res.group(1).upper()
-                elif re_res.group(2):
-                    self.video_encode = re_res.group(2).lower()
+                if re_res.group(2):
+                    self.video_encode = re_res.group(2).upper()
+                elif re_res.group(3):
+                    self.video_encode = re_res.group(3).lower()
                 else:
-                    self.video_encode = re_res.group(0).upper()
+                    self.video_encode = re_res.group(1).upper()
                 self._last_token = self.video_encode
             elif self.video_encode == "10bit":
                 self.video_encode = f"{re_res.group(1).upper()} 10bit"

--- a/app/utils/tokens.py
+++ b/app/utils/tokens.py
@@ -12,7 +12,7 @@ class Tokens:
         self.load_text(text)
 
     def load_text(self, text):
-        splitted_text = re.split(r"\.|\s+|\(|\)|\[|]|-|\+|【|】|/|～|;|&|\||#|_|「|」|~", text)
+        splitted_text = re.split(r"\.|\s+|\(|\)|\[|]|-|【|】|/|～|;|&|\||#|_|「|」|~", text)
         for sub_text in splitted_text:
             if sub_text:
                 self._tokens.append(sub_text)


### PR DESCRIPTION
修复 Commit `23ef8ad` 中 `__init_video_encode` 的错误捕获组使用，现在 `x26[45]` 会正确小写
新增了 `HDR10+` 和 `HDR10Plus` 识别
移除了 `tokens.py` 中对 `+` 号的分割，以此正确识别 `AVS+ HDR10+ DD+`