### PR TITLE
 fix(log): 区分 `主程序日志` 与 `插件日志`

### DIFF
--- a/app/log.py
+++ b/app/log.py
@@ -30,7 +30,7 @@ class LogConfigModel(BaseModel):
     # 备份的日志文件数量
     LOG_BACKUP_COUNT: int = 3
     # 控制台日志格式
-    LOG_CONSOLE_FORMAT: str = "%(leveltext)s%(message)s"
+    LOG_CONSOLE_FORMAT: str = "%(leveltext)s[%(name)s] %(asctime)s %(message)s"
     # 文件日志格式
     LOG_FILE_FORMAT: str = "【%(levelname)s】%(asctime)s - %(message)s"
 


### PR DESCRIPTION
- 增加 `[%(name)s]` 标签，简单区分控制台中的 `主程序日志` 与 `插件日志`  #4328 
- 增加 `%(asctime)s` 标签，显示打印时间