### PR TITLE
Add path mapping setting for each downloader

### DIFF
--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -707,19 +707,17 @@ class ChainBase(metaclass=ABCMeta):
                                cookie=cookie, episodes=episodes, category=category, label=label,
                                downloader=downloader)
 
-    def download_added(self, context: Context, download_dir: Path, storage: str, torrent_content: Union[str, bytes] = None) -> None:
+    def download_added(self, context: Context, download_dir: Path, torrent_content: Union[str, bytes] = None) -> None:
         """
         添加下载任务成功后，从站点下载字幕，保存到下载目录
         :param context:  上下文，包括识别信息、媒体信息、种子信息
         :param download_dir:  下载目录
-        :param storage:  存储类型
         :param torrent_content:  种子内容，如果有则直接使用该内容，否则从context中获取种子文件路径
         :return: None，该方法可被多个模块同时处理
         """
         return self.run_module("download_added", context=context,
                                torrent_content=torrent_content,
-                               download_dir=download_dir,
-                               storage=storage)
+                               download_dir=download_dir)
 
     def list_torrents(self, status: TorrentStatus = None,
                       hashs: Union[list, str] = None,

--- a/app/modules/__init__.py
+++ b/app/modules/__init__.py
@@ -307,8 +307,8 @@ class _DownloaderBase(ServiceBase[TService, DownloaderConf]):
                 storage_path = Path(storage_path.strip()).as_posix()
                 download_path = Path(download_path.strip()).as_posix()
                 if dir.startswith(storage_path):
-                   dir = dir.replace(storage_path, download_path, 1)
-                   break
+                    dir = dir.replace(storage_path, download_path, 1)
+                    break
         # 去掉存储协议前缀 if any, 下载器无法识别
         for s in StorageSchema:
             prefix = f"{s.value}:"

--- a/app/modules/__init__.py
+++ b/app/modules/__init__.py
@@ -297,7 +297,7 @@ class _DownloaderBase(ServiceBase[TService, DownloaderConf]):
         根据下载器配置和路径映射，规范化下载路径
 
         :param path: 存储路径
-        :param conf: 下载器配置
+        :param downloader: 下载器名称
         :return: 规范化后发送给下载器的路径
         """
         dir = path.as_posix()

--- a/app/modules/__init__.py
+++ b/app/modules/__init__.py
@@ -296,20 +296,20 @@ class _DownloaderBase(ServiceBase[TService, DownloaderConf]):
         """
         根据下载器配置和路径映射，规范化下载路径
 
-        :param path: 原始路径
+        :param path: 存储路径
         :param conf: 下载器配置
-        :return: 规范化后的路径
+        :return: 规范化后发送给下载器的路径
         """
         dir = path.as_posix()
         conf = self.get_config(downloader)
         if conf and conf.path_mapping:
-            for (src, dst) in conf.path_mapping:
-                src = Path(src.strip()).as_posix()
-                dst = Path(dst.strip()).as_posix()
-                if dir.startswith(src):
-                   dir = dir.replace(src, dst, 1)
+            for (storage_path, download_path) in conf.path_mapping:
+                storage_path = Path(storage_path.strip()).as_posix()
+                download_path = Path(download_path.strip()).as_posix()
+                if dir.startswith(storage_path):
+                   dir = dir.replace(storage_path, download_path, 1)
                    break
-        # 处理存储协议前缀
+        # 去掉存储协议前缀 if any, 下载器无法识别
         for s in StorageSchema:
             prefix = f"{s.value}:"
             if dir.startswith(prefix):

--- a/app/modules/qbittorrent/__init__.py
+++ b/app/modules/qbittorrent/__init__.py
@@ -150,7 +150,7 @@ class QbittorrentModule(_ModuleBase, _DownloaderBase[Qbittorrent]):
         # 添加任务
         state = server.add_torrent(
             content=content,
-            download_dir=download_dir.as_posix(),
+            download_dir=self.normalize_path(download_dir, downloader),
             is_paused=is_paused,
             tag=tags,
             cookie=cookie,

--- a/app/modules/subtitle/__init__.py
+++ b/app/modules/subtitle/__init__.py
@@ -11,7 +11,7 @@ from app.core.context import Context
 from app.helper.torrent import TorrentHelper
 from app.log import logger
 from app.modules import _ModuleBase
-from app.schemas.file import FileItem
+from app.schemas.file import FileURI 
 from app.schemas.types import ModuleType, OtherModulesType
 from app.utils.http import RequestUtils
 from app.utils.string import StringUtils
@@ -65,12 +65,11 @@ class SubtitleModule(_ModuleBase):
     def test(self):
         pass
 
-    def download_added(self, context: Context, download_dir: Path, storage: str, torrent_content: Union[str, bytes] = None):
+    def download_added(self, context: Context, download_dir: Path, torrent_content: Union[str, bytes] = None):
         """
         添加下载任务成功后，从站点下载字幕，保存到下载目录
         :param context:  上下文，包括识别信息、媒体信息、种子信息
         :param download_dir:  下载目录
-        :param storage:  存储类型
         :param torrent_content: 种子内容，如果是种子文件，则为文件内容，否则为种子字符串
         :return: None，该方法可被多个模块同时处理
         """
@@ -93,6 +92,10 @@ class SubtitleModule(_ModuleBase):
         storageChain = StorageChain()
         # 等待目录存在
         working_dir_item = None
+        # split download_dir into storage and path
+        fileURI = FileURI.from_uri(download_dir.as_posix())
+        storage = fileURI.storage
+        download_dir = Path(fileURI.path)
         for _ in range(30):
             found = storageChain.get_file_item(storage,  download_dir / folder_name)
             if found:

--- a/app/modules/transmission/__init__.py
+++ b/app/modules/transmission/__init__.py
@@ -151,7 +151,7 @@ class TransmissionModule(_ModuleBase, _DownloaderBase[Transmission]):
         # 添加任务
         torrent = server.add_torrent(
             content=content,
-            download_dir=download_dir.as_posix(),
+            download_dir=self.normalize_path(download_dir, downloader),
             is_paused=is_paused,
             labels=labels,
             cookie=cookie

--- a/app/schemas/system.py
+++ b/app/schemas/system.py
@@ -51,6 +51,8 @@ class DownloaderConf(BaseModel):
     config: Optional[dict] = Field(default_factory=dict)
     # 是否启用
     enabled: Optional[bool] = False
+    # 路径映射
+    path_mapping: Optional[list[tuple[str, str]]] = Field(default_factory=list)
 
 
 class NotificationConf(BaseModel):


### PR DESCRIPTION
> frontend change: https://github.com/jxxghp/MoviePilot-Frontend/pull/409


It is possible that the file system are different between downloader and MoviePilot Storages, e.g.
1. the downloader runs on the NAS machine but Moviepilot runs on another server using SMB protocol to manage files
2. the downloader and Moviepilot are under different docker containers with different mount bindings

with this feature, downloader will get a reasonable path after the mapping:

<img width="1062" height="1444" alt="image" src="https://github.com/user-attachments/assets/9d91f1f2-929f-4ca8-a0cd-5e24929b613c" />
