### PR TITLE
fix: 浏览资源时分类可能不生效，使用split后再对比分类id

### DIFF
--- a/app/modules/indexer/spider/__init__.py
+++ b/app/modules/indexer/spider/__init__.py
@@ -156,8 +156,9 @@ class SiteSpider:
                         cats = self.category.get("movie") or []
                     else:
                         cats = (self.category.get("movie") or []) + (self.category.get("tv") or [])
+                    allowed_cats = set(self.cat.split(',')) if self.cat else None
                     for cat in cats:
-                        if self.cat and str(cat.get("id")) not in self.cat:
+                        if allowed_cats and str(cat.get('id')) not in allowed_cats:
                             continue
                         if self.category.get("field"):
                             value = params.get(self.category.get("field"), "")


### PR DESCRIPTION
原来是对比的字符串，可能会判断错误