### PR TITLE
修复tmdbid解析异常

### DIFF
--- a/app/modules/themoviedb/tmdbapi.py
+++ b/app/modules/themoviedb/tmdbapi.py
@@ -404,10 +404,7 @@ class TmdbApi:
                 return int(match.group(1))
             except Exception:
                 return None
-        # 兜底：取最后段再取数字前缀
-        last = link.rsplit("/", 1)[-1]
-        num_match = re.match(r"^(\d+)", last)
-        return int(num_match.group(1)) if num_match else None
+        return None
 
     @staticmethod
     def __get_names(tmdb_info: dict) -> List[str]:


### PR DESCRIPTION
url格式为/movie/1195631-william-tell、/tv/65942-re、/tv/79744-the-rookie等
现有写法会出现异常,使用正则解析
<img width="986" height="122" alt="image" src="https://github.com/user-attachments/assets/4932c16d-2c33-4583-8c5a-37ab4ff3b34a" />
