### PR TITLE
Handle -1 limit for all records in api

### DIFF
--- a/app/db/models/downloadhistory.py
+++ b/app/db/models/downloadhistory.py
@@ -80,9 +80,15 @@ class DownloadHistory(Base):
     @classmethod
     @async_db_query
     async def async_list_by_page(cls, db: AsyncSession, page: Optional[int] = 1, count: Optional[int] = 30):
-        result = await db.execute(
-            select(cls).offset((page - 1) * count).limit(count)
-        )
+        # 当count为-1时，offset应该为0，因为我们要获取所有记录
+        if count == -1:
+            query = select(cls)
+        else:
+            query = select(cls).offset((page - 1) * count)
+            # 当count为-1时，不添加limit限制，返回所有记录
+            if count != -1:
+                query = query.limit(count)
+        result = await db.execute(query)
         return result.scalars().all()
 
     @classmethod

--- a/app/db/models/message.py
+++ b/app/db/models/message.py
@@ -43,7 +43,12 @@ class Message(Base):
     @classmethod
     @async_db_query
     async def async_list_by_page(cls, db: AsyncSession, page: Optional[int] = 1, count: Optional[int] = 30):
-        result = await db.execute(
-            select(cls).order_by(cls.reg_time.desc()).offset((page - 1) * count).limit(count)
-        )
+        if count == -1:
+            query = select(cls).order_by(cls.reg_time.desc())
+        else:
+            query = select(cls).order_by(cls.reg_time.desc()).offset((page - 1) * count)
+            # 当count为-1时，不添加limit限制，返回所有记录
+            if count != -1:
+                query = query.limit(count)
+        result = await db.execute(query)
         return result.scalars().all()

--- a/app/db/models/subscribehistory.py
+++ b/app/db/models/subscribehistory.py
@@ -85,13 +85,22 @@ class SubscribeHistory(Base):
     @classmethod
     @async_db_query
     async def async_list_by_type(cls, db: AsyncSession, mtype: str, page: Optional[int] = 1, count: Optional[int] = 30):
-        result = await db.execute(
-            select(cls).filter(
+        if count == -1:
+            query = select(cls).filter(
                 cls.type == mtype
             ).order_by(
                 cls.date.desc()
-            ).offset((page - 1) * count).limit(count)
-        )
+            )
+        else:
+            query = select(cls).filter(
+                cls.type == mtype
+            ).order_by(
+                cls.date.desc()
+            ).offset((page - 1) * count)
+            # 当count为-1时，不添加limit限制，返回所有记录
+            if count != -1:
+                query = query.limit(count)
+        result = await db.execute(query)
         return result.scalars().all()
 
     @classmethod

--- a/app/db/models/transferhistory.py
+++ b/app/db/models/transferhistory.py
@@ -122,19 +122,35 @@ class TransferHistory(Base):
     async def async_list_by_page(cls, db: AsyncSession, page: Optional[int] = 1, count: Optional[int] = 30,
                                  status: bool = None):
         if status is not None:
-            result = await db.execute(
-                select(cls).filter(
+            if count == -1:
+                query = select(cls).filter(
                     cls.status == status
                 ).order_by(
                     cls.date.desc()
-                ).offset((page - 1) * count).limit(count)
-            )
-        else:
-            result = await db.execute(
-                select(cls).order_by(
+                )
+            else:
+                query = select(cls).filter(
+                    cls.status == status
+                ).order_by(
                     cls.date.desc()
-                ).offset((page - 1) * count).limit(count)
-            )
+                ).offset((page - 1) * count)
+                # 当count为-1时，不添加limit限制，返回所有记录
+                if count != -1:
+                    query = query.limit(count)
+            result = await db.execute(query)
+        else:
+            if count == -1:
+                query = select(cls).order_by(
+                    cls.date.desc()
+                )
+            else:
+                query = select(cls).order_by(
+                    cls.date.desc()
+                ).offset((page - 1) * count)
+                # 当count为-1时，不添加limit限制，返回所有记录
+                if count != -1:
+                    query = query.limit(count)
+            result = await db.execute(query)
         return result.scalars().all()
 
     @classmethod


### PR DESCRIPTION
Allow database queries to handle `count=-1` for "All" selections by removing the LIMIT clause.

This fixes an issue where the frontend sends `count=-1` when "All" is selected for pagination, but PostgreSQL does not support `LIMIT -1`, causing query failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-cadb1a6f-613b-4c0a-b737-c9a865863303">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cadb1a6f-613b-4c0a-b737-c9a865863303">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

