### PR TITLE
Correct three character typo

### DIFF
--- a/app/modules/slack/__init__.py
+++ b/app/modules/slack/__init__.py
@@ -76,7 +76,7 @@ class SlackModule(_ModuleBase, _MessageBase[Slack]):
         for name, client in self.get_instances().items():
             state = client.get_state()
             if not state:
-                return False, f"Slack {name} 未就续"
+                return False, f"Slack {name} 未就绪"
         return True, ""
 
     def init_setting(self) -> Tuple[str, Union[str, bool]]:

--- a/app/modules/synologychat/__init__.py
+++ b/app/modules/synologychat/__init__.py
@@ -70,7 +70,7 @@ class SynologyChatModule(_ModuleBase, _MessageBase[SynologyChat]):
         for name, client in self.get_instances().items():
             state = client.get_state()
             if not state:
-                return False, f"Synology Chat {name} 未就续"
+                return False, f"Synology Chat {name} 未就绪"
         return True, ""
 
     def init_setting(self) -> Tuple[str, Union[str, bool]]:

--- a/app/modules/telegram/__init__.py
+++ b/app/modules/telegram/__init__.py
@@ -81,7 +81,7 @@ class TelegramModule(_ModuleBase, _MessageBase[Telegram]):
         for name, client in self.get_instances().items():
             state = client.get_state()
             if not state:
-                return False, f"Telegram {name} 未就续"
+                return False, f"Telegram {name} 未就绪"
         return True, ""
 
     def init_setting(self) -> Tuple[str, Union[str, bool]]:

--- a/app/modules/vocechat/__init__.py
+++ b/app/modules/vocechat/__init__.py
@@ -71,7 +71,7 @@ class VoceChatModule(_ModuleBase, _MessageBase[VoceChat]):
         for name, client in self.get_instances().items():
             state = client.get_state()
             if not state:
-                return False, f"VoceChat {name} 未就续"
+                return False, f"VoceChat {name} 未就绪"
         return True, ""
 
     def init_setting(self) -> Tuple[str, Union[str, bool]]:

--- a/app/modules/wechat/__init__.py
+++ b/app/modules/wechat/__init__.py
@@ -75,7 +75,7 @@ class WechatModule(_ModuleBase, _MessageBase[WeChat]):
         for name, client in self.get_instances().items():
             state = client.get_state()
             if not state:
-                return False, f"企业微信 {name} 未就续"
+                return False, f"企业微信 {name} 未就绪"
         return True, ""
 
     def init_setting(self) -> Tuple[str, Union[str, bool]]:


### PR DESCRIPTION
Corrected typo '未就续' to '未就绪' in error messages across multiple modules to ensure accuracy.

---
<a href="https://cursor.com/background-agent?bcId=bc-9dbc4541-1ff2-4f29-b493-00a53839d7bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9dbc4541-1ff2-4f29-b493-00a53839d7bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

