### PR TITLE
[Security] 优化 /api/v1/system/global 接口，采用白名单模式返回非敏感系统设置

### DIFF
--- a/app/api/endpoints/system.py
+++ b/app/api/endpoints/system.py
@@ -134,11 +134,15 @@ def get_global_setting(token: str):
     if token != "moviepilot":
         raise HTTPException(status_code=403, detail="Forbidden")
 
-    # FIXME: 新增敏感配置项时要在此处添加排除项
+    # 白名单模式，仅包含前端业务逻辑必需的字段
     info = settings.model_dump(
-        exclude={"SECRET_KEY", "RESOURCE_SECRET_KEY", "API_TOKEN", "TMDB_API_KEY", "TVDB_API_KEY", "FANART_API_KEY",
-                 "COOKIECLOUD_KEY", "COOKIECLOUD_PASSWORD", "GITHUB_TOKEN", "REPO_GITHUB_TOKEN", "U115_APP_ID",
-                 "ALIPAN_APP_ID", "TVDB_V4_API_KEY", "TVDB_V4_API_PIN"}
+        include={
+            "TMDB_IMAGE_DOMAIN",
+            "GLOBAL_IMAGE_CACHE",
+            "ADVANCED_MODE",
+            "RECOGNIZE_SOURCE",
+            "SEARCH_SOURCE"
+        }
     )
     # 追加用户唯一ID和订阅分享管理权限
     share_admin = SubscribeHelper().is_admin_user()


### PR DESCRIPTION
#### 📝 简述 (Description)
将 `/api/v1/system/global` 接口的系统设置返回逻辑从**黑名单模式**（exclude）重构为**白名单模式**（include）。

#### 🔍 变更背景 (Context)
`/api/v1/system/global` 接口主要用于前端初始化（如未登录时的壁纸加载、菜单渲染逻辑判断）。由于该接口采用固定鉴权，且之前使用的是黑名单模式，当系统增加新的敏感配置项时，若开发者忘记在黑名单中手动添加，可能导致敏感信息泄露。

#### ✨ 变更内容 (Changes)
- **重构鉴权逻辑**：由“排除已知敏感项”改为“仅允许必要项”。
- **精简返回字段**：根据对前端源码的分析，目前仅保留前端业务逻辑必需的以下字段：
  - `TMDB_IMAGE_DOMAIN`：用于海报/剧照 URL 拼接。
  - `GLOBAL_IMAGE_CACHE`：用于判断是否启用图片中转缓存。
  - `ADVANCED_MODE`：用于控制前端高级模式菜单显示。
  - `RECOGNIZE_SOURCE`：用于整理/识别弹窗的默认来源配置。
  - `SEARCH_SOURCE`：用于搜索功能的默认数据源逻辑。
- **保留动态字段**：继续保留 `USER_UNIQUE_ID` 等用于分享权限控制的动态追加字段。

#### 🛡️ 安全影响 (Security Impact)
- **防范配置泄露**：从根源上杜绝了未来新增敏感配置（如新的 API Key、数据库连接字符串等）被意外暴露给未登录用户的风险。
- **最小化信息披露**：仅暴露 UI 渲染所需的元数据。