### PR TITLE
feat(agent): 新增媒体详情查询工具

### DIFF
--- a/app/agent/tools/factory.py
+++ b/app/agent/tools/factory.py
@@ -27,6 +27,7 @@ from app.agent.tools.impl.search_person_credits import SearchPersonCreditsTool
 from app.agent.tools.impl.recognize_media import RecognizeMediaTool
 from app.agent.tools.impl.scrape_metadata import ScrapeMetadataTool
 from app.agent.tools.impl.query_episode_schedule import QueryEpisodeScheduleTool
+from app.agent.tools.impl.query_media_detail import QueryMediaDetailTool
 from app.agent.tools.impl.search_torrents import SearchTorrentsTool
 from app.agent.tools.impl.search_web import SearchWebTool
 from app.agent.tools.impl.send_message import SendMessageTool
@@ -61,6 +62,7 @@ class MoviePilotToolFactory:
             RecognizeMediaTool,
             ScrapeMetadataTool,
             QueryEpisodeScheduleTool,
+            QueryMediaDetailTool,
             AddSubscribeTool,
             UpdateSubscribeTool,
             SearchSubscribeTool,

--- a/app/agent/tools/impl/query_media_detail.py
+++ b/app/agent/tools/impl/query_media_detail.py
@@ -1,0 +1,113 @@
+"""查询媒体详情工具"""
+
+import json
+from typing import Optional, Type
+
+from pydantic import BaseModel, Field
+
+from app.agent.tools.base import MoviePilotTool
+from app.chain.media import MediaChain
+from app.log import logger
+from app.schemas import MediaType
+
+
+class QueryMediaDetailInput(BaseModel):
+    """查询媒体详情工具的输入参数模型"""
+    explanation: str = Field(..., description="Clear explanation of why this tool is being used in the current context")
+    tmdb_id: int = Field(..., description="TMDB ID of the media (movie or TV series)")
+
+
+class QueryMediaDetailTool(MoviePilotTool):
+    name: str = "query_media_detail"
+    description: str = "Query detailed media information from TMDB by ID. Returns core metadata including title, year, overview, status, genres, directors, actors, and season count for TV series."
+    args_schema: Type[BaseModel] = QueryMediaDetailInput
+
+    def get_tool_message(self, **kwargs) -> Optional[str]:
+        """根据查询参数生成友好的提示消息"""
+        tmdb_id = kwargs.get("tmdb_id")
+        return f"正在查询媒体详情: TMDB ID {tmdb_id}"
+
+    async def run(self, tmdb_id: int, **kwargs) -> str:
+        logger.info(f"执行工具: {self.name}, 参数: tmdb_id={tmdb_id}")
+
+        try:
+            media_chain = MediaChain()
+
+            # 通过自动媒体类型识别获取媒体信息（电影或电视剧）
+            mediainfo = await media_chain.async_recognize_media(tmdbid=tmdb_id, mtype=None)
+
+            if not mediainfo:
+                return json.dumps({
+                    "success": False,
+                    "message": f"未找到 TMDB ID {tmdb_id} 的媒体信息"
+                }, ensure_ascii=False)
+
+            # 精简 genres - 只保留名称
+            genres = [g.get("name") for g in (mediainfo.genres or []) if g.get("name")]
+
+            # 精简 directors - 只保留姓名和职位
+            directors = [
+                {
+                    "name": d.get("name"),
+                    "job": d.get("job")
+                }
+                for d in (mediainfo.directors or [])
+                if d.get("name")
+            ]
+
+            # 精简 actors - 只保留姓名和角色
+            actors = [
+                {
+                    "name": a.get("name"),
+                    "character": a.get("character")
+                }
+                for a in (mediainfo.actors or [])
+                if a.get("name")
+            ]
+
+            # 构建基础媒体详情信息
+            result = {
+                "success": True,
+                "tmdb_id": tmdb_id,
+                "type": mediainfo.type.value if mediainfo.type else None,
+                "title": mediainfo.title,
+                "year": mediainfo.year,
+                "overview": mediainfo.overview,
+                "status": mediainfo.status,
+                "genres": genres,
+                "directors": directors,
+                "actors": actors
+            }
+
+            # 如果是电视剧，添加电视剧特有信息
+            if mediainfo.type == MediaType.TV:
+                # 精简 season_info - 只保留基础摘要
+                season_info = [
+                    {
+                        "season_number": s.get("season_number"),
+                        "name": s.get("name"),
+                        "episode_count": s.get("episode_count"),
+                        "air_date": s.get("air_date")
+                    }
+                    for s in (mediainfo.season_info or [])
+                    if s.get("season_number") is not None
+                ]
+
+                result.update({
+                    "number_of_seasons": mediainfo.number_of_seasons,
+                    "number_of_episodes": mediainfo.number_of_episodes,
+                    "first_air_date": mediainfo.first_air_date,
+                    "last_air_date": mediainfo.last_air_date,
+                    "season_info": season_info
+                })
+
+            return json.dumps(result, ensure_ascii=False, indent=2)
+
+        except Exception as e:
+            error_message = f"查询媒体详情失败: {str(e)}"
+            logger.error(f"查询媒体详情失败: {e}", exc_info=True)
+            return json.dumps({
+                "success": False,
+                "message": error_message,
+                "tmdb_id": tmdb_id
+            }, ensure_ascii=False)


### PR DESCRIPTION
# Agent 工具增强：新增媒体详情查询工具

## 背景

在使用 Agent 工具时，缺少专门的媒体详情查询工具。

## 问题：缺少媒体详情查询工具

### 现状
- 系统有 `query_episode_schedule` 工具用于查询剧集播出时间
- 但**没有工具能够查询媒体的基础详情信息**（如标题、简介、演员、导演、季数等）
- AI 在需要了解媒体详细信息时，只能依赖搜索结果中的有限数据

### 影响
- 用户询问"这部剧讲什么"、"谁演的"、"有几季"等问题时，AI 无法提供详细信息
- 缺少完整的媒体元数据支持

### 电视剧季数信息缺失导致死锁

在没有专门的媒体详情查询工具时，还存在一个典型的死锁场景：

1. **search_media 工具**返回的电视剧信息中，`season` 字段为 `null`，**没有 `number_of_seasons` 字段**
2. **query_episode_schedule 工具**要求**必须传入 `season` 参数**才能查询剧集播出时间
3. 这形成了一个死锁：AI 不知道有多少季，也就无法调用 `query_episode_schedule` 来获取播出信息

#### 实际案例

当 AI 收到用户查询"Wednesday 有几季？"时：

```
AI: 调用 search_media("Wednesday")
返回: {
  "title": "Wednesday",
  "type": "电视剧",
  "season": null,           // ❌ 当前季号(未指定时为null)
  "tmdb_id": 119051,
  ...
  // ❌ 缺少 number_of_seasons 字段!
}

AI: 想要查询播出时间，但...
    → query_episode_schedule 需要 season 参数
    → AI 不知道有多少季
    → 无法继续操作 ❌
```

## 解决方案

### 新增 `query_media_detail` 工具

创建专门的媒体详情查询工具，提供精简的核心信息。

#### 功能特性
- **必填参数**：`tmdb_id`（TMDB ID）
- **支持类型**：电影和电视剧
- **智能识别**：自动判断媒体类型
- **数据精简**：仅返回核心信息，避免冗余

#### 返回数据结构

**基础信息**（所有媒体）：
- `title`：标题
- `year`：年份
- `overview`：简介
- `status`：状态
- `genres`：类型（仅名称数组）
- `directors`：导演（仅姓名和职位）
- `actors`：演员（仅姓名和角色）

**电视剧特有信息**：
- `number_of_seasons`：总季数 ✅
- `number_of_episodes`：总集数
- `first_air_date`：首播日期
- `last_air_date`：最后播出日期
- `season_info`：季信息摘要（季号、名称、集数、播出日期）

## 修改内容

### 新增文件

| 文件 | 说明 |
|------|------|
| `app/agent/tools/impl/query_media_detail.py` | 新增媒体详情查询工具 |

### 修改文件

| 文件 | 修改内容 |
|------|----------|
| `app/agent/tools/factory.py` | 注册新工具 `QueryMediaDetailTool` |

## 效果

### 解决死锁问题

```
✅ 优化后的流程：

用户: "Wednesday 有几季？"

AI: 调用 search_media("Wednesday")
返回: {
  "title": "Wednesday",
  "type": "电视剧",
  "tmdb_id": 119051,
  ...
}

AI: 调用 query_media_detail(119051) 获取详情
返回: {
  "title": "Wednesday",
  "number_of_seasons": 2,    // ✅ 获取到季数!
  "number_of_episodes": 16,
  "season_info": [
    {"season_number": 1, "episode_count": 8, ...},
    {"season_number": 2, "episode_count": 8, ...}
  ],
  ...
}

AI: 现在知道有 2 季，可以进一步查询
    → 如需播出时间，调用 query_episode_schedule(119051, 1)
    → 成功回答用户问题 ✅
```

- ✅ **填补功能空白**：AI 现在可以查询媒体的完整详情信息
- ✅ **解决死锁问题**：通过 `number_of_seasons` 字段，AI 可以知道有多少季