### PR TITLE
Handle subscription refresh failure: missing name

### DIFF
--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -709,6 +709,9 @@ class Scheduler(metaclass=SingletonClass):
             # 将正在运行的任务提取出来 (保障一次性任务正常显示)
             for job_id, service in self._jobs.items():
                 name = service.get("name")
+                # 确保 name 是字符串类型
+                if name and not isinstance(name, str):
+                    name = str(name)
                 provider_name = service.get("provider_name")
                 if service.get("running") and name and provider_name:
                     if job_id not in added:
@@ -733,9 +736,14 @@ class Scheduler(metaclass=SingletonClass):
                 status = "正在运行" if service.get("running") else "等待"
                 # 下次运行时间
                 next_run = TimerUtils.time_difference(job.next_run_time)
+                # 确保 name 是字符串类型
+                job_name = job.name
+                if not isinstance(job_name, str):
+                    # 如果 name 不是字符串，尝试转换为字符串或使用 service 中的 name
+                    job_name = str(job_name) if job_name else service.get("name", "")
                 schedulers.append(schemas.ScheduleInfo(
                     id=job_id,
-                    name=job.name,
+                    name=job_name,
                     provider=service.get("provider_name", "[系统]"),
                     status=status,
                     next_run=next_run


### PR DESCRIPTION
Ensure scheduler job names are always strings to prevent `AttributeError` when listing schedules.

The error `'SubscribeAssistant' object has no attribute 'name'` occurred because `job.name` or `service.get("name")` sometimes returned an object instead of a string, causing issues when the code expected a string. This PR adds explicit type checking and conversion to string to resolve this.

---
<a href="https://cursor.com/background-agent?bcId=bc-2264d8b4-cd8b-47d8-aae8-48354dfa48cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2264d8b4-cd8b-47d8-aae8-48354dfa48cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

