### PR TITLE
改进本地媒体检查，避免因特定的重命名格式导致额外的扫盘

### DIFF
--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -434,14 +434,15 @@ class SubscribeChain(ChainBase):
                     else:
                         self.messagehelper.put('没有找到订阅！', title="订阅搜索", role="system")
 
-                logger.debug(f"search Lock released at {datetime.now()}")
             finally:
                 subscribes.clear()
                 del subscribes
 
-            # 如果不是大内存模式，进行垃圾回收
-            if not settings.BIG_MEMORY_MODE:
-                gc.collect()
+            logger.debug(f"search Lock released at {datetime.now()}")
+
+        # 如果不是大内存模式，进行垃圾回收
+        if not settings.BIG_MEMORY_MODE:
+            gc.collect()
 
     def update_subscribe_priority(self, subscribe: Subscribe, meta: MetaBase,
                                   mediainfo: MediaInfo, downloads: Optional[List[Context]]):


### PR DESCRIPTION
Fix #4508
当电视剧配置以下重命名格式
`{{title}}/Season {{season}}/{{season_episode}}{{fileExt}}`

在判定本地是否存在媒体文件时，构造的元数据`MetaInfo`仅使用了剧名，导致season_episode、fileExt属性为空白，
重命名后的路径变成`/媒体库路径/剧名/Season /`。

由于`pathlib`会移除末尾的斜杠，变成`/媒体库路径/剧名/Season `
这会导致mp误将`/媒体库路径`作为剧集目录，产生超出预期范围的扫盘。

这种大范围的扫盘，还会误报该剧的媒体文件已存在，影响订阅行为。