### PR TITLE
fix 仅安装用户需要使用的插件依赖

### DIFF
--- a/app/chain/system.py
+++ b/app/chain/system.py
@@ -6,6 +6,7 @@ from typing import Union, Optional
 
 from app.chain import ChainBase
 from app.core.config import settings
+from app.core.plugin import PluginManager
 from app.log import logger
 from app.schemas import Notification, MessageChannel
 from app.utils.http import RequestUtils
@@ -136,13 +137,6 @@ class SystemChain(ChainBase):
                             shutil.rmtree(target_path)
                         shutil.copytree(item, target_path)
                         logger.info(f"已恢复插件目录: {item.name}")
-                        # 安装依赖
-                        requirements_file = target_path / "requirements.txt"
-                        if requirements_file.exists():
-                            logger.info(f"正在安装插件 {item.name} 的依赖...")
-                            success, message = PluginHelper.pip_install_with_fallback(requirements_file)
-                            if not success:
-                                logger.warn(f"插件 {item.name} 依赖安装失败: {message}")
                         restored_count += 1
                     # 如果是文件
                     elif item.is_file():
@@ -154,6 +148,9 @@ class SystemChain(ChainBase):
                     continue
 
             logger.info(f"插件恢复完成，共恢复 {restored_count} 个项目")
+
+            # 安装缺少的依赖
+            PluginManager.install_plugin_missing_dependencies()
 
         # 删除备份目录
         try:

--- a/app/helper/plugin.py
+++ b/app/helper/plugin.py
@@ -649,13 +649,12 @@ class PluginHelper(metaclass=WeakSingleton):
         """
         dependencies = {}
         try:
-            install_plugins = [
-                plugin_id.lower() # 对应插件的小写目录名
+            install_plugins = {
+                plugin_id.lower()  # 对应插件的小写目录名
                 for plugin_id in SystemConfigOper().get(
                     SystemConfigKey.UserInstalledPlugins
-                )
-                or []
-            ]
+                ) or []
+            }
             for plugin_dir in PLUGIN_DIR.iterdir():
                 if plugin_dir.is_dir():
                     requirements_file = plugin_dir / "requirements.txt"

--- a/app/helper/plugin.py
+++ b/app/helper/plugin.py
@@ -649,10 +649,21 @@ class PluginHelper(metaclass=WeakSingleton):
         """
         dependencies = {}
         try:
+            install_plugins = [
+                plugin_id.lower() # 对应插件的小写目录名
+                for plugin_id in SystemConfigOper().get(
+                    SystemConfigKey.UserInstalledPlugins
+                )
+                or []
+            ]
             for plugin_dir in PLUGIN_DIR.iterdir():
                 if plugin_dir.is_dir():
                     requirements_file = plugin_dir / "requirements.txt"
                     if requirements_file.exists():
+                        if plugin_dir.name not in install_plugins:
+                            # 这个插件不在安装列表中 忽略它的依赖
+                            logger.debug(f"忽略插件 {plugin_dir.name} 的依赖")
+                            continue
                         # 解析当前插件的 requirements.txt，获取依赖项
                         plugin_deps = self.__parse_requirements(requirements_file)
                         for pkg_name, version_specifiers in plugin_deps.items():


### PR DESCRIPTION
目前在容器重置或首次启动时，会自动安装内置插件库的所有依赖，这对于没有安装这些插件的用户而言，是一个不必要的启动开销。
为此，改进为仅当该插件是已安装的情况下，才在启动时恢复依赖。