### PR TITLE
feat(endpoints): /download/add allow tmdbid/doubanid/bangumiid

### DIFF
--- a/app/api/endpoints/download.py
+++ b/app/api/endpoints/download.py
@@ -64,6 +64,9 @@ def download(
 @router.post("/add", summary="添加下载（不含媒体信息）", response_model=schemas.Response)
 def add(
         torrent_in: schemas.TorrentInfo,
+        tmdbid: Annotated[int | None, Body()] = None,
+        doubanid: Annotated[str | None, Body()] = None,
+        bangumiid: Annotated[int | None, Body()] = None,
         downloader: Annotated[str | None, Body()] = None,
         save_path: Annotated[str | None, Body()] = None,
         current_user: User = Depends(get_current_active_user)) -> Any:
@@ -73,7 +76,7 @@ def add(
     # 元数据
     metainfo = MetaInfo(title=torrent_in.title, subtitle=torrent_in.description)
     # 媒体信息
-    mediainfo = MediaChain().recognize_media(meta=metainfo)
+    mediainfo = MediaChain().recognize_media(meta=metainfo, tmdbid=tmdbid, doubanid=doubanid, bangumiid=bangumiid)
     if not mediainfo:
         return schemas.Response(success=False, message="无法识别媒体信息")
     # 种子信息


### PR DESCRIPTION
现在下载一般调用/download/add接口，然后会根据标题/副标题去tmdb/douban/bangumi搜索，但是有些资源的标题不一定能搜对或者搜到，实际上它在tmdb等网站是能搜到的。所以在该接口上加入可以让用户直接传入tmdbid/doubanid/bangumiid的选项，使得资源能够正常下载而非显示无法识别媒体信息