### PR TITLE
Optimize magnet link handling for torrents

### DIFF
--- a/app/helper/torrent.py
+++ b/app/helper/torrent.py
@@ -201,6 +201,15 @@ class TorrentHelper(metaclass=WeakSingleton):
         """
         if not torrent_content:
             return "", []
+        
+        # 检查是否为磁力链接
+        if isinstance(torrent_content, str) and torrent_content.startswith("magnet:"):
+            # 磁力链接无法预先获取文件信息，返回空
+            return "", []
+        elif isinstance(torrent_content, bytes) and torrent_content.startswith(b"magnet:"):
+            # 磁力链接无法预先获取文件信息，返回空
+            return "", []
+        
         try:
             # 解析种子内容
             torrentinfo = Torrent.from_string(torrent_content)

--- a/app/modules/qbittorrent/__init__.py
+++ b/app/modules/qbittorrent/__init__.py
@@ -125,6 +125,14 @@ class QbittorrentModule(_ModuleBase, _DownloaderBase[Qbittorrent]):
                 else:
                     torrent_content = content
 
+                # 检查是否为磁力链接
+                if isinstance(torrent_content, str) and torrent_content.startswith("magnet:"):
+                    # 磁力链接不需要解析种子文件
+                    return None, torrent_content
+                elif isinstance(torrent_content, bytes) and torrent_content.startswith(b"magnet:"):
+                    # 磁力链接不需要解析种子文件
+                    return None, torrent_content
+
                 if torrent_content:
                     torrent_info = Torrent.from_string(torrent_content)
 
@@ -138,7 +146,9 @@ class QbittorrentModule(_ModuleBase, _DownloaderBase[Qbittorrent]):
 
         # 读取种子的名称
         torrent, content = __get_torrent_info()
-        if not torrent:
+        # 检查是否为磁力链接
+        is_magnet = isinstance(content, str) and content.startswith("magnet:") or isinstance(content, bytes) and content.startswith(b"magnet:")
+        if not torrent and not is_magnet:
             return None, None, None, f"添加种子任务失败：无法读取种子文件"
 
         # 获取下载器

--- a/app/modules/transmission/__init__.py
+++ b/app/modules/transmission/__init__.py
@@ -126,6 +126,14 @@ class TransmissionModule(_ModuleBase, _DownloaderBase[Transmission]):
                 else:
                     torrent_content = content
 
+                # 检查是否为磁力链接
+                if isinstance(torrent_content, str) and torrent_content.startswith("magnet:"):
+                    # 磁力链接不需要解析种子文件
+                    return None, torrent_content
+                elif isinstance(torrent_content, bytes) and torrent_content.startswith(b"magnet:"):
+                    # 磁力链接不需要解析种子文件
+                    return None, torrent_content
+
                 if torrent_content:
                     torrent_info = Torrent.from_string(torrent_content)
 
@@ -139,7 +147,9 @@ class TransmissionModule(_ModuleBase, _DownloaderBase[Transmission]):
 
         # 读取种子的名称
         torrent, content = __get_torrent_info()
-        if not torrent:
+        # 检查是否为磁力链接
+        is_magnet = isinstance(content, str) and content.startswith("magnet:") or isinstance(content, bytes) and content.startswith(b"magnet:")
+        if not torrent and not is_magnet:
             return None, None, None, f"添加种子任务失败：无法读取种子文件"
 
         # 获取下载器


### PR DESCRIPTION
Enable direct processing of magnet links in download modules, bypassing torrent file parsing, to fix "Unable to interpret `m` char" errors.

Previously, magnet links were incorrectly treated as standard torrent files, leading to parsing failures when attempting to use `Torrent.from_string()`. This change ensures magnet links are identified and passed directly to the downloaders.

---
<a href="https://cursor.com/background-agent?bcId=bc-6fc90be3-2504-4187-8287-56b9c2c3dd2d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6fc90be3-2504-4187-8287-56b9c2c3dd2d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

