### PR TITLE
refactor(db): 更新数据库模型更新方法以保留空值  && fix(chain): 修复消息隔离和发送逻辑问题

### DIFF
--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -862,7 +862,7 @@ class ChainBase(metaclass=ABCMeta):
         self.messagehelper.put(message, role="user", title=message.title)
         self.messageoper.add(**message.model_dump())
         # 发送消息按设置隔离
-        if not message.userid and message.mtype:
+        if message.mtype:
             # 消息隔离设置
             notify_action = ServiceConfigHelper.get_notification_switch(message.mtype)
             if notify_action:
@@ -903,6 +903,7 @@ class ChainBase(metaclass=ABCMeta):
                     else:
                         # 按原消息发送全体
                         if not admin_sended:
+                            message.userid = None
                             send_orignal = True
                         break
                     # 按设定发送

--- a/app/chain/__init__.py
+++ b/app/chain/__init__.py
@@ -946,7 +946,7 @@ class ChainBase(metaclass=ABCMeta):
         self.messagehelper.put(message, role="user", title=message.title)
         await self.messageoper.async_add(**message.model_dump())
         # 发送消息按设置隔离
-        if not message.userid and message.mtype:
+        if message.mtype:
             # 消息隔离设置
             notify_action = ServiceConfigHelper.get_notification_switch(message.mtype)
             if notify_action:
@@ -987,6 +987,7 @@ class ChainBase(metaclass=ABCMeta):
                     else:
                         # 按原消息发送全体
                         if not admin_sended:
+                            message.userid = None
                             send_orignal = True
                         break
                     # 按设定发送

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -454,7 +454,7 @@ class Base:
 
     @db_update
     def update(self, db: Session, payload: dict):
-        payload = {k: v for k, v in payload.items() if v is not None}
+        payload = {k: v for k, v in payload.items()}
         for key, value in payload.items():
             setattr(self, key, value)
         if inspect(self).detached:
@@ -462,7 +462,7 @@ class Base:
 
     @async_db_update
     async def async_update(self, db: AsyncSession, payload: dict):
-        payload = {k: v for k, v in payload.items() if v is not None}
+        payload = {k: v for k, v in payload.items()}
         for key, value in payload.items():
             setattr(self, key, value)
         if inspect(self).detached:


### PR DESCRIPTION
- 移除更新方法中过滤空值的逻辑
- 确保数据库实体能够正确处理空值更新
- 保持异步和同步更新方法的一致性

目前当通过更新的方式，删除一些已经存在的值时，由于进行了空值过滤，会导致无效。例如：更新订阅中的内容，先设置了指定下载器或者目录，但是后期想通过更新的方式删除相关设置时，由于空值过滤会导致无效。


fix(chain): 修复消息隔离和发送逻辑问题

- 移除了消息隔离条件中的 userid 非空检查
- 在全体发送时重置 message.userid 为 None
- 修复了消息按设置隔离的判断逻辑
 当用户通过微信或者tg与mp交互订阅时，未按照设定的范围进行通知发送