### PR TITLE
feat: show episode storyline info when scraping episodes

### DIFF
--- a/app/chain/media.py
+++ b/app/chain/media.py
@@ -25,6 +25,9 @@ scraping_lock = Lock()
 current_umask = os.umask(0)
 os.umask(current_umask)
 
+# 集剧情简介显示的最大长度
+EPISODE_SYNOPSIS_MAX_LENGTH = 200
+
 
 class MediaChain(ChainBase):
     """
@@ -650,21 +653,18 @@ class MediaChain(ChainBase):
                                                season=file_meta.begin_season,
                                                episode_group=file_mediainfo.episode_group)
                     if episodes:
-                        for ep in episodes:
-                            # 处理不同的返回类型：dict或TmdbEpisode对象
-                            if isinstance(ep, dict):
-                                ep_num = ep.get("episode_number")
-                                if ep_num == file_meta.begin_episode:
-                                    episode_synopsis = ep.get("overview")
-                                    episode_title = ep.get("name")
-                                    break
-                            else:
-                                # TmdbEpisode对象（Pydantic BaseModel）
-                                ep_num = getattr(ep, 'episode_number', None)
-                                if ep_num == file_meta.begin_episode:
-                                    episode_synopsis = getattr(ep, 'overview', None)
-                                    episode_title = getattr(ep, 'name', None)
-                                    break
+                        # 使用next()和生成器表达式查找目标集，支持dict和TmdbEpisode对象
+                        target_ep = next(
+                            (ep for ep in episodes if (
+                                ep.get("episode_number") if isinstance(ep, dict) 
+                                else getattr(ep, "episode_number", None)
+                            ) == file_meta.begin_episode),
+                            None
+                        )
+                        if target_ep:
+                            is_dict = isinstance(target_ep, dict)
+                            episode_synopsis = target_ep.get("overview") if is_dict else getattr(target_ep, "overview", None)
+                            episode_title = target_ep.get("name") if is_dict else getattr(target_ep, "name", None)
                     
                     # 显示集信息
                     if episode_title or episode_synopsis:
@@ -674,7 +674,10 @@ class MediaChain(ChainBase):
                         logger.info(episode_info_msg)
                         if episode_synopsis:
                             # 限制显示长度，避免日志过长
-                            synopsis_display = episode_synopsis[:200] + "..." if len(episode_synopsis) > 200 else episode_synopsis
+                            if len(episode_synopsis) > EPISODE_SYNOPSIS_MAX_LENGTH:
+                                synopsis_display = episode_synopsis[:EPISODE_SYNOPSIS_MAX_LENGTH] + "..."
+                            else:
+                                synopsis_display = episode_synopsis
                             logger.info(f"剧情简介：{synopsis_display}")
                 except Exception as e:
                     logger.debug(f"获取集信息失败：{str(e)}")

--- a/app/chain/media.py
+++ b/app/chain/media.py
@@ -640,6 +640,45 @@ class MediaChain(ChainBase):
                 if not file_mediainfo:
                     logger.warn(f"{filepath.name} 无法识别文件媒体信息！")
                     return
+                
+                # 获取并显示集信息（包括剧情简介）
+                try:
+                    episode_synopsis = None
+                    episode_title = None
+                    # 使用tmdb_episodes方法获取集信息
+                    episodes = self.run_module("tmdb_episodes", tmdbid=file_mediainfo.tmdb_id,
+                                               season=file_meta.begin_season,
+                                               episode_group=file_mediainfo.episode_group)
+                    if episodes:
+                        for ep in episodes:
+                            # 处理不同的返回类型：dict或TmdbEpisode对象
+                            if isinstance(ep, dict):
+                                ep_num = ep.get("episode_number")
+                                if ep_num == file_meta.begin_episode:
+                                    episode_synopsis = ep.get("overview")
+                                    episode_title = ep.get("name")
+                                    break
+                            else:
+                                # TmdbEpisode对象（Pydantic BaseModel）
+                                ep_num = getattr(ep, 'episode_number', None)
+                                if ep_num == file_meta.begin_episode:
+                                    episode_synopsis = getattr(ep, 'overview', None)
+                                    episode_title = getattr(ep, 'name', None)
+                                    break
+                    
+                    # 显示集信息
+                    if episode_title or episode_synopsis:
+                        episode_info_msg = f"第 {file_meta.begin_season} 季第 {file_meta.begin_episode} 集"
+                        if episode_title:
+                            episode_info_msg += f" - {episode_title}"
+                        logger.info(episode_info_msg)
+                        if episode_synopsis:
+                            # 限制显示长度，避免日志过长
+                            synopsis_display = episode_synopsis[:200] + "..." if len(episode_synopsis) > 200 else episode_synopsis
+                            logger.info(f"剧情简介：{synopsis_display}")
+                except Exception as e:
+                    logger.debug(f"获取集信息失败：{str(e)}")
+                
                 # 检查集NFO开关
                 if scraping_switchs.get('episode_nfo', True):
                     # 是否已存在


### PR DESCRIPTION
## Feature: Display Episode Plot Synopsis During Scraping #5088 

### Description
Displays episode plot synopsis while scraping TV episode files.

### Changes
- Modified `app/chain/media.py`: Added episode synopsis retrieval and logging in `scrape_metadata()` for episode files.

### Details
- Fetches episode details (title and synopsis) from TMDB when scraping episode files.
- Logs episode information:
  - Season and episode number (e.g., "第 1 季第 5 集")
  - Episode title (if available)
  - Episode synopsis/plot (truncated to 200 characters)
- Supports both regular TV shows and episode groups.
- Includes error handling to avoid breaking scraping if episode info retrieval fails.

### Example Output
```
第 1 季第 5 集 - Episode Title
剧情简介：This is the episode synopsis...
```