### PR TITLE
修复TransHandler误报success

### DIFF
--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -59,6 +59,8 @@ class TransHandler:
                             current_value.update(value)
                         else:
                             current_value[key] = value
+                    elif isinstance(current_value, bool):
+                        current_value = value
                     elif isinstance(current_value, int):
                         current_value += value
                     else:


### PR DESCRIPTION
由于`bool`类型继承于`int`，现有逻辑会导致`success`等成员变量的赋值操作走进`int`类型的分支，产生不符合预期的结果