### PR TITLE
AutoCloseResponse支持上下文管理协议，避免部分插件报错

### DIFF
--- a/app/utils/http.py
+++ b/app/utils/http.py
@@ -80,6 +80,12 @@ class AutoCloseResponse:
         for name, value in state.items():
             setattr(self, name, value)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
 class RequestUtils:
 
     def __init__(self,


### PR DESCRIPTION
比如 Emby元数据刷新 插件中的 `with RequestUtils().post_res(req_url) as res:`