### PR TITLE
Change user_level type to Union[str, int]

### DIFF
--- a/app/schemas/site.py
+++ b/app/schemas/site.py
@@ -77,7 +77,7 @@ class SiteUserData(BaseModel):
     # 用户ID
     userid: Optional[Union[str, int]] = None
     # 用户等级
-    user_level: Optional[str] = None
+    user_level: Optional[Union[str, int]] = None
     # 加入时间
     join_at: Optional[str] = None
     # 积分


### PR DESCRIPTION
有一个站点，user_level也使用的数字，YemaPT，导致报错。

```
    For further information visit https://errors.pydantic.dev/2.12/v/string_type
  Input should be a valid string [type=string_type, input_value=2, input_type=int]
user_level
pydantic_core._pydantic_core.ValidationError: 1 validation error for SiteUserData
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
  File "/opt/venv/lib/python3.12/site-packages/pydantic/main.py", line 250, in __init__
           ^^^^^^^^^^^^^
    return SiteUserData(
  File "/app/app/modules/indexer/__init__.py", line 444, in refresh_userdata
             ^^^^^^^^^^^^^^^^^^^^^
    result = func(*args, **kwargs)
  File "/app/app/chain/__init__.py", line 240, in __execute_system_modules
Traceback (most recent call last):
    For further information visit https://errors.pydantic.dev/2.12/v/string_type
  Input should be a valid string [type=string_type, input_value=2, input_type=int]
user_level
【ERROR】2025-11-30 08:56:18,724 - chain - 运行模块 IndexerModule.refresh_userdata 出错：1 validation error for SiteUserData 
【INFO】2025-11-30 08:56:16,353 - indexer - 站点 YemaPT 开始以 Yema 模型解析数据...
```