### PR TITLE
fix(api): 在下载管理页面无法控制非默认下载器状态

### DIFF
--- a/app/api/endpoints/download.py
+++ b/app/api/endpoints/download.py
@@ -94,22 +94,22 @@ def add(
 
 @router.get("/start/{hashString}", summary="开始任务", response_model=schemas.Response)
 def start(
-        hashString: str,
+        hashString: str, name: Optional[str] = None,
         _: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
     开如下载任务
     """
-    ret = DownloadChain().set_downloading(hashString, "start")
+    ret = DownloadChain().set_downloading(hashString, "start", name=name)
     return schemas.Response(success=True if ret else False)
 
 
 @router.get("/stop/{hashString}", summary="暂停任务", response_model=schemas.Response)
-def stop(hashString: str,
+def stop(hashString: str, name: Optional[str] = None,
          _: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
     暂停下载任务
     """
-    ret = DownloadChain().set_downloading(hashString, "stop")
+    ret = DownloadChain().set_downloading(hashString, "stop", name=name)
     return schemas.Response(success=True if ret else False)
 
 
@@ -125,10 +125,10 @@ def clients(_: schemas.TokenPayload = Depends(verify_token)) -> Any:
 
 
 @router.delete("/{hashString}", summary="删除下载任务", response_model=schemas.Response)
-def delete(hashString: str,
+def delete(hashString: str, name: Optional[str] = None,
            _: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
     删除下载任务
     """
-    ret = DownloadChain().remove_downloading(hashString)
+    ret = DownloadChain().remove_downloading(hashString, name=name)
     return schemas.Response(success=True if ret else False)

--- a/app/chain/download.py
+++ b/app/chain/download.py
@@ -939,21 +939,21 @@ class DownloadChain(ChainBase):
             ret_torrents.append(torrent)
         return ret_torrents
 
-    def set_downloading(self, hash_str, oper: str) -> bool:
+    def set_downloading(self, hash_str, oper: str, name: Optional[str] = None) -> bool:
         """
         控制下载任务 start/stop
         """
         if oper == "start":
-            return self.start_torrents(hashs=[hash_str])
+            return self.start_torrents(hashs=[hash_str], downloader=name)
         elif oper == "stop":
-            return self.stop_torrents(hashs=[hash_str])
+            return self.stop_torrents(hashs=[hash_str], downloader=name)
         return False
 
-    def remove_downloading(self, hash_str: str) -> bool:
+    def remove_downloading(self, hash_str: str, name: Optional[str] = None) -> bool:
         """
         删除下载任务
         """
-        return self.remove_torrents(hashs=[hash_str])
+        return self.remove_torrents(hashs=[hash_str], downloader=name)
 
     @eventmanager.register(EventType.DownloadFileDeleted)
     def download_file_deleted(self, event: Event):

--- a/app/modules/transmission/__init__.py
+++ b/app/modules/transmission/__init__.py
@@ -355,7 +355,7 @@ class TransmissionModule(_ModuleBase, _DownloaderBase[Transmission]):
         server: Transmission = self.get_instance(downloader)
         if not server:
             return None
-        return server.start_torrents(ids=hashs)
+        return server.stop_torrents(ids=hashs)
 
     def torrent_files(self, tid: str, downloader: Optional[str] = None) -> Optional[List[File]]:
         """

--- a/app/modules/transmission/transmission.py
+++ b/app/modules/transmission/transmission.py
@@ -134,7 +134,7 @@ class Transmission:
             return None
         try:
             torrents, error = self.get_torrents(ids=ids,
-                                                status=["downloading", "download_pending"],
+                                                status=["downloading", "download_pending", "stopped"],
                                                 tags=tags)
             return None if error else torrents or []
         except Exception as err:


### PR DESCRIPTION
改动：
- 为`开始任务` `暂停任务`  `删除下载任务`的API增加name参数
- 在TR的get_downloading_torrents方法获取的种子状态中增加了"stopped"，以包含被暂停的种子