### PR TITLE
修复 刮削电影会误报父目录的海报图已存在

### DIFF
--- a/app/chain/media.py
+++ b/app/chain/media.py
@@ -618,7 +618,7 @@ class MediaChain(ChainBase):
                                 should_scrape = True  # 未知类型默认刮削
 
                             if should_scrape:
-                                image_path = filepath.with_name(image_name)
+                                image_path = filepath / image_name
                                 if overwrite or not storagechain.get_file_item(storage=fileitem.storage,
                                                                                path=image_path):
                                     # 流式下载图片并直接保存


### PR DESCRIPTION
问题发生在刮削电影目录内的图片时，错误使用了with_name的方式构造图片路径，这会导致后续错误的去判断父目录内的图片，如果父目录内存在同名图片，则当前电影的图片会被忽略下载。

日志
> 【INFO】2026-01-02 18:04:26,006 - media.py - 开始刮削：/media/links/电影/欧美电影/惊天魔盗团3 (2025) ...
【INFO】2026-01-02 18:04:26,098 - media.py - 已存在图片文件：/media/links/电影/欧美电影/poster.jpg