### PR TITLE
修复 蓝光原盘整理成功后不刮削的问题

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -489,6 +489,9 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         """
         判断是否为主要媒体文件
         """
+        if fileitem.type == "dir":
+            # 蓝光原盘判断
+            return StorageChain().is_bluray_folder(fileitem)
         if not fileitem.extension:
             return False
         return True if f".{fileitem.extension.lower()}" in self._media_exts else False

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -150,10 +150,9 @@ class TransHandler:
                 if stream_fileitem := source_oper.get_item(
                         Path(fileitem.path) / "BDMV" / "STREAM"
                 ):
-                    fileitem.size = 0
-                    files = source_oper.list(stream_fileitem) or []
-                    for file in files:
-                        fileitem.size += file.size
+                    fileitem.size = sum(
+                        file.size for file in source_oper.list(stream_fileitem) or []
+                    )
                 # 整理目录
                 new_diritem, errmsg = self.__transfer_dir(fileitem=fileitem,
                                                           mediainfo=mediainfo,


### PR DESCRIPTION
在判断是否主要媒体文件时没有考虑到目录类型的`fileitem`