### PR TITLE
fix(tests): 修正 restype, 测试用例不使用识别词

### DIFF
--- a/tests/cases/meta.py
+++ b/tests/cases/meta.py
@@ -153,7 +153,7 @@ meta_cases = [{
         "part": "",
         "season": "S01",
         "episode": "E02",
-        "restype": "B-Global WEB-DL",
+        "restype": "WEB-DL",
         "pix": "1080p",
         "video_codec": "x264",
         "audio_codec": "AAC"
@@ -569,7 +569,7 @@ meta_cases = [{
         "part": "",
         "season": "S02",
         "episode": "E05",
-        "restype": "Crunchyroll WEB-DL",
+        "restype": "WEB-DL",
         "pix": "1080p",
         "video_codec": "x264",
         "audio_codec": "AAC"
@@ -649,7 +649,7 @@ meta_cases = [{
         "part": "",
         "season": "",
         "episode": "",
-        "restype": "Netflix WEBRip",
+        "restype": "WEBRip",
         "pix": "1080p",
         "video_codec": "H264",
         "audio_codec": "DDP 5.1"
@@ -681,7 +681,7 @@ meta_cases = [{
         "part": "",
         "season": "S01",
         "episode": "E16",
-        "restype": "KKTV WEB-DL",
+        "restype": "WEB-DL",
         "pix": "1080p",
         "video_codec": "x264",
         "audio_codec": "AAC"
@@ -921,7 +921,7 @@ meta_cases = [{
         "part": "",
         "season": "S06",
         "episode": "E06",
-        "restype": "Max WEBRip",
+        "restype": "WEBRip",
         "pix": "1080p",
         "video_codec": "x264",
         "audio_codec": "DD 5.1"
@@ -937,7 +937,7 @@ meta_cases = [{
         "part": "",
         "season": "S06",
         "episode": "E05",
-        "restype": "Max WEBRip",
+        "restype": "WEBRip",
         "pix": "1080p",
         "video_codec": "x264",
         "audio_codec": "DD 5.1"
@@ -969,7 +969,7 @@ meta_cases = [{
         "part": "",
         "season": "S02",
         "episode": "",
-        "restype": "Netflix WEB-DL",
+        "restype": "WEB-DL",
         "pix": "2160p",
         "video_codec": "H265",
         "audio_codec": "DDP 5.1 Atmos"

--- a/tests/test_metainfo.py
+++ b/tests/test_metainfo.py
@@ -18,7 +18,7 @@ class MetaInfoTest(TestCase):
             if info.get("path"):
                 meta_info = MetaInfoPath(path=Path(info.get("path")))
             else:
-                meta_info = MetaInfo(title=info.get("title"), subtitle=info.get("subtitle"))
+                meta_info = MetaInfo(title=info.get("title"), subtitle=info.get("subtitle"), custom_words=["#"])
             target = {
                 "type": meta_info.type.value,
                 "cn_name": meta_info.cn_name or "",


### PR DESCRIPTION
ref: 5ff7da0

<details>
<summary>修正前输出</summary>

```
======================================================================
FAIL: test_metainfo (tests.test_metainfo.MetaInfoTest.test_metainfo)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/MoviePilot/tests/test_metainfo.py", line 40, in test_metainfo
    self.assertEqual(target, info.get("target"))
AssertionError: {'typ[171 chars]e': 'WEB-DL', 'pix': '1080p', 'video_codec': '[23 chars]AAC'} != {'typ[171 chars]e': 'B-Global WEB-DL', 'pix': '1080p', 'video_[32 chars]AAC'}
  {'audio_codec': 'AAC',
   'cn_name': '',
   'en_name': 'Noumin Kanren No Skill Bakka Agetetara Naze Ka Tsuyoku Natta',
   'episode': 'E02',
   'part': '',
   'pix': '1080p',
-  'restype': 'WEB-DL',
+  'restype': 'B-Global WEB-DL',
?              +++++++++

   'season': 'S01',
   'type': '电视剧',
   'video_codec': 'x264',
   'year': '2022'}

----------------------------------------------------------------------
Ran 3 tests in 0.095s

FAILED (failures=1)
```

</details>

<details>
<summary>修正后输出</summary>

```
...
----------------------------------------------------------------------
Ran 3 tests in 0.171s

OK
```

</details>