### PR TITLE
refactor(storage): 优化空目录删除逻辑

### DIFF
--- a/app/api/endpoints/history.py
+++ b/app/api/endpoints/history.py
@@ -90,7 +90,7 @@ def delete_transfer_history(history_in: schemas.TransferHistory,
     # 册除媒体库文件
     if deletedest and history.dest_fileitem:
         dest_fileitem = schemas.FileItem(**history.dest_fileitem)
-        StorageChain().delete_media_file(fileitem=dest_fileitem, mtype=MediaType(history.type))
+        StorageChain().delete_media_file(dest_fileitem)
 
     # 删除源文件
     if deletesrc and history.src_fileitem:

--- a/app/api/endpoints/transfer.py
+++ b/app/api/endpoints/transfer.py
@@ -109,7 +109,7 @@ def manual_transfer(transer_item: ManualTransferItem,
             if history.dest_fileitem:
                 # 删除旧的已整理文件
                 dest_fileitem = FileItem(**history.dest_fileitem)
-                state = StorageChain().delete_media_file(dest_fileitem, mtype=MediaType(history.type))
+                state = StorageChain().delete_media_file(dest_fileitem)
                 if not state:
                     return schemas.Response(success=False, message=f"{dest_fileitem.path} 删除失败")
 


### PR DESCRIPTION


**修改内容**
- 移除 `delete_media_file` 方法中的 `mtype` 参数
- 废弃基于重命名格式推断媒体根目录的旧逻辑
- 实现基于配置目录匹配的新目录处理机制
- 采用递归向上处理父目录的安全删除策略

**解决的问题**
- 解决了只能处理媒体库目录，无法处理资源目录的限制
- 解决了只能处理一级目录的问题，支持多级目录递归处理
- 解决了因整理后修改目录配置导致的潜在误删风险