### PR TITLE
fix(telegram): 修复通知标题含特殊符号时异常显示**符号

### DIFF
--- a/app/modules/telegram/telegram.py
+++ b/app/modules/telegram/telegram.py
@@ -237,10 +237,14 @@ class Telegram:
             return False
 
         try:
-            if title and text:
-                caption = f"**{title}**\n{text}"
-            elif title:
-                caption = f"**{title}**"
+            # 标准化标题后再加粗，避免**符号被显示为文本
+            bold_title = (
+                f"**{standardize(title).removesuffix('\n')}**" if title else None
+            )
+            if bold_title and text:
+                caption = f"{bold_title}\n{text}"
+            elif bold_title:
+                caption = bold_title
             elif text:
                 caption = text
             else:


### PR DESCRIPTION
fix #5242