### PR TITLE
fix(subscribe): 修复订阅链中种子预识别逻辑

### DIFF
--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -563,7 +563,7 @@ class SubscribeChain(ChainBase, metaclass=Singleton):
             subscribes = self.subscribeoper.list(self.get_states_for_search('R'))
 
             # 预识别所有未识别的种子
-            processed_torrents = {}
+            processed_torrents: dict[str, list[Context]] = {}
             for domain, contexts in torrents.items():
                 processed_torrents[domain] = []
                 for context in contexts:
@@ -577,7 +577,7 @@ class SubscribeChain(ChainBase, metaclass=Singleton):
                         torrent_mediainfo = self.recognize_media(meta=torrent_meta)
                         if torrent_mediainfo:
                             # 更新种子缓存
-                            context.media_info = torrent_mediainfo
+                            _context.media_info = torrent_mediainfo
                     # 添加已预处理
                     processed_torrents[domain].append(_context)
 


### PR DESCRIPTION
- 添加 `processed_torrents` 类型注解
- 修复变量 `context` 的赋值错误，改为 `_context`