### PR TITLE
fix(filemanager): 检查目标媒体库目录是否设置

### DIFF
--- a/app/modules/filemanager/__init__.py
+++ b/app/modules/filemanager/__init__.py
@@ -429,6 +429,12 @@ class FileManagerModule(_ModuleBase):
                                 message=f"{target_path} 不是有效目录")
         # 获取目标路径
         if target_directory:
+            # 目标媒体库目录未设置
+            if not target_directory.library_path:
+                logger.error(f"目标媒体库目录未设置，无法整理文件，源路径：{fileitem.path}")
+                return TransferInfo(success=False,
+                                    fileitem=fileitem,
+                                    message="目标媒体库目录未设置")
             # 整理方式
             if not transfer_type:
                 transfer_type = target_directory.transfer_type


### PR DESCRIPTION
- 在文件整理过程中，增加对目标媒体库目录是否设置的检查- 如果目标媒体库目录未设置，返回错误信息并中断整理过程
- 优化了错误处理逻辑，提高了系统的稳定性和可靠性

<img width="1707" height="406" alt="image" src="https://github.com/user-attachments/assets/4a90995d-bde9-41c5-bed9-8612849d3a88" />
