### PR TITLE
fix:增强识别电影、电视剧标题里中文

### DIFF
--- a/app/core/meta/metavideo.py
+++ b/app/core/meta/metavideo.py
@@ -230,6 +230,12 @@ class MetaVideo(MetaBase):
                     self.en_name = "%s %s" % (self.en_name, self._unknown_name_str)
                 self._last_token_type = "enname"
             self._unknown_name_str = ""
+        # 允许在特定条件下继续处理中文
+        # 保存原始的_stop_name_flag状态
+        original_stop_flag = self._stop_name_flag
+        if StringUtils.is_chinese(token) and not self._stop_cnname_flag:
+            # 重置标志位以允许中文识别
+            self._stop_name_flag = False
         if self._stop_name_flag:
             return
         if token.upper() == "AKA":
@@ -250,6 +256,8 @@ class MetaVideo(MetaBase):
                             and not re.search("%s" % self._name_se_words, token, flags=re.IGNORECASE)):
                     self.cn_name = "%s %s" % (self.cn_name, token)
                 self._stop_cnname_flag = True
+            # 处理完中文后，恢复原始的_stop_name_flag状态
+            self._stop_name_flag = original_stop_flag
         else:
             is_roman_digit = re.search(self._roman_numerals, token)
             # 阿拉伯数字或者罗马数字


### PR DESCRIPTION
目前识别到标题中的季信息后就停止识别标题信息。如果中文标题在季信息后则无法识别，目前的改动在不影响原有逻辑的情况下，针对这种情况进行了处理，以为增加后续tmbd识别正确率。