### PR TITLE
fix: support non-local filesystem as default dir and subtitle target

### DIFF
--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -707,17 +707,19 @@ class ChainBase(metaclass=ABCMeta):
                                cookie=cookie, episodes=episodes, category=category, label=label,
                                downloader=downloader)
 
-    def download_added(self, context: Context, download_dir: Path, torrent_content: Union[str, bytes] = None) -> None:
+    def download_added(self, context: Context, download_dir: Path, storage: str, torrent_content: Union[str, bytes] = None) -> None:
         """
         添加下载任务成功后，从站点下载字幕，保存到下载目录
         :param context:  上下文，包括识别信息、媒体信息、种子信息
         :param download_dir:  下载目录
+        :param storage:  存储类型
         :param torrent_content:  种子内容，如果有则直接使用该内容，否则从context中获取种子文件路径
         :return: None，该方法可被多个模块同时处理
         """
         return self.run_module("download_added", context=context,
                                torrent_content=torrent_content,
-                               download_dir=download_dir)
+                               download_dir=download_dir,
+                               storage=storage)
 
     def list_torrents(self, status: TorrentStatus = None,
                       hashs: Union[list, str] = None,

--- a/app/chain/download.py
+++ b/app/chain/download.py
@@ -239,11 +239,11 @@ class DownloadChain(ChainBase):
             download_dir = Path(save_path)
             # Check if the download_dir matches any configured dirs
             dir_info = DirectoryHelper().get_dir(dest_path=download_dir)
-            storage = dir_info.library_storage if dir_info else storage
+            storage = dir_info.storage if dir_info else storage
         else:
             # 根据媒体信息查询下载目录配置
             dir_info = DirectoryHelper().get_dir(_media, include_unsorted=True)
-            storage = dir_info.library_storage if dir_info else storage
+            storage = dir_info.storage if dir_info else storage
             # 拼装子目录
             if dir_info:
                 # 一级目录

--- a/app/chain/download.py
+++ b/app/chain/download.py
@@ -232,13 +232,18 @@ class DownloadChain(ChainBase):
         # 获取种子文件的文件夹名和文件清单
         _folder_name, _file_list = TorrentHelper().get_fileinfo_from_torrent_content(torrent_content)
 
+        storage = 'local'
         # 下载目录
         if save_path:
             # 下载目录使用自定义的
             download_dir = Path(save_path)
+            # Check if the download_dir matches any configured dirs
+            dir_info = DirectoryHelper().get_dir(dest_path=download_dir)
+            storage = dir_info.library_storage if dir_info else storage
         else:
             # 根据媒体信息查询下载目录配置
-            dir_info = DirectoryHelper().get_dir(_media, storage="local", include_unsorted=True)
+            dir_info = DirectoryHelper().get_dir(_media, include_unsorted=True)
+            storage = dir_info.library_storage if dir_info else storage
             # 拼装子目录
             if dir_info:
                 # 一级目录
@@ -358,7 +363,7 @@ class DownloadChain(ChainBase):
                 username=username,
             )
             # 下载成功后处理
-            self.download_added(context=context, download_dir=download_dir, torrent_content=torrent_content)
+            self.download_added(context=context, download_dir=download_dir, storage=storage, torrent_content=torrent_content)
             # 广播事件
             self.eventmanager.send_event(EventType.DownloadAdded, {
                 "hash": _hash,

--- a/app/modules/subtitle/__init__.py
+++ b/app/modules/subtitle/__init__.py
@@ -101,10 +101,15 @@ class SubtitleModule(_ModuleBase):
             time.sleep(1)
         # 目录仍然不存在，且有文件夹名，则创建目录
         if not working_dir_item and folder_name:
-            working_dir_item = storageChain.create_folder(
-                storageChain.get_file_item(storage, download_dir), 
-                folder_name
-            )
+            parent_dir_item = storageChain.get_file_item(storage, download_dir)
+            if parent_dir_item:
+                working_dir_item = storageChain.create_folder(
+                    parent_dir_item,
+                    folder_name
+                )
+            else:
+                logger.error(f"下载根目录不存在，无法创建字幕文件夹：{download_dir}")
+                return
         if not working_dir_item:
             logger.error(f"下载目录不存在，无法保存字幕：{download_dir / folder_name}")
             return

--- a/app/modules/subtitle/__init__.py
+++ b/app/modules/subtitle/__init__.py
@@ -5,11 +5,13 @@ from typing import Tuple, Union
 
 from lxml import etree
 
+from app.chain.storage import StorageChain
 from app.core.config import settings
 from app.core.context import Context
 from app.helper.torrent import TorrentHelper
 from app.log import logger
 from app.modules import _ModuleBase
+from app.schemas.file import FileItem
 from app.schemas.types import ModuleType, OtherModulesType
 from app.utils.http import RequestUtils
 from app.utils.string import StringUtils
@@ -63,11 +65,12 @@ class SubtitleModule(_ModuleBase):
     def test(self):
         pass
 
-    def download_added(self, context: Context, download_dir: Path, torrent_content: Union[str, bytes] = None):
+    def download_added(self, context: Context, download_dir: Path, storage: str, torrent_content: Union[str, bytes] = None):
         """
         添加下载任务成功后，从站点下载字幕，保存到下载目录
         :param context:  上下文，包括识别信息、媒体信息、种子信息
         :param download_dir:  下载目录
+        :param storage:  存储类型
         :param torrent_content: 种子内容，如果是种子文件，则为文件内容，否则为种子字符串
         :return: None，该方法可被多个模块同时处理
         """
@@ -87,15 +90,24 @@ class SubtitleModule(_ModuleBase):
         # 获取种子信息
         folder_name, _ = TorrentHelper().get_fileinfo_from_torrent_content(torrent_content)
         # 文件保存目录，如果是单文件种子，则folder_name是空，此时文件保存目录就是下载目录
-        download_dir = download_dir / folder_name
+        storageChain = StorageChain()
         # 等待目录存在
+        working_dir_item = None
         for _ in range(30):
-            if download_dir.exists():
+            found = storageChain.get_file_item(storage,  download_dir / folder_name)
+            if found:
+                working_dir_item = found
                 break
             time.sleep(1)
         # 目录仍然不存在，且有文件夹名，则创建目录
-        if not download_dir.exists() and folder_name:
-            download_dir.mkdir(parents=True, exist_ok=True)
+        if not working_dir_item and folder_name:
+            working_dir_item = storageChain.create_folder(
+                storageChain.get_file_item(storage, download_dir), 
+                folder_name
+            )
+        if not working_dir_item:
+            logger.error(f"下载目录不存在，无法保存字幕：{download_dir / folder_name}")
+            return
         # 读取网站代码
         request = RequestUtils(cookies=torrent.site_cookie, ua=torrent.site_ua)
         res = request.get_res(torrent.page_url)
@@ -144,12 +156,12 @@ class SubtitleModule(_ModuleBase):
                         shutil.unpack_archive(zip_file, zip_path, format='zip')
                         # 遍历转移文件
                         for sub_file in SystemUtils.list_files(zip_path, settings.RMT_SUBEXT):
-                            target_sub_file = download_dir / sub_file.name
-                            if target_sub_file.exists():
+                            target_sub_file = Path(working_dir_item.path) / Path(sub_file.name)
+                            if storageChain.get_file_item(storage, target_sub_file):
                                 logger.info(f"字幕文件已存在：{target_sub_file}")
                                 continue
                             logger.info(f"转移字幕 {sub_file} 到 {target_sub_file} ...")
-                            SystemUtils.copy(sub_file, target_sub_file)
+                            storageChain.upload_file(working_dir_item, sub_file)
                         # 删除临时文件
                         try:
                             shutil.rmtree(zip_path)
@@ -160,9 +172,12 @@ class SubtitleModule(_ModuleBase):
                         sub_file = settings.TEMP_PATH / file_name
                         # 保存
                         sub_file.write_bytes(ret.content)
-                        target_sub_file = download_dir / sub_file.name
-                        logger.info(f"转移字幕 {sub_file} 到 {target_sub_file}")
-                        SystemUtils.copy(sub_file, target_sub_file)
+                        target_sub_file = Path(working_dir_item.path) / Path(sub_file.name)
+                        if storageChain.get_file_item(storage, target_sub_file):
+                            logger.info(f"字幕文件已存在：{target_sub_file}")
+                            continue
+                        logger.info(f"转移字幕 {sub_file} 到 {target_sub_file} ...")
+                        storageChain.upload_file(working_dir_item, sub_file)
                 else:
                     logger.error(f"下载字幕文件失败：{sublink}")
                     continue


### PR DESCRIPTION
 当媒体库是非本地类型(SMB,阿里网盘...)时，修复两个问题：
## 无法使用默认目录下载资源：
<img width="590" height="281" alt="image" src="https://github.com/user-attachments/assets/9cffa3c3-487a-4fb5-bbbc-c93fdbe108b8" />

logs:
<img width="1160" height="235" alt="image" src="https://github.com/user-attachments/assets/45c80fe4-9a04-49c8-9ee7-0251dfe04e8f" />

## 字幕下载失败，或者错误下载到了本地
修复前：
TODO
修复后：
<img width="1552" height="227" alt="image" src="https://github.com/user-attachments/assets/8fbe66fb-96dd-4f2d-976f-10d0c1061cd5" />

