### PR TITLE
fix(themoviedb): 直接在 API 层次处理剧集组集号

### DIFF
--- a/app/modules/themoviedb/tmdbapi.py
+++ b/app/modules/themoviedb/tmdbapi.py
@@ -1334,7 +1334,18 @@ class TmdbApi:
             return []
         try:
             logger.debug(f"正在获取剧集组：{group_id}...")
-            return self.tv.group_episodes(group_id) or []
+            group_seasons = self.tv.group_episodes(group_id) or []
+            return [
+                {
+                    **group_season,
+                    "episodes": [
+                        {**ep, "episode_number": idx}
+                        # 剧集组中每个季的episode_number从1开始
+                        for idx, ep in enumerate(group_season.get("episodes", []), start=1)
+                    ]
+                }
+                for group_season in group_seasons
+            ]
         except Exception as e:
             logger.error(str(e))
             return []
@@ -1348,9 +1359,6 @@ class TmdbApi:
             return {}
         for group_season in group_seasons:
             if group_season.get('order') == season:
-                # 剧集组中每个季的episode_number从1开始
-                for i, e in enumerate(group_season.get('episodes', []), start=1):
-                    e['episode_number'] = i
                 return group_season
         return {}
 

--- a/database/versions/89d24811e894_2_1_4.py
+++ b/database/versions/89d24811e894_2_1_4.py
@@ -37,7 +37,7 @@ def upgrade() -> None:
     'text': '{% if site_name %}站点：{{ site_name }}{% endif %}'
             '{% if resource_term %}\\n质量：{{ resource_term }}{% endif %}'
             '{% if size %}\\n大小：{{ size }}{% endif %}'
-            '{% if title %}\\n种子：{{ title }}{% endif %}'
+            '{% if torrent_title %}\\n种子：{{ torrent_title }}{% endif %}'
             '{% if pubdate %}\\n发布时间：{{ pubdate }}{% endif %}'
             '{% if freedate %}\\n免费时间：{{ freedate }}{% endif %}'
             '{% if seeders %}\\n做种数：{{ seeders }}{% endif %}'


### PR DESCRIPTION
 - 移除 `season_group_details` 中的冗余集号处理
 - 将下载模板中的 `title` 更改为 `torrent_title`