### PR TITLE
Add flag to ignore check folder modtime for rclone snapshot

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -311,7 +311,8 @@ class ConfigModel(BaseModel):
     DOCKER_CLIENT_API: Optional[str] = "tcp://127.0.0.1:38379"
     # 工作流数据共享
     WORKFLOW_STATISTIC_SHARE: bool = True
-
+    # 对rclone进行快照对比时，是否检查文件夹的修改时间
+    RCLONE_SNAPSHOT_CHECK_FOLDER_MODTIME = True
 
 class Settings(BaseSettings, ConfigModel, LogConfigModel):
     """

--- a/app/modules/filemanager/storages/__init__.py
+++ b/app/modules/filemanager/storages/__init__.py
@@ -13,6 +13,7 @@ class StorageBase(metaclass=ABCMeta):
     """
     schema = None
     transtype = {}
+    snapshot_check_folder_modtime = True
 
     def __init__(self):
         self.storagehelper = StorageHelper()
@@ -214,7 +215,8 @@ class StorageBase(metaclass=ABCMeta):
                         return
 
                     # 增量检查：如果目录修改时间早于上次快照，跳过
-                    if (last_snapshot_time and
+                    if (self.snapshot_check_folder_modtime and
+                            last_snapshot_time and
                             _fileitm.modify_time and
                             _fileitm.modify_time <= last_snapshot_time):
                         return

--- a/app/modules/filemanager/storages/rclone.py
+++ b/app/modules/filemanager/storages/rclone.py
@@ -26,6 +26,8 @@ class Rclone(StorageBase):
         "copy": "复制"
     }
 
+    snapshot_check_folder_modtime = settings.RCLONE_SNAPSHOT_CHECK_FOLDER_MODTIME
+
     def init_storage(self):
         """
         初始化


### PR DESCRIPTION
有的云文件夹（比如onedrive）的修改时间不会因为文件增加修改而更新，现有逻辑导致无法同步，总是返回0文件