### PR TITLE
Cache subscription calendar with redis error

### DIFF
--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -1198,25 +1198,35 @@ class SubscribeChain(ChainBase):
             except ValueError:
                 logger.error(f'订阅 {subscribe.name} 类型错误：{subscribe.type}')
                 continue
+            
             # 识别媒体信息
-            if mtype == MediaType.MOVIE:
-                mediainfo: MediaInfo = await self.async_recognize_media(mtype=mtype,
-                                                                        tmdbid=subscribe.tmdbid,
-                                                                        doubanid=subscribe.doubanid,
-                                                                        bangumiid=subscribe.bangumiid,
-                                                                        episode_group=subscribe.episode_group,
-                                                                        cache=False)
-                if not mediainfo:
-                    logger.warn(
-                        f'未识别到媒体信息，标题：{subscribe.name}，tmdbid：{subscribe.tmdbid}，doubanid：{subscribe.doubanid}')
+            try:
+                if mtype == MediaType.MOVIE:
+                    mediainfo: MediaInfo = await self.async_recognize_media(mtype=mtype,
+                                                                            tmdbid=subscribe.tmdbid,
+                                                                            doubanid=subscribe.doubanid,
+                                                                            bangumiid=subscribe.bangumiid,
+                                                                            episode_group=subscribe.episode_group,
+                                                                            cache=False)
+                    if not mediainfo:
+                        logger.warn(
+                            f'未识别到媒体信息，标题：{subscribe.name}，tmdbid：{subscribe.tmdbid}，doubanid：{subscribe.doubanid}')
+                        continue
+                else:
+                    episodes = await TmdbChain().async_tmdb_episodes(tmdbid=subscribe.tmdbid,
+                                                                     season=subscribe.season,
+                                                                     episode_group=subscribe.episode_group)
+                    if not episodes:
+                        logger.warn(
+                            f'未识别到季集信息，标题：{subscribe.name}，tmdbid：{subscribe.tmdbid}，豆瓣ID：{subscribe.doubanid}，季：{subscribe.season}')
+                        continue
+            except Exception as e:
+                # 捕获Redis连接错误或其他异步操作错误
+                if "Event loop is closed" in str(e) or "Failed to get key" in str(e):
+                    logger.warning(f'订阅日历预缓存时遇到Redis连接问题，跳过订阅 {subscribe.name}: {e}')
                     continue
-            else:
-                episodes = await TmdbChain().async_tmdb_episodes(tmdbid=subscribe.tmdbid,
-                                                                 season=subscribe.season,
-                                                                 episode_group=subscribe.episode_group)
-                if not episodes:
-                    logger.warn(
-                        f'未识别到季集信息，标题：{subscribe.name}，tmdbid：{subscribe.tmdbid}，豆瓣ID：{subscribe.doubanid}，季：{subscribe.season}')
+                else:
+                    logger.error(f'订阅日历预缓存时处理订阅 {subscribe.name} 时出错: {e}')
                     continue
         logger.info(f'订阅日历预缓存完成')
 

--- a/app/core/cache.py
+++ b/app/core/cache.py
@@ -1174,18 +1174,38 @@ def cached(region: Optional[str] = None, maxsize: Optional[int] = 1024, ttl: Opt
             async def async_wrapper(*args, **kwargs):
                 # 获取缓存键
                 cache_key = __get_cache_key(args, kwargs)
-                # 尝试获取缓存
-                cached_value = await cache_backend.get(cache_key, region=cache_region)
-                if should_cache(cached_value) and await async_is_valid_cache_value(cache_key, cached_value,
-                                                                                   cache_region):
-                    return cached_value
-                # 执行异步函数并缓存结果
+                
+                # 尝试获取缓存，如果失败则跳过缓存
+                cached_value = None
+                try:
+                    cached_value = await cache_backend.get(cache_key, region=cache_region)
+                    if should_cache(cached_value) and await async_is_valid_cache_value(cache_key, cached_value,
+                                                                                       cache_region):
+                        return cached_value
+                except Exception as e:
+                    # 如果缓存操作失败（比如Redis连接问题），记录警告但继续执行
+                    if "Event loop is closed" in str(e) or "Failed to get key" in str(e):
+                        logger.warning(f"Cache get operation failed, skipping cache for {func.__name__}: {e}")
+                    else:
+                        logger.error(f"Cache get operation failed for {func.__name__}: {e}")
+                
+                # 执行异步函数
                 result = await func(*args, **kwargs)
+                
                 # 判断是否需要缓存
                 if not should_cache(result):
                     return result
-                # 设置缓存（如果有传入的 maxsize 和 ttl，则覆盖默认值）
-                await cache_backend.set(cache_key, result, ttl=ttl, maxsize=maxsize, region=cache_region)
+                
+                # 尝试设置缓存，如果失败则忽略
+                try:
+                    await cache_backend.set(cache_key, result, ttl=ttl, maxsize=maxsize, region=cache_region)
+                except Exception as e:
+                    # 如果缓存操作失败（比如Redis连接问题），记录警告但不影响函数执行
+                    if "Event loop is closed" in str(e) or "Failed to get key" in str(e):
+                        logger.warning(f"Cache set operation failed, skipping cache for {func.__name__}: {e}")
+                    else:
+                        logger.error(f"Cache set operation failed for {func.__name__}: {e}")
+                
                 return result
 
             async def cache_clear():

--- a/app/helper/redis.py
+++ b/app/helper/redis.py
@@ -18,6 +18,34 @@ _complex_serializable_types = set()
 _simple_serializable_types = set()
 
 
+async def safe_async_operation(operation, *args, **kwargs):
+    """
+    安全执行异步操作的辅助函数，处理事件循环关闭等异常情况
+    
+    :param operation: 要执行的异步操作函数
+    :param args: 位置参数
+    :param kwargs: 关键字参数
+    :return: 操作结果或None（如果操作失败）
+    """
+    try:
+        import asyncio
+        # 检查事件循环是否运行
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            logger.warning("Event loop is not running, skipping async operation")
+            return None
+        
+        return await operation(*args, **kwargs)
+    except Exception as e:
+        if "Event loop is closed" in str(e) or "Failed to get key" in str(e):
+            logger.warning(f"Async operation failed due to event loop issues: {e}")
+            return None
+        else:
+            logger.error(f"Async operation failed: {e}")
+            return None
+
+
 def serialize(value: Any) -> bytes:
     """
     将值序列化为二进制数据，根据序列化方式标识格式
@@ -420,13 +448,16 @@ class AsyncRedisHelper(metaclass=Singleton):
         :param region: 缓存的区
         :param kwargs: 其他参数
         """
-        try:
+        async def _set_operation():
             await self._connect()
             redis_key = self.__make_redis_key(region, key)
             # 对值进行序列化
             serialized_value = serialize(value)
             kwargs.pop("maxsize", None)
             await self.client.set(redis_key, serialized_value, ex=ttl, **kwargs)
+        
+        try:
+            await safe_async_operation(_set_operation)
         except Exception as e:
             logger.error(f"Failed to set key (async): {key} in region: {region}, error: {e}")
 
@@ -438,11 +469,14 @@ class AsyncRedisHelper(metaclass=Singleton):
         :param region: 缓存的区
         :return: 存在返回True，否则返回False
         """
-        try:
+        async def _exists_operation():
             await self._connect()
             redis_key = self.__make_redis_key(region, key)
-            result = await self.client.exists(redis_key)
-            return result == 1
+            return await self.client.exists(redis_key) == 1
+        
+        try:
+            result = await safe_async_operation(_exists_operation)
+            return result if result is not None else False
         except Exception as e:
             logger.error(f"Failed to exists key (async): {key} region: {region}, error: {e}")
             return False
@@ -455,13 +489,17 @@ class AsyncRedisHelper(metaclass=Singleton):
         :param region: 缓存的区
         :return: 返回缓存的值，如果缓存不存在返回None
         """
-        try:
+        async def _get_operation():
             await self._connect()
             redis_key = self.__make_redis_key(region, key)
             value = await self.client.get(redis_key)
             if value is not None:
                 return deserialize(value)
             return None
+        
+        try:
+            result = await safe_async_operation(_get_operation)
+            return result
         except Exception as e:
             logger.error(f"Failed to get key (async): {key} in region: {region}, error: {e}")
             return None

--- a/app/modules/themoviedb/tmdbv3api/tmdb.py
+++ b/app/modules/themoviedb/tmdbv3api/tmdb.py
@@ -133,7 +133,16 @@ class TMDb(object):
     @cached(maxsize=settings.CONF.tmdb, ttl=settings.CONF.meta)
     async def async_cached_request(self, method, url, data, json,
                                    _ts=datetime.strftime(datetime.now(), '%Y%m%d')):
-        return await self.async_request(method, url, data, json)
+        try:
+            return await self.async_request(method, url, data, json)
+        except Exception as e:
+            # 如果缓存操作失败（比如Redis连接问题），直接执行请求而不使用缓存
+            if "Event loop is closed" in str(e) or "Failed to get key" in str(e):
+                logger.warning(f"Redis cache operation failed, falling back to direct request: {e}")
+                return await self.async_request(method, url, data, json)
+            else:
+                # 重新抛出其他类型的异常
+                raise
 
     def request(self, method, url, data, json):
         if method == "GET":


### PR DESCRIPTION
Fix 'Event loop is closed' error during Redis cache operations by adding robust error handling and fallbacks.

The previous implementation would fail with an "Event loop is closed" error when async Redis cache operations were attempted after the event loop had closed or the connection was invalid. This PR introduces `safe_async_operation` and enhances error handling in the cache decorator, Redis helper methods, and TMDB API calls to gracefully handle these scenarios, ensuring that cache failures do not halt critical operations like subscription calendar pre-caching. Instead, it falls back to direct requests or skips caching, improving system resilience.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4b4cc82-1e93-435b-9aa0-b16af3a07b07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c4b4cc82-1e93-435b-9aa0-b16af3a07b07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

