### PR TITLE
Add sort type to subscription queries

### DIFF
--- a/app/api/endpoints/subscribe.py
+++ b/app/api/endpoints/subscribe.py
@@ -20,7 +20,7 @@ from app.db.systemconfig_oper import SystemConfigOper
 from app.db.user_oper import get_current_active_user_async
 from app.helper.subscribe import SubscribeHelper
 from app.scheduler import Scheduler
-from app.schemas.types import MediaType, EventType, SystemConfigKey
+from app.schemas.types import MediaType, EventType, SystemConfigKey, SortType
 
 router = APIRouter()
 
@@ -424,6 +424,7 @@ async def popular_subscribes(
         genre_id: Optional[int] = None,
         min_rating: Optional[float] = None,
         max_rating: Optional[float] = None,
+        sort_type: Optional[str] = None,
         _: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
     查询热门订阅
@@ -434,7 +435,8 @@ async def popular_subscribes(
         count=count,
         genre_id=genre_id,
         min_rating=min_rating,
-        max_rating=max_rating
+        max_rating=max_rating,
+        sort_type=sort_type
     )
     if subscribes:
         ret_medias = []
@@ -583,6 +585,7 @@ async def popular_subscribes(
         genre_id: Optional[int] = None,
         min_rating: Optional[float] = None,
         max_rating: Optional[float] = None,
+        sort_type: Optional[str] = None,
         _: schemas.TokenPayload = Depends(verify_token)) -> Any:
     """
     查询分享的订阅
@@ -593,7 +596,8 @@ async def popular_subscribes(
         count=count,
         genre_id=genre_id,
         min_rating=min_rating,
-        max_rating=max_rating
+        max_rating=max_rating,
+        sort_type=sort_type
     )
 
 

--- a/app/helper/subscribe.py
+++ b/app/helper/subscribe.py
@@ -133,7 +133,7 @@ class SubscribeHelper(metaclass=WeakSingleton):
     @cached(region=_shares_cache_region, maxsize=5, ttl=1800, skip_empty=True)
     def get_statistic(self, stype: str, page: Optional[int] = 1, count: Optional[int] = 30,
                       genre_id: Optional[int] = None, min_rating: Optional[float] = None,
-                      max_rating: Optional[float] = None) -> List[dict]:
+                      max_rating: Optional[float] = None, sort_type: Optional[str] = None) -> List[dict]:
         """
         获取订阅统计数据
         """
@@ -154,6 +154,8 @@ class SubscribeHelper(metaclass=WeakSingleton):
             params["min_rating"] = min_rating
         if max_rating is not None:
             params["max_rating"] = max_rating
+        if sort_type is not None:
+            params["sort_type"] = sort_type
 
         res = RequestUtils(proxies=settings.PROXY, timeout=15).get_res(self._sub_statistic, params=params)
 
@@ -162,7 +164,7 @@ class SubscribeHelper(metaclass=WeakSingleton):
     @cached(region=_shares_cache_region, maxsize=5, ttl=1800, skip_empty=True)
     async def async_get_statistic(self, stype: str, page: Optional[int] = 1, count: Optional[int] = 30,
                                   genre_id: Optional[int] = None, min_rating: Optional[float] = None,
-                                  max_rating: Optional[float] = None) -> List[dict]:
+                                  max_rating: Optional[float] = None, sort_type: Optional[str] = None) -> List[dict]:
         """
         异步获取订阅统计数据
         """
@@ -183,6 +185,8 @@ class SubscribeHelper(metaclass=WeakSingleton):
             params["min_rating"] = min_rating
         if max_rating is not None:
             params["max_rating"] = max_rating
+        if sort_type is not None:
+            params["sort_type"] = sort_type
 
         res = await AsyncRequestUtils(proxies=settings.PROXY, timeout=15).get_res(self._sub_statistic, params=params)
 
@@ -384,7 +388,7 @@ class SubscribeHelper(metaclass=WeakSingleton):
     @cached(region=_shares_cache_region, maxsize=1, ttl=1800, skip_empty=True)
     def get_shares(self, name: Optional[str] = None, page: Optional[int] = 1, count: Optional[int] = 30,
                    genre_id: Optional[int] = None, min_rating: Optional[float] = None,
-                   max_rating: Optional[float] = None) -> List[dict]:
+                   max_rating: Optional[float] = None, sort_type: Optional[str] = None) -> List[dict]:
         """
         获取订阅分享数据
         """
@@ -405,6 +409,8 @@ class SubscribeHelper(metaclass=WeakSingleton):
             params["min_rating"] = min_rating
         if max_rating is not None:
             params["max_rating"] = max_rating
+        if sort_type is not None:
+            params["sort_type"] = sort_type
 
         res = RequestUtils(proxies=settings.PROXY, timeout=15).get_res(self._sub_shares, params=params)
 
@@ -413,7 +419,7 @@ class SubscribeHelper(metaclass=WeakSingleton):
     @cached(region=_shares_cache_region, maxsize=1, ttl=1800, skip_empty=True)
     async def async_get_shares(self, name: Optional[str] = None, page: Optional[int] = 1, count: Optional[int] = 30,
                                genre_id: Optional[int] = None, min_rating: Optional[float] = None,
-                               max_rating: Optional[float] = None) -> List[dict]:
+                               max_rating: Optional[float] = None, sort_type: Optional[str] = None) -> List[dict]:
         """
         异步获取订阅分享数据
         """
@@ -434,6 +440,8 @@ class SubscribeHelper(metaclass=WeakSingleton):
             params["min_rating"] = min_rating
         if max_rating is not None:
             params["max_rating"] = max_rating
+        if sort_type is not None:
+            params["sort_type"] = sort_type
 
         res = await AsyncRequestUtils(proxies=settings.PROXY, timeout=15).get_res(self._sub_shares, params=params)
 

--- a/app/schemas/types.py
+++ b/app/schemas/types.py
@@ -9,6 +9,13 @@ class MediaType(Enum):
     UNKNOWN = '未知'
 
 
+# 排序类型枚举
+class SortType(Enum):
+    TIME = "time"  # 按时间排序
+    COUNT = "count"  # 按人数排序
+    RATING = "rating"  # 按评分排序
+
+
 # 种子状态
 class TorrentStatus(Enum):
     TRANSFER = "可转移"


### PR DESCRIPTION
Add `sort_type` parameter to popular and shared subscription APIs and helper methods to support sorting by time, count, or rating.

---
<a href="https://cursor.com/background-agent?bcId=bc-88b1a049-71bc-4942-b31c-bb26546d29ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-88b1a049-71bc-4942-b31c-bb26546d29ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

