### PR TITLE
feat(passkey): 允许在未开启 OTP 时注册通行密钥

### DIFF
--- a/app/api/endpoints/mfa.py
+++ b/app/api/endpoints/mfa.py
@@ -207,8 +207,8 @@ def passkey_register_start(
 ) -> Any:
     """开始注册 PassKey - 生成注册选项"""
     try:
-        # 安全检查：必须先启用 OTP
-        if not current_user.is_otp:
+        # 安全检查：默认需要先启用 OTP，除非配置允许在未启用 OTP 时注册
+        if not current_user.is_otp and not settings.PASSKEY_ALLOW_REGISTER_WITHOUT_OTP:
             return schemas.Response(
                 success=False,
                 message="为了确保在域名配置错误时仍能找回访问权限，请先启用 OTP 验证码再注册通行密钥"

--- a/app/api/endpoints/mfa.py
+++ b/app/api/endpoints/mfa.py
@@ -161,9 +161,9 @@ async def otp_disable(
     current_user: User = Depends(get_current_active_user_async)
 ) -> Any:
     """关闭当前用户的 OTP 验证功能"""
-    # 安全检查：如果存在 PassKey，不允许关闭 OTP
+    # 安全检查：如果存在 PassKey，默认不允许关闭 OTP，除非配置允许
     has_passkey = await _check_user_has_passkey(db, current_user.id)
-    if has_passkey:
+    if has_passkey and not settings.PASSKEY_ALLOW_REGISTER_WITHOUT_OTP:
         return schemas.Response(
             success=False,
             message="您已注册通行密钥，为了防止域名配置变更导致无法登录，请先删除所有通行密钥再关闭 OTP 验证"

--- a/app/api/endpoints/system.py
+++ b/app/api/endpoints/system.py
@@ -163,7 +163,8 @@ async def get_user_global_setting(_: User = Depends(get_current_active_user_asyn
         include={
             "RECOGNIZE_SOURCE",
             "SEARCH_SOURCE",
-            "AI_RECOMMEND_ENABLED"
+            "AI_RECOMMEND_ENABLED",
+            "PASSKEY_ALLOW_REGISTER_WITHOUT_OTP"
         }
     )
     # 智能助手总开关未开启，智能推荐状态强制返回False

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -393,6 +393,8 @@ class ConfigModel(BaseModel):
     SECURITY_IMAGE_SUFFIXES: list = Field(default=[".jpg", ".jpeg", ".png", ".webp", ".gif", ".svg", ".avif"])
     # PassKey 是否强制用户验证（生物识别等）
     PASSKEY_REQUIRE_UV: bool = True
+    # 允许在未启用 OTP 时直接注册 PassKey
+    PASSKEY_ALLOW_REGISTER_WITHOUT_OTP: bool = False
 
     # ==================== 工作流配置 ====================
     # 工作流数据共享


### PR DESCRIPTION
当环境变量`PASSKEY_ALLOW_REGISTER_WITHOUT_OTP`设置为`true`时，将允许在未开启 OTP 时注册通行密钥
关联：https://github.com/jxxghp/MoviePilot-Frontend/pull/434