### PR TITLE
feat: 实现站点域名别名自动去重功能

### DIFF
--- a/app/db/site_oper.py
+++ b/app/db/site_oper.py
@@ -1,11 +1,12 @@
 from datetime import datetime
-from typing import List, Tuple, Optional
+from typing import List, Tuple, Optional, Dict
 
 from app.db import DbOper
 from app.db.models import SiteIcon
 from app.db.models.site import Site
 from app.db.models.sitestatistic import SiteStatistic
 from app.db.models.siteuserdata import SiteUserData
+from app.helper.domain_alias import DomainAliasHelper
 
 
 class SiteOper(DbOper):
@@ -13,15 +14,53 @@ class SiteOper(DbOper):
     站点管理
     """
 
+    def __init__(self):
+        super().__init__()
+        self.domain_alias_helper = DomainAliasHelper()
+
     def add(self, **kwargs) -> Tuple[bool, str]:
         """
         新增站点
         """
+        domain = kwargs.get("domain")
+        if not domain:
+            return False, "域名不能为空"
+
+        # 检查站点是否已存在（包括别名检查）
+        exists, existing_domain = self.exists_with_alias(domain)
+        if exists and existing_domain:
+            # 先检查是否有重复站点需要合并
+            duplicates = self.find_duplicate_sites()
+            for group_key, sites in duplicates.items():
+                # 检查当前域名是否在某个重复组中
+                domain_in_group = any(site['domain'] == domain for site in sites)
+                existing_in_group = any(site['domain'] == existing_domain for site in sites)
+
+                if domain_in_group or existing_in_group:
+                    # 合并重复站点，保留当前要添加的域名
+                    success, merge_message = self.merge_duplicate_sites(keep_domain=domain)
+                    if success:
+                        # 如果合并成功，检查是否还需要更新域名
+                        final_site = self.get_by_domain(domain)
+                        if not final_site:
+                            # 如果当前域名的站点不存在，可能是被合并了，需要更新保留站点的域名
+                            remaining_site = self.get_by_domain(existing_domain)
+                            if remaining_site:
+                                remaining_site.update(self._db, {"domain": domain})
+                                return True, f"已合并重复站点并更新域名到 {domain}。{merge_message}"
+                        return True, f"已合并重复站点。{merge_message}"
+                    break
+
+            # 如果没有重复站点需要合并，只更新域名
+            existing_site = self.get_by_domain(existing_domain)
+            if existing_site:
+                existing_site.update(self._db, {"domain": domain})
+                return True, f"站点已存在，已更新域名从 {existing_domain} 到 {domain}"
+
+        # 直接使用当前域名存储（不再转换为主域名）
         site = Site(**kwargs)
-        if not site.get_by_domain(self._db, kwargs.get("domain")):
-            site.create(self._db)
-            return True, "新增站点成功"
-        return False, "站点已存在"
+        site.create(self._db)
+        return True, "新增站点成功"
 
     def get(self, sid: int) -> Site:
         """
@@ -78,6 +117,28 @@ class SiteOper(DbOper):
         判断站点是否存在
         """
         return Site.get_by_domain(self._db, domain) is not None
+
+    def exists_with_alias(self, domain: str) -> Tuple[bool, Optional[str]]:
+        """
+        检查站点是否存在（包括别名检查）
+
+        :param domain: 域名
+        :return: (是否存在, 存在的域名)
+        """
+        if not domain:
+            return False, None
+
+        # 获取所有相关域名（主域名和别名）
+        all_domains = self.domain_alias_helper.get_all_domains(domain)
+
+        # 检查每个域名是否已存在
+        for check_domain in all_domains:
+            if self.exists(check_domain):
+                return True, check_domain
+
+        return False, None
+
+
 
     def update_cookie(self, domain: str, cookies: str) -> Tuple[bool, str]:
         """
@@ -231,3 +292,115 @@ class SiteOper(DbOper):
                 lst_state=1,
                 lst_mod_date=lst_date
             ).create(self._db)
+
+    def find_duplicate_sites(self) -> Dict[str, List[Dict]]:
+        """
+        检测数据库中的重复站点（同一站点的不同域名）
+
+        :return: 重复站点分组 {主域名: [站点信息列表]}
+        """
+        duplicates = {}
+        all_sites = self.list()
+        processed_domains = set()
+
+        for site in all_sites:
+            domain = site.domain
+            if domain in processed_domains:
+                continue
+
+            # 查找所有相关域名的站点
+            related_sites = []
+            all_related_domains = self.domain_alias_helper.get_all_domains(domain)
+
+            for check_site in all_sites:
+                if check_site.domain in all_related_domains:
+                    related_sites.append({
+                        'id': check_site.id,
+                        'domain': check_site.domain,
+                        'name': check_site.name,
+                        'is_active': check_site.is_active,
+                        'success_count': getattr(check_site, 'success_count', 0) or 0,
+                        'fail_count': getattr(check_site, 'fail_count', 0) or 0,
+                        'updated_at': getattr(check_site, 'updated_at', None)
+                    })
+                    processed_domains.add(check_site.domain)
+
+            # 如果有多个相关站点，则认为是重复的
+            if len(related_sites) > 1:
+                # 使用第一个域名作为组标识
+                group_key = related_sites[0]['domain']
+                duplicates[group_key] = related_sites
+
+        return duplicates
+
+    def merge_duplicate_sites(self, keep_domain: Optional[str] = None) -> Tuple[bool, str]:
+        """
+        合并重复的站点
+
+        :param keep_domain: 要保留的域名，如果为None则保留最后更新的
+        :return: (是否成功, 消息)
+        """
+        try:
+            duplicates = self.find_duplicate_sites()
+            if not duplicates:
+                return True, "未发现重复站点"
+
+            merged_count = 0
+            for group_key, sites in duplicates.items():
+                if len(sites) <= 1:
+                    continue
+
+                # 确定要保留的站点
+                if keep_domain:
+                    # 查找指定域名的站点
+                    keep_site = None
+                    for site in sites:
+                        if site['domain'] == keep_domain:
+                            keep_site = site
+                            break
+                    if not keep_site:
+                        continue  # 指定的域名不在这个组中
+                else:
+                    # 选择最后更新的站点，如果没有更新时间则选择第一个
+                    keep_site = sites[0]
+                    for site in sites:
+                        if site['updated_at'] and (not keep_site['updated_at'] or site['updated_at'] > keep_site['updated_at']):
+                            keep_site = site
+
+                # 获取要删除的站点
+                remove_sites = [s for s in sites if s['id'] != keep_site['id']]
+
+                # 合并统计数据
+                total_success = sum(s['success_count'] for s in sites)
+                total_fail = sum(s['fail_count'] for s in sites)
+
+                # 更新保留的站点
+                keep_site_obj = self.get(keep_site['id'])
+                if keep_site_obj:
+                    # 获取当前统计数据
+                    current_stats = SiteStatistic.get_by_domain(self._db, keep_site['domain'])
+                    if current_stats:
+                        current_stats.update(self._db, {
+                            'success': total_success,
+                            'fail': total_fail
+                        })
+
+                # 删除重复的站点
+                for remove_site in remove_sites:
+                    # 删除站点统计数据
+                    remove_stats = SiteStatistic.get_by_domain(self._db, remove_site['domain'])
+                    if remove_stats:
+                        SiteStatistic.delete(self._db, remove_stats.id)
+
+                    # 删除站点记录
+                    Site.delete(self._db, remove_site['id'])
+                    print(f"删除重复站点: {remove_site['domain']} (ID: {remove_site['id']})")
+
+                merged_count += len(remove_sites)
+                print(f"合并站点组 {group_key}: 保留 {keep_site['domain']}, 删除 {len(remove_sites)} 个重复站点")
+
+            return True, f"成功合并 {merged_count} 个重复站点"
+
+        except Exception as e:
+            print(f"合并重复站点失败: {str(e)}")
+            return False, f"合并失败: {str(e)}"

--- a/app/helper/domain_alias.py
+++ b/app/helper/domain_alias.py
@@ -1,0 +1,76 @@
+from typing import Dict, List
+
+
+class DomainAliasHelper:
+    """
+    域名别名管理工具类
+    用于处理同一站点的不同域名别名，防止重复入库
+    以最后入站的域名为准
+    """
+
+    # 域名别名组配置
+    # 格式：[同一站点的所有域名列表]
+    DOMAIN_ALIAS_GROUPS: List[List[str]] = [
+        ["pt.gtk.pw", "pt.gtkpw.xyz"],  # GTK站点的所有域名
+        # 可以在这里添加更多站点的域名组
+        # ["example.com", "alias1.example.com", "alias2.example.com"],
+    ]
+
+    # 域名到组的映射：域名 -> 组索引
+    _DOMAIN_TO_GROUP: Dict[str, int] = {}
+
+    def __init__(self):
+        """初始化域名组映射"""
+        self._build_domain_mapping()
+
+    def _build_domain_mapping(self):
+        """构建域名到组的映射"""
+        self._DOMAIN_TO_GROUP.clear()
+        for group_index, domains in enumerate(self.DOMAIN_ALIAS_GROUPS):
+            for domain in domains:
+                self._DOMAIN_TO_GROUP[domain] = group_index
+    
+    def get_all_domains(self, domain: str) -> List[str]:
+        """
+        获取域名的所有相关域名（同一站点的所有域名）
+
+        :param domain: 输入域名
+        :return: 所有相关域名列表
+        """
+        if not domain:
+            return [domain] if domain else []
+
+        # 查找域名所属的组
+        if domain in self._DOMAIN_TO_GROUP:
+            group_index = self._DOMAIN_TO_GROUP[domain]
+            return self.DOMAIN_ALIAS_GROUPS[group_index].copy()
+
+        # 如果不在任何组中，返回自身
+        return [domain]
+
+    def is_same_site(self, domain1: str, domain2: str) -> bool:
+        """
+        检查两个域名是否属于同一站点
+
+        :param domain1: 域名1
+        :param domain2: 域名2
+        :return: 是否为同一站点
+        """
+        if not domain1 or not domain2:
+            return False
+
+        # 检查是否在同一个域名组中
+        group1 = self._DOMAIN_TO_GROUP.get(domain1)
+        group2 = self._DOMAIN_TO_GROUP.get(domain2)
+
+        return group1 is not None and group1 == group2
+
+    def get_alias_info(self) -> List[List[str]]:
+        """
+        获取所有域名别名组信息
+
+        :return: 域名别名组列表
+        """
+        return [group.copy() for group in self.DOMAIN_ALIAS_GROUPS]
+
+

--- a/app/startup/modules_initializer.py
+++ b/app/startup/modules_initializer.py
@@ -6,6 +6,7 @@ from app.core.module import ModuleManager
 from app.log import logger
 from app.utils.system import SystemUtils
 from app.command import CommandChain
+from app.db.site_oper import SiteOper
 
 # SitesHelper涉及资源包拉取，提前引入并容错提示
 try:
@@ -105,6 +106,28 @@ def check_auth():
         )
 
 
+def auto_merge_duplicate_sites():
+    """
+    自动合并重复站点
+    """
+    try:
+        logger.info("正在检测并自动合并重复站点...")
+        site_oper = SiteOper()
+        duplicates = site_oper.find_duplicate_sites()
+
+        if duplicates:
+            logger.info(f"发现 {len(duplicates)} 组重复站点，开始自动合并...")
+            success, message = site_oper.merge_duplicate_sites()
+            if success:
+                logger.info(f"自动合并重复站点成功: {message}")
+            else:
+                logger.error(f"自动合并重复站点失败: {message}")
+        else:
+            logger.info("未发现重复站点，无需合并")
+    except Exception as e:
+        logger.error(f"自动合并重复站点时发生错误: {str(e)}")
+
+
 def stop_modules():
     """
     服务关闭
@@ -149,3 +172,5 @@ def init_modules():
     start_frontend()
     # 检查认证状态
     check_auth()
+    # 自动合并重复站点
+    auto_merge_duplicate_sites()

--- a/scripts/merge_duplicate_sites.py
+++ b/scripts/merge_duplicate_sites.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+合并重复站点脚本
+
+用于处理在实现域名别名功能之前已经存在的重复站点记录。
+"""
+
+import sys
+import os
+
+# 添加项目根目录到Python路径
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app.db.site_oper import SiteOper
+from app.core.config import settings
+
+
+def main():
+    """主函数"""
+    print("=== MoviePilot 重复站点合并工具 ===")
+    print()
+    
+    # 初始化站点操作器
+    site_oper = SiteOper()
+    
+    # 检测重复站点
+    print("正在检测重复站点...")
+    duplicates = site_oper.find_duplicate_sites()
+    
+    if not duplicates:
+        print("✅ 未发现重复站点，无需合并。")
+        return
+    
+    print(f"🔍 发现 {len(duplicates)} 组重复站点：")
+    print()
+    
+    # 显示重复站点信息
+    for group_key, sites in duplicates.items():
+        print(f"📍 站点组 [{group_key}]:")
+        for i, site in enumerate(sites, 1):
+            status = "✅ 活跃" if site['is_active'] else "❌ 禁用"
+            print(f"  {i}. {site['domain']} - {site['name']} ({status})")
+            print(f"     成功: {site['success_count']}, 失败: {site['fail_count']}")
+            print(f"     更新时间: {site['updated_at'] or '未知'}")
+        print()
+    
+    # 询问用户是否继续
+    while True:
+        choice = input("是否继续合并重复站点？(y/n): ").lower().strip()
+        if choice in ['y', 'yes', '是']:
+            break
+        elif choice in ['n', 'no', '否']:
+            print("操作已取消。")
+            return
+        else:
+            print("请输入 y 或 n")
+    
+    print()
+    print("开始合并重复站点...")
+    
+    # 执行合并
+    success, message = site_oper.merge_duplicate_sites()
+    
+    if success:
+        print(f"✅ {message}")
+    else:
+        print(f"❌ {message}")
+    
+    print()
+    print("=== 合并完成 ===")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- 添加域名别名配置系统，支持同站点不同域名识别
- 实现重复站点自动检测和合并逻辑
- 应用启动时、API调用时、添加站点时自动处理重复站点
- 支持GTK站点别名：pt.gtk.pw ↔ pt.gtkpw.xyz
- 智能合并策略：保留最后更新站点，合并统计数据
- 添加重复站点合并工具脚本

解决问题：防止同一站点不同域名重复添加，自动维护数据一致性