### PR TITLE
修复使用 imdbid 未匹配到豆瓣信息时回退到使用名称匹配豆瓣信息失败的问题

### DIFF
--- a/app/modules/douban/__init__.py
+++ b/app/modules/douban/__init__.py
@@ -987,8 +987,9 @@ class DoubanModule(_ModuleBase):
             if doubanid and not str(doubanid).isdigit():
                 doubanid = re.search(r"\d+", doubanid).group(0)
                 result["id"] = doubanid
-            logger.info(f"{imdbid} 查询到豆瓣信息：{result.get('title')}")
-            return result
+                logger.info(f"{imdbid} 查询到豆瓣信息：{result.get('title')}")
+                return result
+            return None
         return None
 
     @staticmethod


### PR DESCRIPTION
修复 [match_doubaninfo](https://github.com/jxxghp/MoviePilot/blob/v2/app/modules/douban/__init__.py#L1062) 方法中使用 imdbid 匹配豆瓣信息返回结果不为空且不包含 id 时跳过了使用名称匹配豆瓣信息的问题。