### PR TITLE
Handle plugin initialization and sync errors

### DIFF
--- a/app/agent/tools/impl/scrape_metadata.py
+++ b/app/agent/tools/impl/scrape_metadata.py
@@ -1,5 +1,6 @@
 """刮削媒体元数据工具"""
 
+import asyncio
 import json
 from pathlib import Path
 from typing import Optional, Type
@@ -8,7 +9,6 @@ from pydantic import BaseModel, Field
 
 from app.agent.tools.base import MoviePilotTool
 from app.chain.media import MediaChain
-from app.core.config import GlobalVar
 from app.core.metainfo import MetaInfoPath
 from app.log import logger
 from app.schemas import FileItem
@@ -83,7 +83,8 @@ class ScrapeMetadataTool(MoviePilotTool):
                 }, ensure_ascii=False)
             
             # 在线程池中执行同步的刮削操作
-            await GlobalVar.CURRENT_EVENT_LOOP.run_in_executor(
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(
                 None,
                 lambda: media_chain.scrape_metadata(
                     fileitem=fileitem,

--- a/app/agent/tools/impl/search_subscribe.py
+++ b/app/agent/tools/impl/search_subscribe.py
@@ -1,5 +1,6 @@
 """搜索订阅缺失剧集工具"""
 
+import asyncio
 import json
 from typing import Optional, Type, List
 
@@ -7,7 +8,6 @@ from pydantic import BaseModel, Field
 
 from app.agent.tools.base import MoviePilotTool
 from app.chain.subscribe import SubscribeChain
-from app.core.config import GlobalVar
 from app.db.subscribe_oper import SubscribeOper
 from app.log import logger
 
@@ -85,7 +85,8 @@ class SearchSubscribeTool(MoviePilotTool):
             
             # 在线程池中执行同步的搜索操作
             # 当 sid 有值时，state 参数会被忽略，直接处理该订阅
-            await GlobalVar.CURRENT_EVENT_LOOP.run_in_executor(
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(
                 None,
                 lambda: subscribe_chain.search(
                     sid=subscribe_id,

--- a/app/startup/plugins_initializer.py
+++ b/app/startup/plugins_initializer.py
@@ -1,4 +1,5 @@
-from app.core.config import GlobalVar
+import asyncio
+
 from app.core.plugin import PluginManager
 from app.log import logger
 
@@ -8,7 +9,9 @@ async def sync_plugins() -> bool:
     初始化安装插件，并动态注册后台任务及API
     """
     try:
-        loop = GlobalVar.CURRENT_EVENT_LOOP
+        # 使用当前正在运行的事件循环，而不是全局变量中的事件循环
+        # 这样可以避免事件循环不匹配的问题
+        loop = asyncio.get_running_loop()
         plugin_manager = PluginManager()
 
         sync_result = await execute_task(loop, plugin_manager.sync, "插件同步到本地")


### PR DESCRIPTION
Replace `GlobalVar.CURRENT_EVENT_LOOP` with `asyncio.get_running_loop()` to fix event loop mismatch errors.

The `GlobalVar.CURRENT_EVENT_LOOP` was initialized at module import, potentially differing from the event loop used by FastAPI's runtime or `lifespan` functions. This caused `Task got Future attached to a different loop` errors when tasks were created or executed. Using `asyncio.get_running_loop()` ensures the correct, currently active event loop is always used.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa74bc77-8284-4a5e-9480-695ce49ab466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aa74bc77-8284-4a5e-9480-695ce49ab466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

