### PR TITLE
fix: 修复AutoCloseResponse类在反序列化时无限递归

### DIFF
--- a/app/utils/http.py
+++ b/app/utils/http.py
@@ -76,6 +76,9 @@ class AutoCloseResponse:
         """
         self._auto_close()
 
+    def __setstate__(self, state):
+        for name, value in state.items():
+            setattr(self, name, value)
 
 class RequestUtils:
 


### PR DESCRIPTION
fix #4511