### PR TITLE
fix: 修复Docker编译时版本不兼容导致的报错问题

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,8 +65,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 COPY requirements.in requirements.in
 RUN python3 -m venv ${VENV_PATH} \
-    && pip install --upgrade pip \
-    && pip install Cython pip-tools \
+    && pip install --upgrade "pip<25.0" \
+    && pip install "Cython" "pip-tools<7.5" \
     && pip-compile requirements.in \
     && pip install -r requirements.txt
 


### PR DESCRIPTION
参考三楼回复：
https://stackoverflow.com/questions/76717537/valueerror-requirement-object-has-no-field-use-pep517-when-installing-pytho


已验证完成修复：
https://github.com/jiongjiongJOJO/MoviePilot/actions/runs/19261627749