### PR TITLE
继续完善文件整理功能

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -660,9 +660,6 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                         # 删除剩余空目录
                         StorageChain().delete_media_file(t.fileitem, delete_self=False)
 
-        # 清理作业
-        self.jobview.remove_job(task)
-
         return ret_status, ret_message
 
     def put_to_queue(self, task: TransferTask):

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -968,11 +968,14 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
 
             # 从下载器获取种子列表
             if torrents_list := self.list_torrents(status=TorrentStatus.TRANSFER):
+                seen = set()
                 existing_hashes = self.jobview.get_all_torrent_hashes()
                 torrents = [
                     torrent
                     for torrent in torrents_list
-                    if torrent.hash not in existing_hashes
+                    if (h := torrent.hash) not in existing_hashes
+                    # 排除多下载器返回的重复种子
+                    and (h not in seen and (seen.add(h) or True))
                 ]
             else:
                 torrents = []


### PR DESCRIPTION
- 因过早清理作业（上层`__handle_transfer`已经实现了正确清理），导致入库通知缺少集信息，可能还会造成下载器监控的重复整理
- 对于配置了多个相同下载器的场景，增加根据种子hash去重的过滤，避免重复整理相同的种子