### PR TITLE
refactor: 将“媒体详情查询工具"中的media_type 参数改为必要

### DIFF
--- a/app/agent/tools/impl/query_media_detail.py
+++ b/app/agent/tools/impl/query_media_detail.py
@@ -15,10 +15,7 @@ class QueryMediaDetailInput(BaseModel):
     """查询媒体详情工具的输入参数模型"""
     explanation: str = Field(..., description="Clear explanation of why this tool is being used in the current context")
     tmdb_id: int = Field(..., description="TMDB ID of the media (movie or TV series)")
-    media_type: Optional[str] = Field(
-        None, 
-        description="Media type: 'movie' or 'tv'. If unknown or not provided, the system will auto-detect based on TMDB ID."
-    )
+    media_type: str = Field(..., description="Media type: 'movie' or 'tv'")
 
 
 class QueryMediaDetailTool(MoviePilotTool):
@@ -31,7 +28,7 @@ class QueryMediaDetailTool(MoviePilotTool):
         tmdb_id = kwargs.get("tmdb_id")
         return f"正在查询媒体详情: TMDB ID {tmdb_id}"
 
-    async def run(self, tmdb_id: int, media_type: Optional[str] = None, **kwargs) -> str:
+    async def run(self, tmdb_id: int, media_type: str, **kwargs) -> str:
         logger.info(f"执行工具: {self.name}, 参数: tmdb_id={tmdb_id}, media_type={media_type}")
 
         try:


### PR DESCRIPTION
### 问题描述
使用过程中发现有部分查询没有使用media_type参数

### 原因分析
`query_media_detail` 调用 `async_recognize_media` 时固定传递 `mtype=None`，未利用 `search_media` 返回结果中已有的 `type` 字段。
### 解决方案
- 将 `media_type` 参数从可选改为必填，强制 AI 传递媒体类型
- 更新工具描述，引导 AI 传递 `movie` 或 `tv`
- 增加容错处理：若 AI 传递无效值，自动回退到 `mtype=None` 进行自动检测
### 修改文件
- `app/agent/tools/query_media_detail.py`

ps 抱歉大佬，刚刚的pr有点问题，重新修复一下 :)