### PR TITLE
Debug link object next attribute error

### DIFF
--- a/app/core/cache.py
+++ b/app/core/cache.py
@@ -390,7 +390,17 @@ class MemoryBackend(CacheBackend):
         region_cache = self._region_caches.setdefault(region, MemoryTTLCache(maxsize=maxsize, ttl=ttl))
         # 设置缓存值
         with lock:
-            region_cache[key] = value
+            try:
+                region_cache[key] = value
+            except AttributeError as e:
+                # Handle cachetools AttributeError with _Link.next
+                if "'_Link' object has no attribute 'next'" in str(e):
+                    logger.warning(f"Cachetools AttributeError encountered, clearing cache for region {region}")
+                    # Clear the problematic cache and retry
+                    region_cache.clear()
+                    region_cache[key] = value
+                else:
+                    raise
 
     def exists(self, key: str, region: Optional[str] = DEFAULT_CACHE_REGION) -> bool:
         """
@@ -429,7 +439,16 @@ class MemoryBackend(CacheBackend):
         if region_cache is None:
             return
         with lock:
-            del region_cache[key]
+            try:
+                del region_cache[key]
+            except AttributeError as e:
+                # Handle cachetools AttributeError with _Link.next
+                if "'_Link' object has no attribute 'next'" in str(e):
+                    logger.warning(f"Cachetools AttributeError encountered during delete, clearing cache for region {region}")
+                    # Clear the problematic cache
+                    region_cache.clear()
+                else:
+                    raise
 
     def clear(self, region: Optional[str] = DEFAULT_CACHE_REGION) -> None:
         """
@@ -513,7 +532,17 @@ class AsyncMemoryBackend(AsyncCacheBackend):
         region_cache = self._region_caches.setdefault(region, MemoryTTLCache(maxsize=maxsize, ttl=ttl))
         # 设置缓存值
         with lock:
-            region_cache[key] = value
+            try:
+                region_cache[key] = value
+            except AttributeError as e:
+                # Handle cachetools AttributeError with _Link.next
+                if "'_Link' object has no attribute 'next'" in str(e):
+                    logger.warning(f"Cachetools AttributeError encountered, clearing cache for region {region}")
+                    # Clear the problematic cache and retry
+                    region_cache.clear()
+                    region_cache[key] = value
+                else:
+                    raise
 
     async def exists(self, key: str, region: Optional[str] = DEFAULT_CACHE_REGION) -> bool:
         """
@@ -552,7 +581,16 @@ class AsyncMemoryBackend(AsyncCacheBackend):
         if region_cache is None:
             return
         with lock:
-            del region_cache[key]
+            try:
+                del region_cache[key]
+            except AttributeError as e:
+                # Handle cachetools AttributeError with _Link.next
+                if "'_Link' object has no attribute 'next'" in str(e):
+                    logger.warning(f"Cachetools AttributeError encountered during delete, clearing cache for region {region}")
+                    # Clear the problematic cache
+                    region_cache.clear()
+                else:
+                    raise
 
     async def clear(self, region: Optional[str] = DEFAULT_CACHE_REGION) -> None:
         """

--- a/requirements.in
+++ b/requirements.in
@@ -54,7 +54,7 @@ requests-cache~=1.2.1
 parse~=1.20.2
 docker~=7.1.0
 pywin32==310; platform_system == "Windows"
-cachetools~=6.1.0
+cachetools~=6.1.1
 fast-bencode~=1.1.7
 pystray~=0.19.5
 pyotp~=2.9.0

--- a/test_cache_fix.py
+++ b/test_cache_fix.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+Test script to verify the cache AttributeError fix
+"""
+
+import sys
+import os
+
+# Add the app directory to the Python path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'app'))
+
+from core.cache import MemoryBackend
+import logging
+
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def test_cache_fix():
+    """Test the cache fix for AttributeError"""
+    print("Testing cache fix for AttributeError...")
+    
+    # Create a cache instance
+    cache = MemoryBackend(maxsize=10, ttl=60)
+    
+    # Test normal cache operations
+    try:
+        # Set some cache values
+        cache.set("test_key_1", "test_value_1", region="test_region")
+        cache.set("test_key_2", "test_value_2", region="test_region")
+        
+        # Get cache values
+        value1 = cache.get("test_key_1", region="test_region")
+        value2 = cache.get("test_key_2", region="test_region")
+        
+        print(f"Cache get test: {value1}, {value2}")
+        
+        # Test delete operation
+        cache.delete("test_key_1", region="test_region")
+        deleted_value = cache.get("test_key_1", region="test_region")
+        print(f"After delete: {deleted_value}")
+        
+        # Test clear operation
+        cache.clear(region="test_region")
+        cleared_value = cache.get("test_key_2", region="test_region")
+        print(f"After clear: {cleared_value}")
+        
+        print("✅ All cache operations completed successfully!")
+        
+    except Exception as e:
+        print(f"❌ Error during cache operations: {e}")
+        return False
+    
+    return True
+
+if __name__ == "__main__":
+    success = test_cache_fix()
+    if success:
+        print("\n🎉 Cache fix test passed!")
+    else:
+        print("\n💥 Cache fix test failed!")
+        sys.exit(1)


### PR DESCRIPTION
Update `cachetools` and add defensive error handling to cache operations to fix `AttributeError: '_Link' object has no attribute 'next'`.

The `AttributeError` was traced to an internal linked list issue within `cachetools` version 6.1.0. Updating to 6.1.1 is expected to resolve the bug. Additionally, error handling was implemented in `MemoryBackend` and `AsyncMemoryBackend` to catch this specific error, log a warning, clear the affected cache region, and retry the operation, ensuring application stability even if the underlying `cachetools` issue recurs or a similar problem arises.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7c34659-b6f1-4b11-8139-eb4a124940e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7c34659-b6f1-4b11-8139-eb4a124940e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

