### PR TITLE
修复潜在的漏刮削问题

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -373,7 +373,8 @@ class TransferChain(ChainBase, metaclass=Singleton):
         # 事件管理器
         self.jobview = JobManager()
         # 刮削事件数据
-        self.scraper_events = []
+        self._scraper_target_diritem = None
+        self._scraper_file_list = None
         # 启动整理任务
         self.__init()
 
@@ -411,9 +412,19 @@ class TransferChain(ChainBase, metaclass=Singleton):
                                             season_episode=se_str,
                                             username=task.username)
             # 刮削事件
-            for event_data in self.scraper_events:
-                self.eventmanager.send_event(EventType.MetadataScrape, event_data)
-            self.scraper_events = []
+            if self._scraper_target_diritem:
+                self.eventmanager.send_event(
+                    EventType.MetadataScrape,
+                    {
+                        "meta": task.meta,
+                        "mediainfo": task.mediainfo,
+                        "fileitem": self._scraper_target_diritem,
+                        "file_list": self._scraper_file_list,
+                        "overwrite": False,
+                    },
+                )
+            self._scraper_target_diritem = None
+            self._scraper_file_list = None
 
             # 移除已完成的任务
             self.jobview.remove_job(task)
@@ -477,15 +488,12 @@ class TransferChain(ChainBase, metaclass=Singleton):
         with task_lock:
             if transferinfo.need_scrape:
                 # 记录当前任务的刮削数据，当全部整理完成后使用
-                self.scraper_events.append(
-                    {
-                        "meta": task.meta,
-                        "mediainfo": task.mediainfo,
-                        "fileitem": transferinfo.target_diritem,
-                        "file_list": transferinfo.file_list_new,
-                        "overwrite": False,
-                    }
-                )
+                self._scraper_target_diritem = transferinfo.target_diritem
+                if self._scraper_file_list is None:
+                    self._scraper_file_list = []
+                if transferinfo.file_list_new:
+                    self._scraper_file_list.extend(transferinfo.file_list_new)
+
             # 全部整理成功时
             if self.jobview.is_success(task):
                 # 移动模式删除空目录

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -390,6 +390,34 @@ class TransferChain(ChainBase, metaclass=Singleton):
         """
         整理完成后处理
         """
+        def on_finished():
+            # 发送通知，实时手动整理时不发
+            if transferinfo.need_notify and (task.background or not task.manual):
+                se_str = None
+                if task.mediainfo.type == MediaType.TV:
+                    season_episodes = self.jobview.season_episodes(task.mediainfo, task.meta.begin_season)
+                    if season_episodes:
+                        se_str = f"{task.meta.season} {StringUtils.format_ep(season_episodes)}"
+                    else:
+                        se_str = f"{task.meta.season}"
+                # 更新文件数量
+                transferinfo.file_count = self.jobview.count(task.mediainfo, task.meta.begin_season) or 1
+                # 更新文件大小
+                transferinfo.total_size = self.jobview.size(task.mediainfo,
+                                                            task.meta.begin_season) or task.fileitem.size
+                self.send_transfer_message(meta=task.meta,
+                                            mediainfo=task.mediainfo,
+                                            transferinfo=transferinfo,
+                                            season_episode=se_str,
+                                            username=task.username)
+            # 刮削事件
+            for event_data in self.scraper_events:
+                self.eventmanager.send_event(EventType.MetadataScrape, event_data)
+            self.scraper_events = []
+
+            # 移除已完成的任务
+            self.jobview.remove_job(task)
+
         transferhis = TransferHistoryOper()
         if not transferinfo.success:
             # 转移失败
@@ -415,6 +443,10 @@ class TransferChain(ChainBase, metaclass=Singleton):
             ))
             # 整理失败
             self.jobview.fail_task(task)
+            # 整理完成且有成功的任务时
+            with task_lock:
+                if self.jobview.is_finished(task):
+                    on_finished()
             return False, transferinfo.message
 
         # 转移成功
@@ -474,32 +506,7 @@ class TransferChain(ChainBase, metaclass=Singleton):
                             storagechain.delete_media_file(t.fileitem, delete_self=False)
             # 整理完成且有成功的任务时
             if self.jobview.is_finished(task):
-                # 发送通知，实时手动整理时不发
-                if transferinfo.need_notify and (task.background or not task.manual):
-                    se_str = None
-                    if task.mediainfo.type == MediaType.TV:
-                        season_episodes = self.jobview.season_episodes(task.mediainfo, task.meta.begin_season)
-                        if season_episodes:
-                            se_str = f"{task.meta.season} {StringUtils.format_ep(season_episodes)}"
-                        else:
-                            se_str = f"{task.meta.season}"
-                    # 更新文件数量
-                    transferinfo.file_count = self.jobview.count(task.mediainfo, task.meta.begin_season) or 1
-                    # 更新文件大小
-                    transferinfo.total_size = self.jobview.size(task.mediainfo,
-                                                                task.meta.begin_season) or task.fileitem.size
-                    self.send_transfer_message(meta=task.meta,
-                                               mediainfo=task.mediainfo,
-                                               transferinfo=transferinfo,
-                                               season_episode=se_str,
-                                               username=task.username)
-                # 刮削事件
-                for event_data in self.scraper_events:
-                    self.eventmanager.send_event(EventType.MetadataScrape, event_data)
-                self.scraper_events = []
-
-                # 移除已完成的任务
-                self.jobview.remove_job(task)
+                on_finished()
 
         return True, ""
 

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -372,6 +372,8 @@ class TransferChain(ChainBase, metaclass=Singleton):
         self._transfer_interval = 15
         # 事件管理器
         self.jobview = JobManager()
+        # 刮削事件数据
+        self.scraper_events = []
         # 启动整理任务
         self.__init()
 
@@ -441,6 +443,17 @@ class TransferChain(ChainBase, metaclass=Singleton):
         })
 
         with task_lock:
+            if transferinfo.need_scrape:
+                # 记录当前任务的刮削数据，当全部整理完成后使用
+                self.scraper_events.append(
+                    {
+                        "meta": task.meta,
+                        "mediainfo": task.mediainfo,
+                        "fileitem": transferinfo.target_diritem,
+                        "file_list": transferinfo.file_list_new,
+                        "overwrite": False,
+                    }
+                )
             # 全部整理成功时
             if self.jobview.is_success(task):
                 # 移动模式删除空目录
@@ -481,14 +494,9 @@ class TransferChain(ChainBase, metaclass=Singleton):
                                                season_episode=se_str,
                                                username=task.username)
                 # 刮削事件
-                if transferinfo.need_scrape:
-                    self.eventmanager.send_event(EventType.MetadataScrape, {
-                        'meta': task.meta,
-                        'mediainfo': task.mediainfo,
-                        'fileitem': transferinfo.target_diritem,
-                        'file_list': transferinfo.file_list_new,
-                        'overwrite': False
-                    })
+                for event_data in self.scraper_events:
+                    self.eventmanager.send_event(EventType.MetadataScrape, event_data)
+                self.scraper_events = []
 
                 # 移除已完成的任务
                 self.jobview.remove_job(task)


### PR DESCRIPTION
1、在文件管理中手动整理剧集目录时，如果触发了增量刮削，将导致只有一个文件能刮削。(v2.6.3引入)
2、当前只在最后一个整理任务成功时才会触发刮削事件，但没有考虑到如果最后一个任务失败的情况。