### PR TITLE
feat(system): 添加前端和后端版本信息

### DIFF
--- a/app/api/endpoints/system.py
+++ b/app/api/endpoints/system.py
@@ -150,7 +150,7 @@ def get_global_setting(token: str):
         "USER_UNIQUE_ID": SubscribeHelper().get_user_uuid(),
         "SUBSCRIBE_SHARE_MANAGE": share_admin,
         "WORKFLOW_SHARE_MANAGE": share_admin,
-        "FRONTEND_VERSION": SystemChain().get_frontend_version(),
+        "FRONTEND_VERSION": SystemChain.get_frontend_version(),
         "BACKEND_VERSION": APP_VERSION
     })
     return schemas.Response(success=True,

--- a/app/api/endpoints/system.py
+++ b/app/api/endpoints/system.py
@@ -149,7 +149,9 @@ def get_global_setting(token: str):
     info.update({
         "USER_UNIQUE_ID": SubscribeHelper().get_user_uuid(),
         "SUBSCRIBE_SHARE_MANAGE": share_admin,
-        "WORKFLOW_SHARE_MANAGE": share_admin
+        "WORKFLOW_SHARE_MANAGE": share_admin,
+        "FRONTEND_VERSION": SystemChain().get_frontend_version(),
+        "BACKEND_VERSION": APP_VERSION
     })
     return schemas.Response(success=True,
                             data=info)


### PR DESCRIPTION
## 概述

在系统全局配置接口中添加前后端版本号字段，供前端进行版本检测和展示。
关联：https://github.com/jxxghp/MoviePilot-Frontend/pull/415

## 主要改动

### `app/api/endpoints/system.py`

在 `get_global_setting` 接口响应中新增字段：

```python
{
    "FRONTEND_VERSION": SystemChain().get_frontend_version(),  # 前端版本号
    "BACKEND_VERSION": APP_VERSION  # 后端版本号
}
```

## 接口变更

**接口：** `GET /api/v1/system/global?token=moviepilot`

**新增响应字段：**
```json
{
  "FRONTEND_VERSION": "v2.8.9",
  "BACKEND_VERSION": "v2.9.0",
  ...其他字段
}
```