### PR TITLE
Move media files to season directory

### DIFF
--- a/app/chain/media.py
+++ b/app/chain/media.py
@@ -371,12 +371,16 @@ class MediaChain(ChainBase):
                 if any(f.name.endswith('.nfo') for f in sub_files):
                     logger.info(f"目录 {fileitem.path} 已有NFO文件，开始增量刮削...")
                     for file_path in file_list:
-                        self.scrape_metadata(fileitem=storagechain.get_file_item(storage=fileitem.storage,
-                                                                                 path=Path(file_path)),
-                                             mediainfo=mediainfo,
-                                             init_folder=False,
-                                             parent=fileitem,
-                                             overwrite=overwrite)
+                        file_item = storagechain.get_file_item(storage=fileitem.storage,
+                                                              path=Path(file_path))
+                        if file_item:
+                            # 对于电视剧文件，应该保存到与视频文件相同的目录
+                            # 而不是电视剧根目录
+                            self.scrape_metadata(fileitem=file_item,
+                                                 mediainfo=mediainfo,
+                                                 init_folder=False,
+                                                 parent=None,  # 让函数内部自动获取正确的父目录
+                                                 overwrite=overwrite)
                 else:
                     # 执行全量刮削
                     logger.info(f"开始全量刮削目录 {fileitem.path} ...")

--- a/app/chain/media.py
+++ b/app/chain/media.py
@@ -492,6 +492,8 @@ class MediaChain(ChainBase):
                         movie_nfo = self.metadata_nfo(meta=meta, mediainfo=mediainfo)
                         if movie_nfo:
                             # 保存或上传nfo文件到上级目录
+                            if not parent:
+                                parent = storagechain.get_parent_item(fileitem)
                             __save_file(_fileitem=parent, _path=nfo_path, _content=movie_nfo)
                         else:
                             logger.warn(f"{filepath.name} nfo文件生成失败！")


### PR DESCRIPTION
Ensure NFO and image files are saved to the correct media directory.

Previously, during incremental scraping for TV series, metadata files were saved to the show's root directory instead of the season directory. Additionally, movie NFO files were not correctly determining their parent directory if `parent` was not explicitly passed. This change ensures metadata files are always saved alongside their associated media files.