### PR TITLE
feat(cache): 引入 fresh 和 async_fresh 以控制缓存行为

### DIFF
--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -11,7 +11,7 @@ from fastapi.concurrency import run_in_threadpool
 from qbittorrentapi import TorrentFilesList
 from transmission_rpc import File
 
-from app.core.cache import FileCache, AsyncFileCache
+from app.core.cache import FileCache, AsyncFileCache, fresh, async_fresh
 from app.core.config import settings
 from app.core.context import Context, MediaInfo, TorrentInfo
 from app.core.event import EventManager
@@ -358,9 +358,10 @@ class ChainBase(metaclass=ABCMeta):
         if tmdbid:
             doubanid = None
             bangumiid = None
-        return self.run_module("recognize_media", meta=meta, mtype=mtype,
-                               tmdbid=tmdbid, doubanid=doubanid, bangumiid=bangumiid,
-                               episode_group=episode_group, cache=cache)
+        with fresh(not cache):
+            return self.run_module("recognize_media", meta=meta, mtype=mtype,
+                                tmdbid=tmdbid, doubanid=doubanid, bangumiid=bangumiid,
+                                episode_group=episode_group, cache=cache)
 
     async def async_recognize_media(self, meta: MetaBase = None,
                                     mtype: Optional[MediaType] = None,
@@ -391,9 +392,10 @@ class ChainBase(metaclass=ABCMeta):
         if tmdbid:
             doubanid = None
             bangumiid = None
-        return await self.async_run_module("async_recognize_media", meta=meta, mtype=mtype,
-                                           tmdbid=tmdbid, doubanid=doubanid, bangumiid=bangumiid,
-                                           episode_group=episode_group, cache=cache)
+        async with async_fresh(not cache):
+            return await self.async_run_module("async_recognize_media", meta=meta, mtype=mtype,
+                                            tmdbid=tmdbid, doubanid=doubanid, bangumiid=bangumiid,
+                                            episode_group=episode_group, cache=cache)
 
     def match_doubaninfo(self, name: str, imdbid: Optional[str] = None,
                          mtype: Optional[MediaType] = None, year: Optional[str] = None, season: Optional[int] = None,

--- a/app/chain/download.py
+++ b/app/chain/download.py
@@ -290,7 +290,7 @@ class DownloadChain(ChainBase):
             # 登记下载记录
             downloadhis = DownloadHistoryOper()
             downloadhis.add(
-                path=str(download_path),
+                path=download_path.as_posix(),
                 type=_media.type.value,
                 title=_media.title,
                 year=_media.year,
@@ -331,8 +331,8 @@ class DownloadChain(ChainBase):
                 files_to_add.append({
                     "download_hash": _hash,
                     "downloader": _downloader,
-                    "fullpath": str(_save_path / file),
-                    "savepath": str(_save_path),
+                    "fullpath": (_save_path / file).as_posix(),
+                    "savepath": _save_path.as_posix(),
                     "filepath": file,
                     "torrentname": _meta.org_string,
                 })

--- a/app/modules/themoviedb/tmdbv3api/tmdb.py
+++ b/app/modules/themoviedb/tmdbv3api/tmdb.py
@@ -18,14 +18,13 @@ logger = logging.getLogger(__name__)
 
 class TMDb(object):
 
-    def __init__(self, obj_cached=True, session=None, language=None):
+    def __init__(self, session=None, language=None):
         self._api_key = settings.TMDB_API_KEY
         self._language = language or settings.TMDB_LOCALE or "en-US"
         self._session_id = None
         self._session = session
         self._wait_on_rate_limit = True
         self._debug_enabled = False
-        self._cache_enabled = obj_cached
         self._proxies = settings.PROXY
         self._domain = settings.TMDB_API_DOMAIN
         self._page = None
@@ -41,7 +40,6 @@ class TMDb(object):
         self._remaining = 40
         self._reset = None
         self._timeout = 15
-        self.obj_cached = obj_cached
 
         self.__clear_async_cache__ = False
 
@@ -118,14 +116,6 @@ class TMDb(object):
     @debug.setter
     def debug(self, debug):
         self._debug_enabled = bool(debug)
-
-    @property
-    def cache(self):
-        return self._cache_enabled
-
-    @cache.setter
-    def cache(self, cache):
-        self._cache_enabled = bool(cache)
 
     @cached(maxsize=settings.CONF.tmdb, ttl=settings.CONF.meta, skip_none=True)
     def cached_request(self, method, url, data, json,
@@ -224,8 +214,9 @@ class TMDb(object):
         self._validate_api_key()
         url = self._build_url(action, params)
 
-        if self.cache and self.obj_cached and call_cached and method != "POST":
-            req = self.cached_request(method, url, data, json)
+        if call_cached and method != "POST":
+            req = self.cached_request(method, url, data, json,
+                                      _ts=datetime.strftime(datetime.now(), '%Y%m%d'))
         else:
             req = self.request(method, url, data, json)
 
@@ -253,8 +244,9 @@ class TMDb(object):
         self._validate_api_key()
         url = self._build_url(action, params)
 
-        if self.cache and self.obj_cached and call_cached and method != "POST":
-            req = await self.async_cached_request(method, url, data, json)
+        if call_cached and method != "POST":
+            req = await self.async_cached_request(method, url, data, json,
+                                                  _ts=datetime.strftime(datetime.now(), '%Y%m%d'))
         else:
             req = await self.async_request(method, url, data, json)
 


### PR DESCRIPTION
- 新增 `fresh` 和 `async_fresh` 用于在同步和异步函数中 临时禁用缓存。
- 通过 `_fresh` 这一 contextvars 变量实现上下文感知的 缓存刷新机制
- 修改了 `cached` 装饰器逻辑，在 `is_fresh()` 为 True 时跳过缓存读取。

- 更新了 bangumi 模块接口调用方式，移除冗余的时间戳参数传递，统一由缓存装饰器控制缓存策略。

- 修复 download 模块中路径处理问题，使用 `Path.as_posix()` 确保跨平台兼容性。