### PR TITLE
fix: 修复阿里云盘目录监控快照无法检测文件的问题

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -414,6 +414,8 @@ class ConfigModel(BaseModel):
     RCLONE_SNAPSHOT_CHECK_FOLDER_MODTIME: bool = True
     # 对OpenList进行快照对比时，是否检查文件夹的修改时间
     OPENLIST_SNAPSHOT_CHECK_FOLDER_MODTIME: bool = True
+    # 对阿里云盘进行快照对比时，是否检查文件夹的修改时间（默认关闭，因为阿里云盘目录时间不随子文件变更而更新）
+    ALIPAN_SNAPSHOT_CHECK_FOLDER_MODTIME: bool = False
 
     # ==================== Docker配置 ====================
     # Docker Client API地址

--- a/app/modules/filemanager/storages/__init__.py
+++ b/app/modules/filemanager/storages/__init__.py
@@ -261,13 +261,12 @@ class StorageBase(metaclass=ABCMeta):
                     for sub_file in sub_files:
                         __snapshot_file(sub_file, current_depth + 1)
                 else:
-                    # 记录文件的完整信息用于比对
-                    if getattr(_fileitm, 'modify_time', 0) > last_snapshot_time:
-                        files_info[_fileitm.path] = {
-                            'size': _fileitm.size or 0,
-                            'modify_time': getattr(_fileitm, 'modify_time', 0),
-                            'type': _fileitm.type
-                        }
+                    # 记录文件的完整信息用于比对（始终包含所有文件，由 compare_snapshots 负责检测变化）
+                    files_info[_fileitm.path] = {
+                        'size': _fileitm.size or 0,
+                        'modify_time': getattr(_fileitm, 'modify_time', 0),
+                        'type': _fileitm.type
+                    }
 
             except Exception as e:
                 logger.debug(f"Snapshot error for {_fileitm.path}: {e}")

--- a/app/modules/filemanager/storages/alipan.py
+++ b/app/modules/filemanager/storages/alipan.py
@@ -43,6 +43,9 @@ class AliPan(StorageBase, metaclass=WeakSingleton):
     # 基础url
     base_url = "https://openapi.alipan.com"
 
+    # 阿里云盘目录时间不随子文件变更而更新，默认关闭目录修改时间检查
+    snapshot_check_folder_modtime = settings.ALIPAN_SNAPSHOT_CHECK_FOLDER_MODTIME
+
     # 文件块大小，默认10MB
     chunk_size = 10 * 1024 * 1024
 


### PR DESCRIPTION
## Summary

修复阿里云盘（AliPan）存储的目录监控快照功能无法正确检测文件的两个问题：

- **为阿里云盘添加 `ALIPAN_SNAPSHOT_CHECK_FOLDER_MODTIME` 配置（默认 `False`）**：阿里云盘目录的 `updated_at` 不会随子文件变更而更新，导致增量快照始终跳过目录、快照结果为空。与 Rclone（`RCLONE_SNAPSHOT_CHECK_FOLDER_MODTIME`）和 Alist（`OPENLIST_SNAPSHOT_CHECK_FOLDER_MODTIME`）保持一致的配置模式。
- **移除 `snapshot()` 中文件级 `modify_time` 过滤**：原逻辑仅包含 `modify_time > last_snapshot_time` 的文件，而 `save_snapshot` 将 `timestamp` 设为 `max(modify_times)`，导致首次快照建立基准后，后续快照中未变更的文件因 `modify_time` 不大于 `timestamp` 而被排除，`compare_snapshots` 永远无法检测到变化。此外，当 `last_snapshot_time` 为 `None` 时，比较会触发 `TypeError` 并被静默捕获。

### 问题复现

1. 在阿里云盘监控目录中添加文件
2. 等待首次快照建立基准（文件被记录但不处理）
3. 等待后续快照——期望检测到新文件并自动整理
4. 实际结果：快照始终返回 0 个文件，文件永远不会被处理

### 根因分析

**问题一**：`AliPan` 类未覆盖 `snapshot_check_folder_modtime`（继承默认值 `True`），但阿里云盘的目录 `updated_at` 字段不会因子文件变更而更新。增量检查时目录的 `modify_time` 始终早于 `last_snapshot_time`，整个目录树被跳过。

**问题二**：`StorageBase.snapshot()` 中的文件级过滤 `modify_time > last_snapshot_time` 使快照变为"增量"模式（仅包含最近修改的文件），但 `compare_snapshots()` 期望的是完整快照（old 和 new 都包含所有文件）。首次快照后 `timestamp = max(modify_times)`，未变更文件的 `modify_time` 不大于此值而被排除，导致 `compare_snapshots(old={file: info}, new={})` 检测不到任何新增或修改。

## Test plan

- [ ] 在阿里云盘监控目录添加新文件，验证可被自动检测和整理
- [ ] 验证 Rclone、Alist 等其他存储类型的目录监控不受影响
- [ ] 验证 `ALIPAN_SNAPSHOT_CHECK_FOLDER_MODTIME` 可通过 `app.env` 配置

🤖 Generated with [Claude Code](https://claude.com/claude-code)