### PR TITLE
Fix postgresql textual sql expression error

### DIFF
--- a/app/modules/postgresql/__init__.py
+++ b/app/modules/postgresql/__init__.py
@@ -4,6 +4,7 @@ from app.core.config import settings
 from app.db import SessionFactory
 from app.modules import _ModuleBase
 from app.schemas.types import ModuleType, OtherModulesType
+from sqlalchemy import text
 
 
 class PostgreSQLModule(_ModuleBase):
@@ -54,7 +55,7 @@ class PostgreSQLModule(_ModuleBase):
         # 测试数据库连接
         db = SessionFactory()
         try:
-            db.execute("SELECT 1")
+            db.execute(text("SELECT 1"))
         except Exception as e:
             return False, f"PostgreSQL连接失败：{e}"
         finally:


### PR DESCRIPTION
Fix PostgreSQL connection error by wrapping raw SQL with `text()` for SQLAlchemy 2.0+ compatibility.

The error `Textual SQL expression 'SELECT 1' should be explicitly declared as text('SELECT 1')` occurs in SQLAlchemy 2.0+ when raw SQL strings are passed to `db.execute()` without being wrapped by the `text()` function.

---
<a href="https://cursor.com/background-agent?bcId=bc-688bd602-4f9a-49a2-9f48-efcb67240963">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-688bd602-4f9a-49a2-9f48-efcb67240963">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

