### PR TITLE
fix(event): __invoke_plugin_method_async() 中 __handle_event_error() 参数和签名不匹配

### DIFF
--- a/app/core/event.py
+++ b/app/core/event.py
@@ -586,7 +586,8 @@ class EventManager(metaclass=Singleton):
                 # 插件同步函数在异步环境中运行，避免阻塞
                 await run_in_threadpool(method, event)
         except Exception as e:
-            self.__handle_event_error(event=event, handler=handler, e=e, module_name=plugin.name)
+            self.__handle_event_error(event=event, module_name=plugin.name,
+                                      class_name=class_name, method_name=method_name, e=e)
 
     async def __invoke_module_method_async(self, handler: Any, class_name: str, method_name: str, event: Event):
         """


### PR DESCRIPTION
修改参数与同步版本的 `__invoke_handler_by_type_sync()` 传递的参数保持一致