### PR TITLE
refactor: polling_observer

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -1382,7 +1382,8 @@ class TransferChain(ChainBase, metaclass=Singleton):
             mediainfo: MediaInfo = MediaChain().recognize_media(tmdbid=tmdbid, doubanid=doubanid,
                                                                 mtype=mtype, episode_group=episode_group)
             if not mediainfo:
-                return False, f"媒体信息识别失败，tmdbid：{tmdbid}，doubanid：{doubanid}，type: {mtype.value}"
+                return (False,
+                        f"媒体信息识别失败，tmdbid：{tmdbid}，doubanid：{doubanid}，type: {mtype.value if mtype else None}")
             else:
                 # 更新媒体图片
                 self.obtain_images(mediainfo=mediainfo)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -313,6 +313,8 @@ class ConfigModel(BaseModel):
     WORKFLOW_STATISTIC_SHARE: bool = True
     # 对rclone进行快照对比时，是否检查文件夹的修改时间
     RCLONE_SNAPSHOT_CHECK_FOLDER_MODTIME = True
+    # 对OpenList进行快照对比时，是否检查文件夹的修改时间
+    OPENLIST_SNAPSHOT_CHECK_FOLDER_MODTIME = True
 
 class Settings(BaseSettings, ConfigModel, LogConfigModel):
     """

--- a/app/modules/filemanager/storages/__init__.py
+++ b/app/modules/filemanager/storages/__init__.py
@@ -227,11 +227,13 @@ class StorageBase(metaclass=ABCMeta):
                         __snapshot_file(sub_file, current_depth + 1)
                 else:
                     # 记录文件的完整信息用于比对
-                    files_info[_fileitm.path] = {
-                        'size': _fileitm.size or 0,
-                        'modify_time': getattr(_fileitm, 'modify_time', 0),
-                        'type': _fileitm.type
-                    }
+                    if getattr(_fileitm, 'modify_time', 0) > last_snapshot_time:
+                        files_info[_fileitm.path] = {
+                            'size': _fileitm.size or 0,
+                            'modify_time': getattr(_fileitm, 'modify_time', 0),
+                            'type': _fileitm.type
+                        }
+
             except Exception as e:
                 logger.debug(f"Snapshot error for {_fileitm.path}: {e}")
 

--- a/app/modules/filemanager/storages/alist.py
+++ b/app/modules/filemanager/storages/alist.py
@@ -31,6 +31,8 @@ class Alist(StorageBase, metaclass=WeakSingleton):
         "move": "移动",
     }
 
+    snapshot_check_folder_modtime = settings.OPENLIST_SNAPSHOT_CHECK_FOLDER_MODTIME
+
     def __init__(self):
         super().__init__()
 
@@ -586,6 +588,9 @@ class Alist(StorageBase, metaclass=WeakSingleton):
                 data=f,
             )
 
+        if resp is None:
+            logger.warn(f"【OpenList】请求上传文件 {path} 失败")
+            return None
         if resp.status_code != 200:
             logger.warn(f"【OpenList】请求上传文件 {path} 失败，状态码：{resp.status_code}")
             return None

--- a/app/monitor.py
+++ b/app/monitor.py
@@ -686,11 +686,11 @@ class Monitor(metaclass=Singleton):
 
                 # 动态调整监控间隔
                 new_interval = self.adjust_monitor_interval(file_count)
-                current_job = self._scheduler.get_job(f"monitor_{storage}_{mon_path}")
+                current_job = self._scheduler.get_job(f"monitor_{storage}")
                 if current_job and current_job.trigger.interval.total_seconds() / 60 != new_interval:
                     # 重新安排任务
                     self._scheduler.modify_job(
-                        f"monitor_{storage}_{mon_path}",
+                        f"monitor_{storage}",
                         trigger='interval',
                         minutes=new_interval
                     )


### PR DESCRIPTION
当前的远程目录轮询监控逻辑存在两个潜在的问题，可能导致遗漏远程文件的更新

1.  使用保存快照时刻的时间戳作为快照时间

由于远程文件存储存在缓存机制，如果缓存未能及时刷新，就可能导致文件更新被漏检。
以下是一个示例流程，展示了问题出现的过程：

| time  | event                                                        | `last_snapshot_time` | `modify_time` |
|-------|--------------------------------------------------------------|----------------------|--------------|
| 00:00 | 执行比较并保存快照 | 00:00                | 00:00        |
| 00:01 | 远程目录中的文件被修改 | 00:00                | 00:00        |
| 00:05 | 再次比较并保存快照（但缓存仍未刷新） | 00:05                | 00:00        |
| 00:06 | OpenList 缓存刷新  | 00:05                | 00:01        |
| 00:10 | 比较时发现 last\_snapshot\_time(00:05) > modify\_time(00:01)，跳过更新 | 00:10                | 00:01        |

2. 同一个存储中的监控目录共用一个快照记录文件

如果有两个被监控目录位于同一个远程存储，当它们被轮询的先后顺序和内部文件被修改的顺序相反，后被轮询的文件夹内的修改会被漏检。

改动：

- 使用快照中`文件最后修改时间`作为快照时间（问题1）
- `polling_observer`记录同一存储上所有监控目录的快照，将快照合并保存（问题2）
- 为 OpenList 添加与 rclone 相同的配置项`OPENLIST_SNAPSHOT_CHECK_FOLDER_MODTIME` (https://github.com/jxxghp/MoviePilot/pull/4658)
