### PR TITLE
feat(browser): 添加 FlareSolverr 请求超时设置并优化相关功能

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -324,6 +324,8 @@ class ConfigModel(BaseModel):
     BROWSER_EMULATION: str = "playwright"
     # FlareSolverr 服务地址，例如 http://127.0.0.1:8191
     FLARESOLVERR_URL: Optional[str] = None
+    # FlareSolverr 请求超时(秒)
+    FLARESOLVERR_TIMEOUT: int = 30
 
 
 class Settings(BaseSettings, ConfigModel, LogConfigModel):

--- a/app/helper/browser.py
+++ b/app/helper/browser.py
@@ -31,7 +31,7 @@ class PlaywrightHelper:
     def __flaresolverr_request(url: str,
                                cookies: Optional[str] = None,
                                proxy_url: Optional[str] = None,
-                               timeout: Optional[int] = 30) -> Optional[dict]:
+                               timeout: Optional[int] = settings.FLARESOLVERR_TIMEOUT) -> Optional[dict]:
         """
         调用 FlareSolverr 解决 Cloudflare 并返回 solution 结果
         参考: https://github.com/FlareSolverr/FlareSolverr
@@ -39,6 +39,8 @@ class PlaywrightHelper:
         if not settings.FLARESOLVERR_URL:
             logger.warn("未配置 FLARESOLVERR_URL，无法使用 FlareSolverr")
             return None
+
+        logger.info(f"尝试使用 FlareSolverr 通过 Cloudflare ...")
 
         payload = {
             "cmd": "request.get",
@@ -56,7 +58,7 @@ class PlaywrightHelper:
 
         try:
             fs_api = settings.FLARESOLVERR_URL.rstrip("/") + "/v1"
-            data = RequestUtils(content_type="application/json").post_json(url=fs_api, json=payload)
+            data = RequestUtils(content_type="application/json", timeout=timeout).post_json(url=fs_api, json=payload)
             if not data:
                 logger.error("FlareSolverr 返回空响应")
                 return None
@@ -100,7 +102,7 @@ class PlaywrightHelper:
                         if proxies and isinstance(proxies, dict):
                             proxy_url = proxies.get("server")
                         solution = self.__flaresolverr_request(url=url, cookies=cookies,
-                                                               proxy_url=proxy_url, timeout=timeout)
+                                                               proxy_url=proxy_url)
                         if solution:
                             fs_cookie_header = self.__fs_cookie_str(solution.get("cookies", []))
                             fs_ua = solution.get("userAgent")
@@ -161,7 +163,7 @@ class PlaywrightHelper:
                 if proxies and isinstance(proxies, dict):
                     proxy_url = proxies.get("server")
                 solution = self.__flaresolverr_request(url=url, cookies=cookies,
-                                                       proxy_url=proxy_url, timeout=timeout)
+                                                       proxy_url=proxy_url)
                 if solution:
                     return solution.get("response")
             except Exception as e:

--- a/app/helper/rss.py
+++ b/app/helper/rss.py
@@ -453,7 +453,7 @@ class RssHelper:
                     url=rss_url,
                     cookies=cookie,
                     ua=ua,
-                    proxies=settings.PROXY if proxy else None
+                    proxies=settings.PROXY_SERVER if proxy else None
                 )
             else:
                 res = RequestUtils(


### PR DESCRIPTION
- 在配置文件中添加 FLARESOLVERR_TIMEOUT 设置，用于 FlareSolverr 请求超时（秒）
- 修改浏览器辅助工具中的 FlareSolverr 请求逻辑，使用新的超时设置
- 修正 RSS 中的代理设置，使用 PROXY_SERVER 而不是 PROXY