### PR TITLE
fix cookiecloud: support download encrypted data using post

### DIFF
--- a/app/api/servcookie.py
+++ b/app/api/servcookie.py
@@ -127,9 +127,8 @@ async def get_cookie(
 
 @cookie_router.post("/get/{uuid}")
 async def post_cookie(
-    uuid: Annotated[str, Path(min_length=5, pattern="^[a-zA-Z0-9]+$")],
-    request: Optional[schemas.CookiePassword] = Body(None)
-):
+        uuid: Annotated[str, Path(min_length=5, pattern="^[a-zA-Z0-9]+$")],
+        request: Optional[schemas.CookiePassword] = Body(None)):
     """
     POST 下载加密数据
     """

--- a/app/api/servcookie.py
+++ b/app/api/servcookie.py
@@ -4,7 +4,7 @@ from typing import Annotated, Callable, Any, Dict, Optional
 
 import aiofiles
 from anyio import Path as AsyncPath
-from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Request, Response
 from fastapi.responses import PlainTextResponse
 from fastapi.routing import APIRoute
 
@@ -127,10 +127,14 @@ async def get_cookie(
 
 @cookie_router.post("/get/{uuid}")
 async def post_cookie(
-        uuid: Annotated[str, Path(min_length=5, pattern="^[a-zA-Z0-9]+$")],
-        request: schemas.CookiePassword):
+    uuid: Annotated[str, Path(min_length=5, pattern="^[a-zA-Z0-9]+$")],
+    request: Optional[schemas.CookiePassword] = Body(None)
+):
     """
     POST 下载加密数据
     """
     data = await load_encrypt_data(uuid)
-    return get_decrypted_cookie_data(uuid, request.password, data["encrypted"])
+    if request is not None:
+        return get_decrypted_cookie_data(uuid, request.password, data["encrypted"])
+    else:
+        return data


### PR DESCRIPTION
as the cookicloud official api doc:
> password: optional, if not provided returns the encrypted string, if provided attempts to decrypt and send the content;

The post api should return encrypted data if password is not present on the body.
