### PR TITLE
refactor(plugins): Use pathlib.relative_to for robust plugin path resolution

### DIFF
--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -360,15 +360,14 @@ class PluginManager(metaclass=Singleton):
         try:
             plugins_root = settings.ROOT_PATH / "app" / "plugins"
             # 确保修改的文件在 plugins 目录下
-            if plugins_root not in event_path.parents:
+            if not event_path.is_relative_to(plugins_root):
                 return None
 
-            # 找到插件的根目录
-            plugin_dir = event_path.parent
-            while plugin_dir.parent != plugins_root:
-                plugin_dir = plugin_dir.parent
-                if plugin_dir == plugins_root:  # 防止无限循环
-                    break
+            try:
+                plugin_dir_name = event_path.relative_to(plugins_root).parts[0]
+                plugin_dir = plugins_root / plugin_dir_name
+            except (ValueError, IndexError):
+                return None
 
             init_file = plugin_dir / "__init__.py"
             if not init_file.exists():


### PR DESCRIPTION
### 变更背景 (Background)

在 `PluginManager._get_plugin_id_from_path` 方法中，用于从文件路径确定其所属插件根目录的逻辑，当前是使用一个 `while` 循环来逐级向上追溯父目录。

虽然这个方法能工作，但它存在以下不足：
*   代码较为冗长。
*   在处理深层嵌套的目录时，效率略低。
*   需要额外的代码来处理边缘情况（如防止无限循环）。

### 主要变更 (Changes)

本次提交对该路径解析逻辑进行了现代化重构：

1.  **采用 `pathlib.relative_to`**:
    *   替换了原有的 `while` 循环。
    *   新的实现通过计算文件相对于插件总根目录 (`app/plugins`) 的相对路径，然后直接提取相对路径的第一个部分，来一步到位地确定插件的目录名。

2.  **提升健壮性**:
    *   利用 `try...except` 块来优雅地处理 `relative_to` 可能抛出的 `ValueError`（当文件不在插件目录下时），使得错误处理逻辑更清晰、更可靠。

### 带来的好处 (Benefits)

*   **代码更简洁 (Pythonic)**: 用一行核心代码替代了多行循环，更符合 `pathlib` 的设计哲学。
*   **性能提升**: 路径计算通常比循环查找更快。
*   **可读性与可维护性**: 新的代码逻辑更紧凑，意图更明确，便于未来维护。

这是一个纯粹的代码质量改进，不影响任何现有功能。