### PR TITLE
Convert user level to string if not None

### DIFF
--- a/app/modules/indexer/parser/yema.py
+++ b/app/modules/indexer/parser/yema.py
@@ -52,7 +52,7 @@ class TYemaSiteUserInfo(SiteParserBase):
         user_info = detail.get("data", {})
         self.userid = user_info.get("id")
         self.username = user_info.get("name")
-        self.user_level = user_info.get("level")
+        self.user_level = str(user_info.get("level")) if user_info.get("level") is not None else None
         self.join_at = StringUtils.unify_datetime_str(user_info.get("registerTime"))
 
         self.upload = user_info.get('uploadSize')


### PR DESCRIPTION
有一个站点，user_level也使用的数字，YemaPT，导致报错。

```
    For further information visit https://errors.pydantic.dev/2.12/v/string_type
  Input should be a valid string [type=string_type, input_value=2, input_type=int]
user_level
pydantic_core._pydantic_core.ValidationError: 1 validation error for SiteUserData
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
  File "/opt/venv/lib/python3.12/site-packages/pydantic/main.py", line 250, in __init__
           ^^^^^^^^^^^^^
    return SiteUserData(
  File "/app/app/modules/indexer/__init__.py", line 444, in refresh_userdata
             ^^^^^^^^^^^^^^^^^^^^^
    result = func(*args, **kwargs)
  File "/app/app/chain/__init__.py", line 240, in __execute_system_modules
Traceback (most recent call last):
    For further information visit https://errors.pydantic.dev/2.12/v/string_type
  Input should be a valid string [type=string_type, input_value=2, input_type=int]
user_level
【ERROR】2025-11-30 08:56:18,724 - chain - 运行模块 IndexerModule.refresh_userdata 出错：1 validation error for SiteUserData 
【INFO】2025-11-30 08:56:16,353 - indexer - 站点 YemaPT 开始以 Yema 模型解析数据...
```