### PR TITLE
fix(message): fallback Telegram username to string userid when absent

### DIFF
--- a/app/chain/message.py
+++ b/app/chain/message.py
@@ -112,8 +112,8 @@ class MessageChain(ChainBase):
         channel = info.channel
         # 用户ID
         userid = info.userid
-        # 用户名
-        username = info.username or userid
+        # 用户名（当渠道未提供公开用户名时，回退为 userid 的字符串，避免后续类型校验异常）
+        username = str(info.username) if info.username not in (None, "") else str(userid)
         if userid is None or userid == '':
             logger.debug(f'未识别到用户ID：{body}{form}{args}')
             return


### PR DESCRIPTION
Summary

Fixes a crash scenario when Telegram users do not have a public @username (related to issue #5211).

In message parsing flow, username previously fell back to userid directly.
For Telegram callbacks/messages, userid is often numeric, which may cause downstream strict type handling/validation issues.

This PR normalizes fallback behavior to always use string type:
username = str(info.username) if info.username not in (None, "") else str(userid)
What changed

• File: app/chain/message.py
• Updated username fallback logic to ensure username is always a string.

Why this is safe

• Keeps original behavior (fallback to userid when username is missing)
• Only enforces type consistency (str)
• No behavior change for users who already have Telegram username set

Verification

• Static syntax check passed: python -m py_compile app/chain/message.py
• Branch tested and pushed from fork:
• fix-issue-5211-telegram-username-fallback
• commit: 57f5a19