### PR TITLE
fix 订阅匹配锁增加超时，避免罕见的长时间卡任务问题

### DIFF
--- a/app/modules/filemanager/__init__.py
+++ b/app/modules/filemanager/__init__.py
@@ -562,9 +562,12 @@ class FileManagerModule(_ModuleBase):
         if not settings.LOCAL_EXISTS_SEARCH:
             return None
 
+        logger.debug(f"正在本地媒体库中查找 {mediainfo.title_year}...")
+
         # 检查媒体库
         fileitems = self.media_files(mediainfo)
         if not fileitems:
+            logger.debug(f"{mediainfo.title_year} 不在本地媒体库中")
             return None
 
         if mediainfo.type == MediaType.MOVIE:

--- a/app/modules/filemanager/storages/u115.py
+++ b/app/modules/filemanager/storages/u115.py
@@ -219,8 +219,11 @@ class U115Pan(StorageBase, metaclass=Singleton):
 
         # 处理速率限制
         if resp.status_code == 429:
-            reset_time = int(resp.headers.get("X-RateLimit-Reset", 60))
-            time.sleep(reset_time + 5)
+            reset_time = 5 + int(resp.headers.get("X-RateLimit-Reset", 60))
+            logger.debug(
+                f"【115】{method} 请求 {endpoint} 限流，等待{reset_time}秒后重试"
+            )
+            time.sleep(reset_time)
             return self._request_api(method, endpoint, result_key, **kwargs)
 
         # 处理请求错误


### PR DESCRIPTION
目前又遇到一起因为开启本地媒体库检查后卡订阅任务的案例(本地媒体检查时间超过17个小时仍未结束)， 症状与 #4508 一致。经过排查，可能涉及115网盘访问。由于具体原因未知，为了防止再出现类似问题，临时应对方案是给这些任务共用的锁增加超时机制。