### PR TITLE
修复 自建TMDB服无法通过健康检测

### DIFF
--- a/app/modules/themoviedb/__init__.py
+++ b/app/modules/themoviedb/__init__.py
@@ -78,7 +78,7 @@ class TheMovieDbModule(_ModuleBase):
         """
         测试模块连接性
         """
-        ret = RequestUtils(proxies=settings.PROXY).get_res(
+        ret = RequestUtils(ua=settings.NORMAL_USER_AGENT, proxies=settings.PROXY).get_res(
             f"https://{settings.TMDB_API_DOMAIN}/3/movie/550?api_key={settings.TMDB_API_KEY}")
         if ret and ret.status_code == 200:
             return True, ""


### PR DESCRIPTION
网络请求需携带UA，以避免被反爬虫脚本过滤