### PR TITLE
fix TR模块报错找不到_protocol属性

### DIFF
--- a/app/modules/transmission/transmission.py
+++ b/app/modules/transmission/transmission.py
@@ -25,7 +25,7 @@ class Transmission:
         若不设置参数，则创建配置文件设置的下载器
         """
         if host and port:
-            self._protocol, self._host, self._port = kwargs.get("protocol", self._protocol), host, port
+            self._protocol, self._host, self._port = kwargs.get("protocol", "http"), host, port
         elif host:
             result = UrlUtils.parse_url_params(url=host)
             if result:


### PR DESCRIPTION
v2.5.9引入的bug，当没有指定protocol参数时，会访问尚未定义的self._protocol属性，部分插件受影响。