### PR TITLE
解决了几个与重命名相关的问题

### DIFF
--- a/app/chain/storage.py
+++ b/app/chain/storage.py
@@ -180,13 +180,13 @@ class StorageChain(ChainBase):
             # 重命名格式
             rename_format = settings.TV_RENAME_FORMAT \
                 if mtype == MediaType.TV else settings.MOVIE_RENAME_FORMAT
-            # 计算重命名中的文件夹层数
-            rename_format_level = len(rename_format.split("/")) - 1
-            if rename_format_level < 1:
+            media_path = DirectoryHelper.get_media_root_path(
+                rename_format, rename_path=Path(fileitem.path)
+            )
+            if not media_path:
                 return True
             # 处理媒体文件根目录
-            dir_item = self.get_file_item(storage=fileitem.storage,
-                                          path=Path(fileitem.path).parents[rename_format_level - 1])
+            dir_item = self.get_file_item(storage=fileitem.storage, path=media_path)
         else:
             # 处理上级目录
             dir_item = self.get_parent_item(fileitem)

--- a/app/helper/directory.py
+++ b/app/helper/directory.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from app import schemas
 from app.core.context import MediaInfo
 from app.db.systemconfig_oper import SystemConfigOper
+from app.log import logger
 from app.schemas.types import SystemConfigKey
 from app.utils.system import SystemUtils
 
@@ -109,3 +110,36 @@ class DirectoryHelper:
                         return matched_dir
             return matched_dirs[0]
         return None
+
+    @staticmethod
+    def get_media_root_path(rename_format: str, rename_path: Path) -> Optional[Path]:
+        """
+        获取重命名后的媒体文件根路径
+
+        :param rename_format: 重命名格式
+        :param rename_path: 重命名后的路径
+        :return: 媒体文件根路径
+        """
+        # 计算重命名中的文件夹层数
+        rename_list = rename_format.split("/")
+        rename_format_level = len(rename_list) - 1
+        if rename_format_level <= 0:
+            # 无效重命名格式
+            logger.error(f"重命名格式 {rename_format} 不正确")
+            return None
+        for level, name in enumerate(rename_list):
+            # 处理特例，有的人重命名的第一层是年份、分辨率
+            if "{{title}}" in name:
+                # 找出含标题的这一层作为媒体根目录
+                rename_format_level -= level
+                break
+        else:
+            # 假定第一层目录是媒体根目录
+            logger.warn(f"重命名格式 {rename_format} 缺少 {{{{title}}}}")
+        if rename_format_level > len(rename_path.parents):
+            # 通常因为路径以/结尾，被Path规范化删除了
+            logger.error(f"路径 {rename_path} 不匹配重命名格式 {rename_format}")
+            return None
+        # 媒体根路径
+        media_root = rename_path.parents[rename_format_level - 1]
+        return media_root

--- a/app/modules/filemanager/__init__.py
+++ b/app/modules/filemanager/__init__.py
@@ -547,17 +547,13 @@ class FileManagerModule(_ModuleBase):
                 rename_dict=handler.get_naming_dict(meta=meta,
                                                     mediainfo=mediainfo)
             )
-            # 计算重命名中的文件夹层数
-            rename_list = rename_format.split("/")
-            rename_format_level = len(rename_list) - 1
-            for level, name in enumerate(rename_list):
-                # 处理特例，有的人重命名第一层是年份、分辨率
-                if "{{title}}" in name:
-                    # 找出含标题的这一层作为扫描路径
-                    rename_format_level -= level
-                    break
-            # 取相对路径的第1层目录
-            media_path = target_path.parents[rename_format_level - 1]
+            # 获取重命名后的媒体文件根路径
+            media_path = DirectoryHelper.get_media_root_path(
+                rename_format, rename_path=target_path
+            )
+            if not media_path:
+                # 忽略
+                continue
             if dir_path.is_relative_to(media_path):
                 # 兜底检查，避免不必要的扫盘
                 logger.warn(f"{media_path} 是媒体库目录 {dir_path} 的父目录，忽略获取媒体文件列表，请检查重命名格式！")

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -185,14 +185,15 @@ class TransHandler:
                         file_ext=f".{fileitem.extension}"
                     )
                 )
+                # 计算重命名中的文件夹层级
+                rename_format_level = len(rename_format.split("/")) - 1
+                folder_path = new_file.parents[rename_format_level - 1]
             else:
                 new_file = target_path / fileitem.name
+                folder_path = target_path
 
             # 判断是否要覆盖
             overflag = False
-            # 计算重命名中的文件夹层级
-            rename_format_level = len(rename_format.split("/")) - 1
-            folder_path = new_file.parents[rename_format_level - 1]
             # 目标目录
             target_diritem = target_oper.get_folder(folder_path)
             if not target_diritem:


### PR DESCRIPTION
1、当前处理重命名时，假定的第一层是媒体根目录，但部分用户会以年份做根目录
2、文件管理中手动智能重命名时，缺少集信息
3、如果媒体库没有启用智能重命名，整理记录中的目标目录会误按有重命名的方式处理