### PR TITLE
fix 本地媒体文件检查时首选含影视标题的目录

### DIFF
--- a/app/modules/filemanager/__init__.py
+++ b/app/modules/filemanager/__init__.py
@@ -530,7 +530,14 @@ class FileManagerModule(_ModuleBase):
                                                     mediainfo=mediainfo)
             )
             # 计算重命名中的文件夹层数
-            rename_format_level = len(rename_format.split("/")) - 1
+            rename_list = rename_format.split("/")
+            rename_format_level = len(rename_list) - 1
+            for level, name in enumerate(rename_list):
+                # 处理特例，有的人重命名第一层是年份、分辨率
+                if "{{title}}" in name:
+                    # 找出含标题的这一层作为扫描路径
+                    rename_format_level -= level
+                    break
             # 取相对路径的第1层目录
             media_path = target_path.parents[rename_format_level - 1]
             if dir_path.is_relative_to(media_path):


### PR DESCRIPTION
mp在判断本地媒体库时会假定第一层是影视标题，但如果重命名格式为：`{{year}}/{{title}}/xxx` 这种以年份、分辨率等作为重命名第一层级的话，就会导致后续误判了。
为此，改进成以首个含有`title`关键字的那一层作为判断路径

