### PR TITLE
fix(telegram): 调整tg消息标题格式

### DIFF
--- a/app/modules/telegram/telegram.py
+++ b/app/modules/telegram/telegram.py
@@ -236,9 +236,9 @@ class Telegram:
 
         try:
             if title and text:
-                caption = f"**{title}**\n{text}"
+                caption = f"{title}\n{text}"
             elif title:
-                caption = f"**{title}**"
+                caption = f"{title}"
             elif text:
                 caption = text
             else:


### PR DESCRIPTION
- 移除标题的粗体标记，该标记会导致通知模板中标题的md样式失效