### PR TITLE
修复SystemConfig不能保存的问题

### DIFF
--- a/app/db/systemconfig_oper.py
+++ b/app/db/systemconfig_oper.py
@@ -1,4 +1,5 @@
-from typing import Any, Union, Optional
+import copy
+from typing import Any, Optional, Union
 
 from app.db import DbOper
 from app.db.models.systemconfig import SystemConfig
@@ -52,14 +53,16 @@ class SystemConfigOper(DbOper, metaclass=Singleton):
         if isinstance(key, SystemConfigKey):
             key = key.value
         if not key:
-            return self.__SYSTEMCONF
-        return self.__SYSTEMCONF.get(key)
+            return self.all()
+        # 避免将__SYSTEMCONF内的值引用出去，会导致set时误判没有变动
+        return copy.deepcopy(self.__SYSTEMCONF.get(key))
 
     def all(self):
         """
         获取所有系统设置
         """
-        return self.__SYSTEMCONF or {}
+        # 避免将__SYSTEMCONF内的值引用出去，会导致set时误判没有变动
+        return copy.deepcopy(self.__SYSTEMCONF)
 
     def delete(self, key: Union[str, SystemConfigKey]) -> bool:
         """


### PR DESCRIPTION
从v2.5.3开始，SystemConfig仅当值变动才会写入数据库，但由于部分修改是基于SystemConfig的引用，这会导致误判没有变动。受影响的地方有好几处，比如新装的插件会消失。

修改方案是返回深度拷贝后的对象，避免上层直接修改值引用。