### PR TITLE
fix: 修复使用socks代理时请求失败的问题

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -76,6 +76,6 @@ setuptools~=78.1.0
 pympler~=1.1
 smbprotocol~=1.15.0
 setproctitle~=1.3.6
-httpx~=0.28.1
+httpx[socks]~=0.28.1
 prometheus-client~=0.22.1
 prometheus-fastapi-instrumentator~=7.1.0


### PR DESCRIPTION
使用socks代理时遇到报错：[moviepilot] 2025-08-02 15:53:51,775 tmdbapi.py - Using SOCKS proxy, but the 'socksio' package is not installed. Make sure to install httpx using `pip install httpx[socks]`.

为httpx添加socks支持