### PR TITLE
移除整理进度数据中无用的文件列表

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -560,8 +560,6 @@ class TransferChain(ChainBase, metaclass=Singleton):
         processed_num = 0
         # 失败数量
         fail_num = 0
-        # 已完成文件
-        finished_files = []
 
         progress = ProgressHelper(ProgressKey.FileTransfer)
 
@@ -594,10 +592,7 @@ class TransferChain(ChainBase, metaclass=Singleton):
                     logger.info(__process_msg)
                     progress.update(value=processed_num / total_num * 100,
                                     text=__process_msg,
-                                    data={
-                                        "current": Path(fileitem.path).as_posix(),
-                                        "finished": finished_files
-                                    })
+                                    data={})
                     # 整理
                     state, err_msg = self.__handle_transfer(task=task, callback=item.callback)
                     if not state:
@@ -605,7 +600,6 @@ class TransferChain(ChainBase, metaclass=Singleton):
                         fail_num += 1
                     # 更新进度
                     processed_num += 1
-                    finished_files.append(Path(fileitem.path).as_posix())
                     __process_msg = f"{fileitem.name} 整理完成"
                     logger.info(__process_msg)
                     progress.update(value=(processed_num / total_num) * 100,


### PR DESCRIPTION
在整理进度中传输已完成文件的功能已经不再需要了（v2.7.6开发期间临时添加的功能，在正式发布版本时已删了前端对应的展示），并且它还有可能影响大批量文件整理的场景（如占用过多内存、显著增加实时进度的传输量）