### PR TITLE
fix(transfer): 修复部分情况下无法正确统计已完成任务总大小的问题

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -33,6 +33,7 @@ from app.schemas.types import TorrentStatus, EventType, MediaType, ProgressKey, 
     SystemConfigKey, ChainEventType, ContentType
 from app.utils.singleton import Singleton
 from app.utils.string import StringUtils
+from app.utils.system import SystemUtils
 
 downloader_lock = threading.Lock()
 job_lock = threading.Lock()
@@ -329,8 +330,12 @@ class JobManager:
             # 计算状态为完成的任务数
             if __mediaid__ not in self._job_view:
                 return 0
-            return sum([task.fileitem.size for task in self._job_view[__mediaid__].tasks if
-                        task.state == "completed" and task.fileitem.size is not None])
+            return sum([
+                task.fileitem.size if task.fileitem.size is not None
+                else (SystemUtils.get_directory_size(Path(task.fileitem.path)) if task.fileitem.storage == "local" else 0)
+                for task in self._job_view[__mediaid__].tasks
+                if task.state == "completed"
+            ])
 
     def total(self) -> int:
         """

--- a/app/core/cache.py
+++ b/app/core/cache.py
@@ -1016,7 +1016,7 @@ class AsyncFileBackend(AsyncCacheBackend):
 
 
 @contextmanager
-def fresh(fresh: bool = False):
+def fresh(fresh: bool = True):
     """
     是否获取新数据（不使用缓存的值）
 
@@ -1031,7 +1031,7 @@ def fresh(fresh: bool = False):
         _fresh.reset(token)
 
 @asynccontextmanager
-async def async_fresh(fresh: bool = False):
+async def async_fresh(fresh: bool = True):
     """
     是否获取新数据（不使用缓存的值）
 

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -150,14 +150,11 @@ class TransHandler:
                     return self.result.copy()
 
                 logger.info(f"文件夹 {fileitem.path} 整理成功")
-                # 计算目录下所有文件大小
-                total_size = sum(file.stat().st_size for file in Path(fileitem.path).rglob('*') if file.is_file())
                 # 返回整理后的路径
                 self.__set_result(success=True,
                                   fileitem=fileitem,
                                   target_item=new_diritem,
                                   target_diritem=new_diritem,
-                                  total_size=total_size,
                                   need_scrape=need_scrape,
                                   need_notify=need_notify,
                                   transfer_type=transfer_type)


### PR DESCRIPTION
- get_directory_size 方法支持传入字符串或 Path 类型路径
- 使用 os.scandir 递归遍历提升性能

- 在 transfer 模块中引入 SystemUtils 工具类
- 当文件大小为空且为本地存储则尝试通过目录结构计算实际大小

- 修改 fresh 和 async_fresh 默认参数为 True

- 删除 TransHandler 中对整理后目录进行全量文件大小统计的操作 (对结构复杂的处理较为费时)