### PR TITLE
修复 电影文件可能会误识别成电视剧类型

### DIFF
--- a/app/core/metainfo.py
+++ b/app/core/metainfo.py
@@ -71,12 +71,14 @@ def MetaInfoPath(path: Path) -> MetaBase:
     file_meta = MetaInfo(title=path.name)
     # 上级目录元数据
     dir_meta = MetaInfo(title=path.parent.name)
-    # 合并元数据
-    file_meta.merge(dir_meta)
+    if file_meta.type == MediaType.TV or dir_meta.type == file_meta.type:
+        # 合并元数据
+        file_meta.merge(dir_meta)
     # 上上级目录元数据
     root_meta = MetaInfo(title=path.parent.parent.name)
-    # 合并元数据
-    file_meta.merge(root_meta)
+    if file_meta.type == MediaType.TV or root_meta.type == file_meta.type:
+        # 合并元数据
+        file_meta.merge(root_meta)
     return file_meta
 
 

--- a/app/core/metainfo.py
+++ b/app/core/metainfo.py
@@ -71,7 +71,7 @@ def MetaInfoPath(path: Path) -> MetaBase:
     file_meta = MetaInfo(title=path.name)
     # 上级目录元数据
     dir_meta = MetaInfo(title=path.parent.name)
-    if file_meta.type == MediaType.TV or dir_meta.type == file_meta.type:
+    if file_meta.type == MediaType.TV or dir_meta.type != MediaType.TV:
         # 合并元数据
         file_meta.merge(dir_meta)
     # 上上级目录元数据

--- a/app/core/metainfo.py
+++ b/app/core/metainfo.py
@@ -76,7 +76,7 @@ def MetaInfoPath(path: Path) -> MetaBase:
         file_meta.merge(dir_meta)
     # 上上级目录元数据
     root_meta = MetaInfo(title=path.parent.parent.name)
-    if file_meta.type == MediaType.TV or root_meta.type == file_meta.type:
+    if file_meta.type == MediaType.TV or root_meta.type != MediaType.TV:
         # 合并元数据
         file_meta.merge(root_meta)
     return file_meta

--- a/tests/cases/meta.py
+++ b/tests/cases/meta.py
@@ -1117,4 +1117,19 @@ meta_cases = [{
         "audio_codec": "",
         "tmdbid": 19995
     }
+}, {
+    "path": "/movies/DouBan_IMDB.TOP250.Movies.Mixed.Collection.20240501.FRDS/为奴十二年.12.Years.a.Slave.2013.BluRay.1080p.x265.10bit.2Audio.MNHD-FRDS/12.Years.a.Slave.2013.BluRay.1080p.x265.10bit.2Audio.MNHD-FRDS.mkv",
+    "target": {
+        "type": "未知",
+        "cn_name": "",
+        "en_name": "12 Years A Slave",
+        "year": "2013",
+        "part": "",
+        "season": "",
+        "episode": "",
+        "restype": "BluRay",
+        "pix": "1080p",
+        "video_codec": "x265 10bit",
+        "audio_codec": "2Audio"
+    }
 }]


### PR DESCRIPTION
当前在识别文件元数据时，会和上级目录的元数据合并。如果一个电影文件位于电视剧目录内，或者上级目录因命名问题错误识别成了电视剧类型，则这个电影文件会在合并后错误变成电视剧文件，导致后续无法正确获得电影媒体信息。

本次的改进方法是避免电影文件被上级目录的类型改动，已通过测试用例的验证，识别结果符合预期。