### PR TITLE
fix(ProgressHelper): 整理队列多任务进度显示跳变问题

### DIFF
--- a/app/helper/progress.py
+++ b/app/helper/progress.py
@@ -3,10 +3,9 @@ from typing import Union, Optional
 
 from app.core.cache import TTLCache
 from app.schemas.types import ProgressKey
-from app.utils.singleton import WeakSingleton
 
 
-class ProgressHelper(metaclass=WeakSingleton):
+class ProgressHelper:
     """
     处理进度辅助类
     """


### PR DESCRIPTION
### 背景

之前`ProgressHelper`被实现为单例模式。由于`WeakSingleton`在实例化时忽略了传入的参数，无论传入什么key，返回的都是第一个创建的`ProgressHelper`实例。这会导致进度信息相互覆盖，前端显示的进度条会跳变或显示错误任务的状态。

### 改动

移除了`ProgressHelper`类上的`WeakSingleton`元类。