### PR TITLE
feat: 优化RSS订阅和网页抓取中发布日期(PubDate)的获取兼容性

### DIFF
--- a/app/helper/rss.py
+++ b/app/helper/rss.py
@@ -382,7 +382,10 @@ class RssHelper:
                                     size = int(size_attr)
 
                             # 发布日期
-                            pubdate_nodes = item.xpath('.//pubDate | .//published | .//updated')
+                            pubdate_nodes = item.xpath('./pubDate | ./published | ./updated')
+                            if not pubdate_nodes:
+                                pubdate_nodes = item.xpath('.//*[local-name()="pubDate"] | .//*[local-name()="published"] | .//*[local-name()="updated"]')
+
                             pubdate = ""
                             if pubdate_nodes and pubdate_nodes[0].text:
                                 pubdate = StringUtils.get_time(pubdate_nodes[0].text)

--- a/app/modules/indexer/spider/__init__.py
+++ b/app/modules/indexer/spider/__init__.py
@@ -428,6 +428,12 @@ class SiteSpider:
         if pubdate_str:
             pubdate_str = pubdate_str.replace('\n', ' ').strip()
         self.torrents_info['pubdate'] = self.__filter_text(pubdate_str, selector.get('filters'))
+        if self.torrents_info.get('pubdate'):
+            try:
+                if not isinstance(self.torrents_info['pubdate'], datetime.datetime):
+                    datetime.datetime.strptime(str(self.torrents_info['pubdate']), '%Y-%m-%d %H:%M:%S')
+            except (ValueError, TypeError):
+                self.torrents_info['pubdate'] = StringUtils.unify_datetime_str(str(self.torrents_info['pubdate']))
 
     def __get_date_elapsed(self, torrent: Any):
         # torrent date elapsed text


### PR DESCRIPTION
- `app/helper/rss.py`: 优化RSS解析，优先按RSS标准解析，并支持带命名空间的日期标签（如 pubDate/published/updated）。如Mikan返回的RSS中的PubDate带有命名空间：
```xml
<item>
  <guid isPermaLink="false">【粉羽社】[小哥斯拉的逆袭][66-96][1080p][HDRip]</guid>
  <link>https://mikanani.me/Home/Episode/5178f7d180aeb7fbc388f5fa8eace21e597de418</link>
  <title>【粉羽社】[小哥斯拉的逆袭][66-96][1080p][HDRip]</title>
  <description>【粉羽社】[小哥斯拉的逆袭][66-96][1080p][HDRip][779.3 MB]</description>
  <torrent xmlns="https://mikanani.me/0.1/">
    <link>https://mikanani.me/Home/Episode/5178f7d180aeb7fbc388f5fa8eace21e597de418</link>
    <contentLength>817155264</contentLength>
    <pubDate>2026-02-02T17:06:50.734132</pubDate>
  </torrent>
  <enclosure type="application/x-bittorrent" length="817155264" url="https://mikanani.me/Download/20260202/5178f7d180aeb7fbc388f5fa8eace21e597de418.torrent"/>
</item>
```
- `app/modules/indexer/spider/__init__.py`: 优化网页抓取，增加日期格式校验并对非标准格式进行自动归一化。如Mikan网站中的PubDate使用相对日期“今天 16:47”导致之前解析日期错误

**可能能解决部份情况的订阅不下载最新一集电视剧的问题？**