### PR TITLE
feat(meta): 新增 WEB 平台来源识别并支持更多音视频格式。

### DIFF
--- a/app/core/meta/streamingplatform.py
+++ b/app/core/meta/streamingplatform.py
@@ -1,0 +1,104 @@
+from typing import Dict, Optional, List, Tuple
+
+from app.utils.singleton import Singleton
+
+
+class StreamingPlatforms(metaclass=Singleton):
+    """
+    流媒体平台简称与全称。
+    """
+    STREAMING_PLATFORMS: List[Tuple[str, str]] = [
+        ("AMZN", "Amazon"),
+        ("NF", "Netflix"),
+        ("ATVP", "Apple TV+"),
+        ("iT", "iTunes"),
+        ("DSNP", "Disney+"),
+        ("HS", "Hotstar"),
+        ("APPS", "Disney+ MENA"),
+        ("PMTP", "Paramount+"),
+        ("HMAX", "Max"),
+        ("", "Max"),
+        ("HULU", "Hulu"),
+        ("MA", "Movies Anywhere"),
+        ("BCORE", "Bravia Core"),
+        ("MS", "Microsoft Store"),
+        ("SHO", "Showtime"),
+        ("STAN", "Stan"),
+        ("PCOK", "Peacock"),
+        ("SKST", "SkyShowtime"),
+        ("NOW", "Now TV"),
+        ("FXTL", "Foxtel Now"),
+        ("BNGE", "Binge"),
+        ("CRKL", "Crackle"),
+        ("RKTN", "Rakuten TV"),
+        ("ALL4", "All 4"),
+        ("AS", "Adult Swim"),
+        ("BRTB", "Brtb TV"),
+        ("CNLP", "Canal+"),
+        ("CRIT", "Criterion Channel"),
+        ("DSCP", "Discovery+"),
+        ("", "ESPN"),
+        ("FOOD", "Food Network"),
+        ("MUBI", "Mubi"),
+        ("PLAY", "Google Play"),
+        ("YT", "YouTube"),
+        ("", "friDay"),
+        ("", "KKTV"),
+        ("", "ofiii"),
+        ("", "LiTV"),
+        ("", "MyVideo"),
+        ("Hami", "Hami Video"),
+        ("", "meWATCH"),
+        ("CATCHPLAY", "CATCHPLAY+"),
+        ("", "LINE TV"),
+        ("VIU", "Viu"),
+        ("IQ", ""),
+        ("", "WeTV"),
+        ("ABMA", "Abema"),
+        ("ADN", ""),
+        ("AT-X", ""),
+        ("Baha", ""),
+        ("BG", "B-Global"),
+        ("CR", "Crunchyroll"),
+        ("", "DMM"),
+        ("FOD", ""),
+        ("FUNi", "Funimation"),
+        ("HIDI", "HIDIVE"),
+        ("UNXT", "U-NEXT"),
+    ]
+
+    def __init__(self):
+        """初始化流媒体平台匹配器"""
+        self._lookup_cache = {}
+        self._build_cache()
+
+    def _build_cache(self) -> None:
+        """
+        构建查询缓存。
+        """
+        self._lookup_cache.clear()
+        for short_name, full_name in self.STREAMING_PLATFORMS:
+            canonical_name = full_name or short_name
+            if not canonical_name:
+                continue
+
+            aliases = {short_name, full_name}
+            for alias in aliases:
+                if alias:
+                    self._lookup_cache[alias.upper()] = canonical_name
+
+    def get_streaming_platform_name(self, platform_code: str) -> Optional[str]:
+        """
+        根据流媒体平台简称或全称获取标准名称。
+        """
+        if platform_code is None:
+            return None
+        return self._lookup_cache.get(platform_code.upper())
+
+    def is_streaming_platform(self, name: str) -> bool:
+        """
+        判断给定的字符串是否为已知的流媒体平台代码或名称。
+        """
+        if name is None:
+            return False
+        return name.upper() in self._lookup_cache

--- a/tests/cases/meta.py
+++ b/tests/cases/meta.py
@@ -153,7 +153,7 @@ meta_cases = [{
         "part": "",
         "season": "S01",
         "episode": "E02",
-        "restype": "WEB-DL",
+        "restype": "B-Global WEB-DL",
         "pix": "1080p",
         "video_codec": "x264",
         "audio_codec": "AAC"
@@ -569,7 +569,7 @@ meta_cases = [{
         "part": "",
         "season": "S02",
         "episode": "E05",
-        "restype": "WEB-DL",
+        "restype": "Crunchyroll WEB-DL",
         "pix": "1080p",
         "video_codec": "x264",
         "audio_codec": "AAC"
@@ -649,7 +649,7 @@ meta_cases = [{
         "part": "",
         "season": "",
         "episode": "",
-        "restype": "WEBRip",
+        "restype": "Netflix WEBRip",
         "pix": "1080p",
         "video_codec": "H264",
         "audio_codec": "DDP 5.1"
@@ -681,7 +681,7 @@ meta_cases = [{
         "part": "",
         "season": "S01",
         "episode": "E16",
-        "restype": "WEB-DL",
+        "restype": "KKTV WEB-DL",
         "pix": "1080p",
         "video_codec": "x264",
         "audio_codec": "AAC"
@@ -921,7 +921,7 @@ meta_cases = [{
         "part": "",
         "season": "S06",
         "episode": "E06",
-        "restype": "WEBRip",
+        "restype": "Max WEBRip",
         "pix": "1080p",
         "video_codec": "x264",
         "audio_codec": "DD 5.1"
@@ -937,7 +937,7 @@ meta_cases = [{
         "part": "",
         "season": "S06",
         "episode": "E05",
-        "restype": "WEBRip",
+        "restype": "Max WEBRip",
         "pix": "1080p",
         "video_codec": "x264",
         "audio_codec": "DD 5.1"
@@ -969,7 +969,7 @@ meta_cases = [{
         "part": "",
         "season": "S02",
         "episode": "",
-        "restype": "WEB-DL",
+        "restype": "Netflix WEB-DL",
         "pix": "2160p",
         "video_codec": "H265",
         "audio_codec": "DDP 5.1 Atmos"


### PR DESCRIPTION
修改了正则表达式，现在会识别 `EDR HQ` 这种特殊版本，以及 `AV3A AVSA` 格式的音频。
添加了对于WEB内容 (`WEB-DL WEBRip`) 来源平台的识别，已覆盖常见的平台。
修改了单元测试的预期。

参考：
[vevv/WEB Source Tier List](https://gist.github.com/vevv/1d7037bb556c17e977b26b9f8f175853)
[Pirated movie release types](https://en.wikipedia.org/wiki/Pirated_movie_release_types)