### PR TITLE
Install playwright dependencies in dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,7 +57,7 @@ RUN python3 -m venv ${VENV_PATH} \
 COPY ../requirements.in requirements.in
 RUN ${VENV_PATH}/bin/pip-compile requirements.in \
     && ${VENV_PATH}/bin/pip install -r requirements.txt \
-    && playwright install-deps chromium \
+    && ${VENV_PATH}/bin/playwright install-deps chromium \
     && apt-get remove -y build-essential \
     && apt-get autoremove -y \
     && apt-get clean -y \


### PR DESCRIPTION
Fixes "playwright: not found" error in Docker build by explicitly calling the `playwright` command from the virtual environment.

---
<a href="https://cursor.com/background-agent?bcId=bc-49aa8ab3-c7a2-455c-aedb-68aa4322a936">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-49aa8ab3-c7a2-455c-aedb-68aa4322a936">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

