### PR TITLE
refactor: 将图片获取逻辑抽象为独立的 ImageHelper

### DIFF
--- a/app/api/endpoints/login.py
+++ b/app/api/endpoints/login.py
@@ -10,7 +10,7 @@ from app.core import security
 from app.core.config import settings
 from app.db.systemconfig_oper import SystemConfigOper
 from app.helper.sites import SitesHelper  # noqa
-from app.helper.wallpaper import WallpaperHelper
+from app.helper.graphics import WallpaperHelper
 from app.schemas.types import SystemConfigKey
 
 router = APIRouter()

--- a/app/helper/torrent.py
+++ b/app/helper/torrent.py
@@ -6,8 +6,7 @@ from urllib.parse import unquote
 
 from torrentool.api import Torrent
 
-from app.core.cache import FileCache
-from app.core.cache import TTLCache
+from app.core.cache import TTLCache, FileCache
 from app.core.config import settings
 from app.core.context import Context, TorrentInfo, MediaInfo
 from app.core.meta import MetaBase

--- a/app/modules/wechat/__init__.py
+++ b/app/modules/wechat/__init__.py
@@ -8,7 +8,7 @@ from app.log import logger
 from app.modules import _ModuleBase, _MessageBase
 from app.modules.wechat.WXBizMsgCrypt3 import WXBizMsgCrypt
 from app.modules.wechat.wechat import WeChat
-from app.schemas import MessageChannel, CommingMessage, Notification, CommandRegisterEventData, ConfigChangeEventData
+from app.schemas import MessageChannel, CommingMessage, Notification, CommandRegisterEventData
 from app.schemas.types import ModuleType, ChainEventType
 from app.utils.dom import DomUtils
 from app.utils.structures import DictUtils

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -27,7 +27,7 @@ from app.core.plugin import PluginManager
 from app.db.systemconfig_oper import SystemConfigOper
 from app.helper.message import MessageHelper
 from app.helper.sites import SitesHelper  # noqa
-from app.helper.wallpaper import WallpaperHelper
+from app.helper.graphics import WallpaperHelper
 from app.log import logger
 from app.schemas import Notification, NotificationType, Workflow
 from app.schemas.types import EventType, SystemConfigKey


### PR DESCRIPTION
将图片获取逻辑从多个模块中抽象出来，创建新的 `app/helper/graphics.py` 模块，统一管理图片获取、缓存和验证的逻辑。

- `ImageHelper` 支持**同步和异步**两种图片获取方式
- 代理策略：判断内网和豆瓣 URL，避免不必要的代理

**破坏性变更**：`WallpaperHelper` [登录壁纸本地化](https://github.com/jxxghp/MoviePilot-Plugins/blob/5b763dff42d6144043b734513c20d8794afbc297/plugins/tmdbwallpaper/__init__.py#L10) 需更新导入
--
**其他修改**
- 移除telegram图片获取重试逻辑
- fix: #5216
