### PR TITLE
修复电视剧目录在应用识别词后可能影响刮削的问题

### DIFF
--- a/app/chain/media.py
+++ b/app/chain/media.py
@@ -665,7 +665,11 @@ class MediaChain(ChainBase):
                 if recursive:
                     files = __list_files(_fileitem=fileitem)
                     for file in files:
-                        if file.type == "dir" and not file.name.lower().startswith("season"):
+                        if (
+                            file.type == "dir"
+                            and file.name not in settings.RENAME_FORMAT_S0_NAMES
+                            and not file.name.lower().startswith("season")
+                        ):
                             # 电视剧不处理非季子目录
                             continue
                         self.scrape_metadata(fileitem=file,

--- a/app/chain/media.py
+++ b/app/chain/media.py
@@ -762,7 +762,7 @@ class MediaChain(ChainBase):
                                         logger.info(f"季图片刮削已关闭，跳过：{image_name}")
                     # 判断当前目录是不是剧集根目录
                     elif season_meta.name:
-                        # 不含季信息（包括特别季）但含有名称的，可以认为是剧集根目录 （原PR#3219对此的判断会遗漏被识别词指定成电视剧的根目录 详见issue#5373）
+                        # 不含季信息（包括特别季）但含有名称的，可以认为是剧集根目录
                         # 检查电视剧NFO开关
                         if scraping_switchs.get('tv_nfo', True):
                             # 是否已存在

--- a/app/chain/media.py
+++ b/app/chain/media.py
@@ -679,11 +679,19 @@ class MediaChain(ChainBase):
                                              overwrite=overwrite)
                 # 生成目录的nfo和图片
                 if init_folder:
+                    # TODO  目前的刮削是假定电视剧目录结构符合：/剧集根目录/季目录/剧集文件
+                    #       其中季目录应符合`Season 数字`等明确的季命名，不能用季标题
+                    #       例如：/Torchwood (2006)/Miracle Day/Torchwood (2006) S04E01.mkv
+                    #       当刮削到`Miracle Day`目录时，会误判其为剧集根目录
                     # 识别文件夹名称
                     season_meta = MetaInfo(filepath.name)
                     # 当前文件夹为Specials或者SPs时，设置为S0
                     if filepath.name in settings.RENAME_FORMAT_S0_NAMES:
                         season_meta.begin_season = 0
+                    elif season_meta.name and season_meta.begin_season is not None:
+                        # 当前目录含有非季目录的名称，但却有季信息(通常是被辅助识别词指定了)
+                        # 这种情况应该是剧集根目录，不能按季目录刮削，否则会导致`season_poster`的路径错误 详见issue#5373
+                        season_meta.begin_season = None
                     if season_meta.begin_season is not None:
                         # 检查季NFO开关
                         if scraping_switchs.get('season_nfo', True):
@@ -753,7 +761,8 @@ class MediaChain(ChainBase):
                                     else:
                                         logger.info(f"季图片刮削已关闭，跳过：{image_name}")
                     # 判断当前目录是不是剧集根目录
-                    if not season_meta.season:
+                    elif season_meta.name:
+                        # 不含季信息（包括特别季）但含有名称的，可以认为是剧集根目录 （原PR#3219对此的判断会遗漏被识别词指定成电视剧的根目录 详见issue#5373）
                         # 检查电视剧NFO开关
                         if scraping_switchs.get('tv_nfo', True):
                             # 是否已存在

--- a/app/modules/themoviedb/scraper.py
+++ b/app/modules/themoviedb/scraper.py
@@ -297,7 +297,8 @@ class TmdbScraper:
         uniqueid.setAttribute("type", "tmdb")
         uniqueid.setAttribute("default", "true")
         # tmdbid
-        DomUtils.add_node(doc, root, "tmdbid", str(tmdbid))
+        # 应与uniqueid一致 使用剧集id 否则jellyfin/emby会将此id覆盖上面的uniqueid
+        DomUtils.add_node(doc, root, "tmdbid", str(episodeinfo.get("id")))
         # 标题
         DomUtils.add_node(doc, root, "title", episodeinfo.get("name") or "第 %s 集" % episode)
         # 简介


### PR DESCRIPTION
- 解决了电视剧在配置了识别词后的漏判、错判问题， fix #5373
- 纠正剧集nfo文件的tmdbid值，避免潜在的冲突影响