### PR TITLE
feat 网络测试支持加速代理

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -139,6 +139,7 @@ class ConfigModel(BaseModel):
                         "api.github.com,"
                         "github.com,"
                         "raw.githubusercontent.com,"
+                        "codeload.github.com,"
                         "api.telegram.org")
     # DOH 解析服务器列表
     DOH_RESOLVERS: str = "1.0.0.1,1.1.1.1,9.9.9.9,149.112.112.112"
@@ -584,7 +585,8 @@ class Settings(BaseSettings, ConfigModel, LogConfigModel):
         """
         if self.GITHUB_TOKEN:
             return {
-                "Authorization": f"Bearer {self.GITHUB_TOKEN}"
+                "Authorization": f"Bearer {self.GITHUB_TOKEN}",
+                "User-Agent": self.USER_AGENT,
             }
         return {}
 
@@ -612,7 +614,8 @@ class Settings(BaseSettings, ConfigModel, LogConfigModel):
                     print(f"无效的令牌或仓库信息: {token_pair}")
                     continue
                 headers[repo_info] = {
-                    "Authorization": f"Bearer {token}"
+                    "Authorization": f"Bearer {token}",
+                    "User-Agent": self.USER_AGENT,
                 }
             except Exception as e:
                 print(f"处理令牌对 '{token_pair}' 时出错: {e}")


### PR DESCRIPTION
此PR用于更准确的测试github和pip网络，避免出现连通性成功，但插件库报失败的问题。

1. 根据前端配置，请求可通过github或pip加速代理访问，并对响应内容做出匹配，以避免有的代理能连通，但实际已失效的问题
2. github相关测试增加请求头，用于检测token的有效性