### PR TITLE
fix(transfer): support "自动" media type in manual organize API

### DIFF
--- a/app/api/endpoints/transfer.py
+++ b/app/api/endpoints/transfer.py
@@ -138,8 +138,15 @@ def manual_transfer(transer_item: ManualTransferItem,
     else:
         return schemas.Response(success=False, message=f"缺少参数")
 
-    # 类型
-    mtype = MediaType(transer_item.type_name) if transer_item.type_name else None
+    # 类型（“自动/auto”按未指定处理）
+    mtype = None
+    if transer_item.type_name:
+        type_name = str(transer_item.type_name).strip().lower()
+        if type_name not in ["自动", "auto", "none", ""]:
+            try:
+                mtype = MediaType(transer_item.type_name)
+            except Exception:
+                return schemas.Response(success=False, message=f"不支持的媒体类型：{transer_item.type_name}")
     # 自定义格式
     epformat = None
     if transer_item.episode_offset or transer_item.episode_part \

--- a/app/api/endpoints/transfer.py
+++ b/app/api/endpoints/transfer.py
@@ -138,15 +138,14 @@ def manual_transfer(transer_item: ManualTransferItem,
     else:
         return schemas.Response(success=False, message=f"缺少参数")
 
-    # 类型（“自动/auto”按未指定处理）
+    # 类型（“自动/auto/none”按未指定处理）
     mtype = None
-    if transer_item.type_name:
-        type_name = str(transer_item.type_name).strip().lower()
-        if type_name not in ["自动", "auto", "none", ""]:
-            try:
-                mtype = MediaType(transer_item.type_name)
-            except Exception:
-                return schemas.Response(success=False, message=f"不支持的媒体类型：{transer_item.type_name}")
+    type_name = str(transer_item.type_name).strip() if transer_item.type_name else ""
+    if type_name and type_name.lower() not in {"自动", "auto", "none"}:
+        try:
+            mtype = MediaType(type_name)
+        except ValueError:
+            return schemas.Response(success=False, message=f"不支持的媒体类型：{type_name}")
     # 自定义格式
     epformat = None
     if transer_item.episode_offset or transer_item.episode_part \


### PR DESCRIPTION
## Summary
Fix manual organize failure when media type is set to "自动" in UI/API.

## Problem
`/api/v1/transfer/manual` converts `type_name` directly with `MediaType(type_name)`.
When users choose "自动" (auto), it is not a valid enum value, causing conversion error and manual organize failure.

## Changes
- In manual transfer endpoint:
  - treat `自动/auto/none` as unspecified type (`None`)
  - keep existing enum conversion for explicit values (`电影`/`电视剧`)
  - return a clear error message for truly unsupported type values

This keeps auto-recognition behavior while preserving validation for invalid inputs.

Closes #5508