### PR TITLE
add hard-link support for smb

### DIFF
--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -418,6 +418,9 @@ class TransHandler:
                         return None, f"{fileitem.path} {fileitem.storage} 下载失败"
             elif fileitem.storage == target_storage:
                 # 同一网盘
+                if not source_oper.is_support_transtype(transfer_type):
+                    return None, f"存储 {fileitem.storage} 不支持 {transfer_type} 整理方式"
+
                 if transfer_type == "copy":
                     # 复制文件到新目录
                     target_fileitem = target_oper.get_folder(target_file.parent)
@@ -438,6 +441,11 @@ class TransHandler:
                             return None, f"【{target_storage}】{fileitem.path} 移动文件失败"
                     else:
                         return None, f"【{target_storage}】{target_file.parent} 目录获取失败"
+                elif transfer_type == "link":
+                    if source_oper.link(fileitem, target_file):
+                        return target_oper.get_item(target_file), ""
+                    else:
+                        return None, f"【{target_storage}】{fileitem.path} 创建硬链接失败"
                 else:
                     return None, f"不支持的整理方式：{transfer_type}"
 


### PR DESCRIPTION
fix: #5191

## Note
samba supports hard link by default unless samba server explicitly set `unix extensions = no` https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#UNIXEXTENSIONS

## What about soft-link?
symlink(soft link) is not supported by samba server due to security issue. except for following two exceptions:
1. Windows symlink (Only works on windows with admin users, `FSCTL_SET_REPARSE_POINT`)
2. [Minshall+French symlinks](https://wiki.samba.org/index.php/UNIX_Extensions#Minshall+French_symlinks)
But they are not suitable for our cases.
<img width="447" height="875" alt="image" src="https://github.com/user-attachments/assets/b278ceae-a1c8-4fcb-919e-68942cb47d19" />

<img width="1362" height="227" alt="image" src="https://github.com/user-attachments/assets/ed2f9374-9d02-4d22-9824-17e0bb2f4cec" />
