### PR TITLE
feat: 优化站点资源更新逻辑

### DIFF
--- a/app/helper/resource.py
+++ b/app/helper/resource.py
@@ -112,8 +112,7 @@ class ResourceHelper:
                                 # 写入文件
                                 file_path.write_bytes(res.content)
                         if success:
-                            logger.info("资源包更新完成，开始重启服务...")
-                            SystemHelper.restart()
+                            logger.info("资源包更新完成...")
                         else:
                             logger.warn("资源包更新失败，跳过升级！")
                     else:

--- a/app/startup/modules_initializer.py
+++ b/app/startup/modules_initializer.py
@@ -137,8 +137,6 @@ def init_modules():
     DohHelper()
     # 站点管理
     SitesHelper()
-    # 资源包检测
-    ResourceHelper()
     # 用户认证
     user_auth()
     # 加载模块

--- a/docker/update.sh
+++ b/docker/update.sh
@@ -117,19 +117,52 @@ function install_backend_and_download_resources() {
     INFO "程序部分更新成功，前端版本：${frontend_version}，后端版本：${1}"
     # 恢复插件目录
     cp -a /plugins/* /app/app/plugins/
-    # 更新站点资源
-    INFO "→ 开始更新站点资源..."
-    if ! download_and_unzip "${GITHUB_PROXY}https://github.com/jxxghp/MoviePilot-Resources/archive/refs/heads/main.zip" "Resources"; then
-        cp -a /resources_bakcup/* /app/app/helper/
-        rm -rf /resources_bakcup
-        WARN "站点资源下载失败，继续使用旧的资源来启动..."
-        return 1
-    fi
-    # 复制新站点资源
-    cp -a ${TMP_PATH}/Resources/resources.v2/* /app/app/helper/
-    INFO "站点资源更新成功"
     # 清理临时目录
     rm -rf "${TMP_PATH}"
+    return 0
+}
+
+# 更新站点资源
+function update_site_resources() {
+    INFO "→ 检查站点资源..."
+
+    # 定义站点资源文件列表
+    local site_files=(
+        "sites.cp312-win_amd64.pyd"
+        "sites.cpython-312-aarch64-linux-gnu.so"
+        "sites.cpython-312-darwin.so"
+        "sites.cpython-312-x86_64-linux-gnu.so"
+        "user.sites.v2.bin"
+    )
+
+    # 检查文件是否存在
+    local missing_files=()
+    for file in "${site_files[@]}"; do
+        if [ ! -f "/app/app/helper/${file}" ]; then
+            missing_files+=("${file}")
+        fi
+    done
+
+    # 如果有文件缺失，进行全量更新
+    if [ ${#missing_files[@]} -gt 0 ]; then
+        INFO "更新站点资源..."
+        # 下载站点资源
+        if ! download_and_unzip "${GITHUB_PROXY}https://github.com/jxxghp/MoviePilot-Resources/archive/refs/heads/main.zip" "Resources"; then
+            ERROR "站点资源下载失败！"
+            return 1
+        fi
+        # 复制站点资源文件
+        cp -a ${TMP_PATH}/Resources/resources.v2/* /app/app/helper/
+        INFO "站点资源更新完成"
+    else
+        # 调用ResourceHelper检查版本并更新
+        cd /app
+        python3 -c "
+from app.helper.resource import ResourceHelper
+updater = ResourceHelper()"
+    fi
+    # 清理临时目录
+    rm -rf "${TMP_PATH}/Resources"
     return 0
 }
 
@@ -322,6 +355,8 @@ if [[ "${MOVIEPILOT_AUTO_UPDATE}" = "true" ]] || [[ "${MOVIEPILOT_AUTO_UPDATE}" 
             WARN "当前版本号获取失败，继续启动..."
         fi
     fi
+    # 更新站点资源
+    update_site_resources
     if [ -d "${TMP_PATH}" ]; then
         rm -rf "${TMP_PATH}"
     fi

--- a/docker/update.sh
+++ b/docker/update.sh
@@ -117,24 +117,18 @@ function install_backend_and_download_resources() {
     INFO "程序部分更新成功，前端版本：${frontend_version}，后端版本：${1}"
     # 恢复插件目录
     cp -a /plugins/* /app/app/plugins/
-    # 清理临时目录
-    rm -rf "${TMP_PATH}"
     return 0
 }
 
 # 更新站点资源
 function update_site_resources() {
     INFO "→ 检查站点资源..."
-
-    # 定义站点资源文件列表
-    local site_files=(
-        "sites.cp312-win_amd64.pyd"
-        "sites.cpython-312-aarch64-linux-gnu.so"
-        "sites.cpython-312-darwin.so"
-        "sites.cpython-312-x86_64-linux-gnu.so"
-        "user.sites.v2.bin"
-    )
-
+    local site_files
+    if ! mapfile -t site_files < <(curl ${CURL_OPTIONS} "${GITHUB_PROXY}https://raw.githubusercontent.com/jxxghp/MoviePilot-Resources/refs/heads/main/package.v2.json" ${CURL_HEADERS} | jq -r '.resources | keys[]' 2>/dev/null) && [ ${#site_files[@]} -gt 0 ]; then
+        ERROR "无法获取远程文件列表"
+        return 1
+    fi
+    
     # 检查文件是否存在
     local missing_files=()
     for file in "${site_files[@]}"; do
@@ -151,18 +145,17 @@ function update_site_resources() {
             ERROR "站点资源下载失败！"
             return 1
         fi
-        # 复制站点资源文件
         cp -a ${TMP_PATH}/Resources/resources.v2/* /app/app/helper/
         INFO "站点资源更新完成"
     else
         # 调用ResourceHelper检查版本并更新
         cd /app
-        python3 -c "
-from app.helper.resource import ResourceHelper
-updater = ResourceHelper()"
+        if python3 -c "from app.helper.resource import ResourceHelper; updater = ResourceHelper()" >/dev/null 2>&1; then
+            INFO "站点资源更新检查完成"
+        else
+            WARN "站点资源更新检查  失败"
+        fi
     fi
-    # 清理临时目录
-    rm -rf "${TMP_PATH}/Resources"
     return 0
 }
 

--- a/docker/update.sh
+++ b/docker/update.sh
@@ -128,7 +128,7 @@ function update_site_resources() {
         ERROR "无法获取远程文件列表"
         return 1
     fi
-    
+
     # 检查文件是否存在
     local missing_files=()
     for file in "${site_files[@]}"; do
@@ -153,7 +153,7 @@ function update_site_resources() {
         if python3 -c "from app.helper.resource import ResourceHelper; updater = ResourceHelper()" >/dev/null 2>&1; then
             INFO "站点资源更新检查完成"
         else
-            WARN "站点资源更新检查  失败"
+            WARN "站点资源更新检查失败"
         fi
     fi
     return 0


### PR DESCRIPTION
fix: https://github.com/jxxghp/MoviePilot/issues/4620
目前触发站点资源更新有3种方式：
1.mp_update.sh检查后端版本需要更新
2.MOVIEPILOT_AUTO_UPDATE=dev
3.resource.py资源检查如果站点资源版本低进行更新并触发重启
优化后：
在mp_update.sh中完成站点资源版本检查和更新避免容器重启
1.检查站点资源文件有缺失,进行全量更新
2.调用ResourceHelper如果站点资源版本低则进行更新