### PR TITLE
修复 整理时可能会误将不同影视文件识别为同一个影视剧的问题

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -1380,8 +1380,11 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
 
                 # 获取下载Hash
                 if download_history and (not downloader or not download_hash):
-                    downloader = download_history.downloader
-                    download_hash = download_history.download_hash
+                    _downloader = download_history.downloader
+                    _download_hash = download_history.download_hash
+                else:
+                    _downloader = downloader
+                    _download_hash = download_hash
 
                 # 后台整理
                 transfer_task = TransferTask(
@@ -1395,8 +1398,8 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                     scrape=scrape,
                     library_type_folder=library_type_folder,
                     library_category_folder=library_category_folder,
-                    downloader=downloader,
-                    download_hash=download_hash,
+                    downloader=_downloader,
+                    download_hash=_download_hash,
                     download_history=download_history,
                     manual=manual,
                     background=background


### PR DESCRIPTION
在待整理文件列表的循环体中，一旦`download_hash`参数被覆盖，后续文件均会以这个hash作为下载历史源。
修复方法是另外定义局部变量，避免覆盖传入的`download_hash`参数。