### PR TITLE
Handle ai agent message processing error

### DIFF
--- a/app/chain/message.py
+++ b/app/chain/message.py
@@ -1,3 +1,4 @@
+import asyncio
 import re
 import time
 from datetime import datetime, timedelta
@@ -883,11 +884,12 @@ class MessageChain(ChainBase):
         # 如果有会话ID，同时清除智能体的会话记忆
         if session_id:
             try:
-                global_vars.loop.run_until_complete(
+                asyncio.run_coroutine_threadsafe(
                     agent_manager.clear_session(
                         session_id=session_id,
                         user_id=str(userid)
-                    )
+                    ),
+                    global_vars.loop
                 )
             except Exception as e:
                 logger.warning(f"清除智能体会话记忆失败: {e}")
@@ -950,7 +952,7 @@ class MessageChain(ChainBase):
             session_id = self._get_or_create_session_id(userid)
 
             # 在事件循环中处理
-            global_vars.loop.run_until_complete(
+            asyncio.run_coroutine_threadsafe(
                 agent_manager.process_message(
                     session_id=session_id,
                     user_id=str(userid),
@@ -958,7 +960,8 @@ class MessageChain(ChainBase):
                     channel=channel.value if channel else None,
                     source=source,
                     username=username
-                )
+                ),
+                global_vars.loop
             )
 
         except Exception as e:


### PR DESCRIPTION
Fix "This event loop is already running" error by replacing `run_until_complete()` with `asyncio.run_coroutine_threadsafe()`.

`run_until_complete()` cannot be called on an event loop that is already running, leading to the "This event loop is already running" error. `asyncio.run_coroutine_threadsafe()` is used to safely schedule coroutines in an existing event loop, aligning with other parts of the application.

---
<a href="https://cursor.com/background-agent?bcId=bc-c43fed42-19cf-4455-96a4-9f22b59ed1a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c43fed42-19cf-4455-96a4-9f22b59ed1a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

