### PR TITLE
新增HTTPS的端口环境变量SSL_NGINX_PORT

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -183,8 +183,8 @@ if [ "${ENABLE_SSL}" = "true" ]; then
         include /etc/nginx/mime.types;
         default_type application/octet-stream;
 
-        listen 443 ssl;
-        listen [::]:443 ssl;
+        listen ${SSL_NGINX_PORT:-3002} ssl;
+        listen [::]:${SSL_NGINX_PORT:-3002} ssl;
         server_name ${SSL_DOMAIN:-moviepilot};
 
         # SSL证书路径

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -183,8 +183,8 @@ if [ "${ENABLE_SSL}" = "true" ]; then
         include /etc/nginx/mime.types;
         default_type application/octet-stream;
 
-        listen ${SSL_NGINX_PORT:-3002} ssl;
-        listen [::]:${SSL_NGINX_PORT:-3002} ssl;
+        listen ${SSL_NGINX_PORT:-443} ssl;
+        listen [::]:${SSL_NGINX_PORT:-443} ssl;
         server_name ${SSL_DOMAIN:-moviepilot};
 
         # SSL证书路径


### PR DESCRIPTION
似乎https的端口之前一直没允许通过环境变量设置。
环境变量命名上参考了其他SSL环境变量，加入了SSL的前缀。
请考虑是否需要加入