### PR TITLE
feat(transfer): 支持按条件查询订阅获取自定义识别词用于文件转移

### DIFF
--- a/app/chain/download.py
+++ b/app/chain/download.py
@@ -292,10 +292,6 @@ class DownloadChain(ChainBase):
 
             # 登记下载记录
             downloadhis = DownloadHistoryOper()
-            # 获取应用的识别词（如果有）
-            custom_words_str = None
-            if hasattr(_meta, 'apply_words') and _meta.apply_words:
-                custom_words_str = '\n'.join(_meta.apply_words)
             downloadhis.add(
                 path=download_path.as_posix(),
                 type=_media.type.value,
@@ -319,7 +315,6 @@ class DownloadChain(ChainBase):
                 date=time.strftime("%Y-%m-%d %H:%M:%S", time.localtime()),
                 media_category=_media.category,
                 episode_group=_media.episode_group,
-                custom_words=custom_words_str,
                 note={"source": source}
             )
 

--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -1119,6 +1119,19 @@ class SubscribeChain(ChainBase):
             })
             logger.info(f'{subscribe.name} 订阅元数据更新完成')
 
+    def get_subscribe_by_source(self, source: str) -> Optional[Subscribe]:
+        """
+        从来源获取订阅
+        """
+        source_keyword = self.parse_subscribe_source_keyword(source)
+        if not source_keyword:
+            return None
+        # 只保留需要的字段动态获取订阅
+        valid_fields = {k: v for k, v in source_keyword.items()
+                        if k in ["type", "season", "tmdbid", "doubanid", "bangumiid"]}
+        # 暂时不考虑订阅历史, 若有必要再添加
+        return SubscribeOper().get_by(**valid_fields)
+
     @staticmethod
     def follow():
         """
@@ -1828,8 +1841,9 @@ class SubscribeChain(ChainBase):
     def get_subscribe_source_keyword(subscribe: Subscribe) -> str:
         """
         构造用于订阅来源的关键字字符串
+
         :param subscribe: Subscribe 对象
-        :return: 格式化的订阅来源关键字字符串，格式为 "Subscribe|{...}"
+        :return str: 格式化的订阅来源关键字字符串，格式为 "Subscribe|{...}"
         """
         source_keyword = {
             'id': subscribe.id,
@@ -1844,3 +1858,24 @@ class SubscribeChain(ChainBase):
             'bangumiid': subscribe.bangumiid
         }
         return f"Subscribe|{json.dumps(source_keyword, ensure_ascii=False)}"
+
+    @staticmethod
+    def parse_subscribe_source_keyword(source_keyword_str: str) -> Optional[dict]:
+        """
+        解析订阅来源关键字字符串
+
+        :param source_keyword_str: 订阅来源关键字字符串，格式为 "Subscribe|{...}"
+        :return Dict: 如果解析失败则返回None
+        """
+        if not source_keyword_str or not source_keyword_str.startswith("Subscribe|"):
+            return None
+
+        try:
+            # 分割字符串获取JSON部分
+            json_part = source_keyword_str.split("|", 1)[1]
+            # 解析JSON字符串
+            source_keyword = json.loads(json_part)
+            return source_keyword
+        except (IndexError, json.JSONDecodeError, TypeError) as e:
+            logger.error(f"解析订阅来源关键字失败: {e}")
+            return None

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -10,6 +10,7 @@ from app import schemas
 from app.chain import ChainBase
 from app.chain.media import MediaChain
 from app.chain.storage import StorageChain
+from app.chain.subscribe import SubscribeChain
 from app.chain.tmdb import TmdbChain
 from app.core.config import settings, global_vars
 from app.core.context import MediaInfo
@@ -1222,7 +1223,10 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                 # 提前获取下载历史，以便获取自定义识别词
                 download_history = None
                 downloadhis = DownloadHistoryOper()
-                if bluray_dir:
+                if download_hash:
+                    # 先按hash查询
+                    download_history = downloadhis.get_by_hash(download_hash)
+                elif bluray_dir:
                     # 蓝光原盘，按目录名查询
                     download_history = downloadhis.get_by_path(file_path.as_posix())
                 else:
@@ -1231,14 +1235,14 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                     if download_file:
                         download_history = downloadhis.get_by_hash(download_file.download_hash)
 
-                # 获取自定义识别词
-                custom_words_list = None
-                if download_history and download_history.custom_words:
-                    custom_words_list = download_history.custom_words.split('\n')
-
                 if not meta:
-                    # 文件元数据（传入自定义识别词）
-                    file_meta = MetaInfoPath(file_path, custom_words=custom_words_list)
+                    subscribe_custom_words = None
+                    if download_history and isinstance(download_history.note, dict):
+                        # 使用source动态获取订阅
+                        subscribe = SubscribeChain().get_subscribe_by_source(download_history.note.get("source"))
+                        subscribe_custom_words = subscribe.custom_words.split("\n") if subscribe and subscribe.custom_words else None
+                    # 文件元数据(优先使用订阅识别词)
+                    file_meta = MetaInfoPath(file_path, custom_words=subscribe_custom_words)
                 else:
                     file_meta = meta
 

--- a/app/db/models/subscribe.py
+++ b/app/db/models/subscribe.py
@@ -227,6 +227,66 @@ class Subscribe(Base):
         )
         return result.scalars().first()
 
+    @classmethod
+    @db_query
+    def get_by(cls, db: Session, type: str, season: Optional[str] = None,
+                tmdbid: Optional[int] = None, doubanid: Optional[str] = None, bangumiid: Optional[str] = None):
+        """
+        根据条件查询订阅
+        """
+        # TMDBID
+        if tmdbid:
+            if season is not None:
+                result = db.query(cls).filter(
+                    cls.tmdbid == tmdbid, cls.type == type, cls.season == season
+                )
+            else:
+                result = db.query(cls).filter(cls.tmdbid == tmdbid, cls.type == type)
+        # 豆瓣ID
+        elif doubanid:
+            result = db.query(cls).filter(cls.doubanid == doubanid, cls.type == type)
+        # BangumiID
+        elif bangumiid:
+            result = db.query(cls).filter(cls.bangumiid == bangumiid, cls.type == type)
+        else:
+            return None
+
+        return result.first()
+
+    @classmethod
+    @async_db_query
+    async def async_get_by(cls, db: AsyncSession, type: str, season: Optional[str] = None,
+                tmdbid: Optional[int] = None, doubanid: Optional[str] = None, bangumiid: Optional[str] = None):
+        """
+        根据条件查询订阅
+        """
+        # TMDBID
+        if tmdbid:
+            if season is not None:
+                result = await db.execute(
+                    select(cls).filter(
+                        cls.tmdbid == tmdbid, cls.type == type, cls.season == season
+                    )
+                )
+            else:
+                result = await db.execute(
+                    select(cls).filter(cls.tmdbid == tmdbid, cls.type == type)
+                )
+        # 豆瓣ID
+        elif doubanid:
+            result = await db.execute(
+                select(cls).filter(cls.doubanid == doubanid, cls.type == type)
+            )
+        # BangumiID
+        elif bangumiid:
+            result = await db.execute(
+                select(cls).filter(cls.bangumiid == bangumiid, cls.type == type)
+            )
+        else:
+            return None
+
+        return result.scalars().first()
+
     @db_update
     def delete_by_tmdbid(self, db: Session, tmdbid: int, season: int):
         subscrbies = self.get_by_tmdbid(db, tmdbid, season)

--- a/app/db/subscribe_oper.py
+++ b/app/db/subscribe_oper.py
@@ -111,6 +111,20 @@ class SubscribeOper(DbOper):
         """
         return await Subscribe.async_get(self._db, rid=sid)
 
+    def get_by(self, type: str, season: Optional[str] = None, tmdbid: Optional[int] = None,
+               doubanid: Optional[str] = None, bangumiid: Optional[str] = None) -> Optional[Subscribe]:
+        """
+        根据条件查询订阅
+        """
+        return Subscribe.get_by(self._db, type, season, tmdbid, doubanid, bangumiid)
+
+    async def async_get_by(self, type: str, season: Optional[str] = None, tmdbid: Optional[int] = None,
+                           doubanid: Optional[str] = None, bangumiid: Optional[str] = None) -> Optional[Subscribe]:
+        """
+        根据条件查询订阅
+        """
+        return await Subscribe.async_get_by(self._db, type, season, tmdbid, doubanid, bangumiid)
+
     def list(self, state: Optional[str] = None) -> List[Subscribe]:
         """
         获取订阅列表


### PR DESCRIPTION
## 解决方案
- 添加订阅源关键词解析功能
- 添加 get_by 方法支持通过 type、season、tmdbid、doubanid、bangumiid 等条件查询订阅信息，同时提供同步和异步版本的方法实现
- 优化转移链中自定义识别词获取逻辑
- 将原来直接从下载历史获取自定义识别词的方式改为通过订阅源动态获取，优先使用订阅中的识别词配置

## 实现详情

### 1. 订阅源关键词解析
- 实现 parse_subscribe_source_keyword 和 get_subscribe_source_keyword 方法，用于解析和构造订阅源关键字
- 新增 get_subscribe_by_source 方法，支持从源关键字字符串获取订阅

### 2. 订阅查询功能
- 在 Subscribe 模型中添加 get_by 方法，支持多条件查询
- 提供同步和异步两个版本的实现

### 3. 转移链优化
- 从下载历史的 note 字段中提取订阅源信息
- 动态查询对应订阅获取自定义识别词
- 优先使用订阅中的识别词配置

## 优势

- **保证数据一致性**：始终使用订阅中的最新识别词配置，即使订阅配置后续发生更改也能反映到整理流程中
- **提高维护性**：集中管理自定义识别词，避免在多个地方维护相同数据
- **增强扩展性**：动态查询机制支持更灵活的业务需求
- **减少数据冗余**：不再需要在下载历史中存储识别词副本

> **注意**：暂未移除 #5379 中为 downloadhistory 表新增的 custom_words 字段

fixes: #5341