### PR TITLE
fix(meta): 正确匹配 Sxx 季信息

### DIFF
--- a/app/core/meta/metavideo.py
+++ b/app/core/meta/metavideo.py
@@ -76,7 +76,7 @@ class MetaVideo(MetaBase):
             self.type = MediaType.TV
             return
         # 全名为Season xx 及 Sxx 直接返回
-        season_full_res = re.search(r"^(?:Season\s+|S)(\d{1,3})$", title)
+        season_full_res = re.search(r"^(?:Season\s+|S)(\d{1,3})$", title, re.IGNORECASE)
         if season_full_res:
             self.type = MediaType.TV
             season = season_full_res.group(1)

--- a/app/core/meta/metavideo.py
+++ b/app/core/meta/metavideo.py
@@ -76,7 +76,7 @@ class MetaVideo(MetaBase):
             self.type = MediaType.TV
             return
         # 全名为Season xx 及 Sxx 直接返回
-        season_full_res = re.search(r"^Season\s+(\d{1,3})$|^S(\d{1,3})$", title)
+        season_full_res = re.search(r"^(?:Season\s+|S)(\d{1,3})$", title)
         if season_full_res:
             self.type = MediaType.TV
             season = season_full_res.group(1)

--- a/tests/cases/meta.py
+++ b/tests/cases/meta.py
@@ -1070,6 +1070,38 @@ meta_cases = [{
         "tmdbid": 27205
     }
 }, {
+    "path": "/movies/Breaking Bad (2008) [tmdb=1396]/Season 2/",
+    "target": {
+        "type": "电视剧",
+        "cn_name": "",
+        "en_name": "Breaking Bad",
+        "year": "2008",
+        "part": "",
+        "season": "S02",
+        "episode": "",
+        "restype": "",
+        "pix": "",
+        "video_codec": "",
+        "audio_codec": "",
+        "tmdbid": 1396
+    }
+}, {
+    "path": "/movies/Breaking Bad (2008) [tmdb=1396]/S2/",
+    "target": {
+        "type": "电视剧",
+        "cn_name": "",
+        "en_name": "Breaking Bad",
+        "year": "2008",
+        "part": "",
+        "season": "S02",
+        "episode": "",
+        "restype": "",
+        "pix": "",
+        "video_codec": "",
+        "audio_codec": "",
+        "tmdbid": 1396
+    }
+}, {
     "path": "/movies/Breaking Bad (2008) [tmdb=1396]/Season 1/Breaking.Bad.S01E01.1080p.mkv",
     "target": {
         "type": "电视剧",


### PR DESCRIPTION
现有代码仅捕获正则表达式的第一个分组内容，导致用于匹配 Sxx 格式的第二个分组无法正确提取。
本次修改将两个分组合并为一个捕获组，确保后续逻辑能正确处理。