### PR TITLE
feat: 新增优先使用插件识别的功能

### DIFF
--- a/app/api/endpoints/download.py
+++ b/app/api/endpoints/download.py
@@ -78,21 +78,12 @@ def add(
     # 元数据
     metainfo = MetaInfo(title=torrent_in.title, subtitle=torrent_in.description)
     # 媒体信息
-    mediainfo: MediaInfo = None
-    plugin_available = eventmanager.check(ChainEventType.NameRecognize)
-    # 定义识别函数
-    native_recognize = lambda: MediaChain().recognize_media(meta=metainfo, tmdbid=tmdbid, doubanid=doubanid)
-    plugin_recognize = lambda: MediaChain().recognize_help(title=torrent_in.title, org_meta=metainfo)
-    if settings.RECOGNIZE_PLUGIN_FIRST and plugin_available:
-        # 插件优先
-        mediainfo = plugin_recognize()
-        if not mediainfo:
-            mediainfo = native_recognize()
-    else:
-        # 原生优先
-        mediainfo = native_recognize()
-        if not mediainfo and plugin_available:
-            mediainfo = plugin_recognize()
+    mediainfo = MediaChain().select_recognize_source(
+                    log_name=torrent_in.title,
+                    log_context=torrent_in.title,
+                    native_fn=lambda: MediaChain().recognize_media(meta=metainfo, tmdbid=tmdbid, doubanid=doubanid),
+                    plugin_fn=lambda: MediaChain().recognize_help(title=torrent_in.title, org_meta=metainfo)
+                )
     if not mediainfo:
         return schemas.Response(success=False, message="无法识别媒体信息")
     # 种子信息

--- a/app/api/endpoints/download.py
+++ b/app/api/endpoints/download.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, Body
 from app import schemas
 from app.chain.download import DownloadChain
 from app.chain.media import MediaChain
+from app.core.config import settings
 from app.core.context import MediaInfo, Context, TorrentInfo
 from app.core.event import eventmanager
 from app.core.metainfo import MetaInfo
@@ -77,13 +78,24 @@ def add(
     # 元数据
     metainfo = MetaInfo(title=torrent_in.title, subtitle=torrent_in.description)
     # 媒体信息
-    mediainfo = MediaChain().recognize_media(meta=metainfo, tmdbid=tmdbid, doubanid=doubanid)
-    if not mediainfo:
-        # 尝试使用辅助识别，如果有注册响应事件的话
-        if eventmanager.check(ChainEventType.NameRecognize):
-            mediainfo = MediaChain().recognize_help(title=torrent_in.title, org_meta=metainfo)
+    mediainfo: MediaInfo = None
+    if settings.RECOGNIZE_PLUGIN_FIRST and eventmanager.check(ChainEventType.NameRecognize):
+        # 插件优先模式：优先使用辅助识别
+        mediainfo = MediaChain().recognize_help(title=torrent_in.title, org_meta=metainfo)
         if not mediainfo:
-            return schemas.Response(success=False, message="无法识别媒体信息")
+            # 尝试使用原生识别
+            mediainfo = MediaChain().recognize_media(meta=metainfo, tmdbid=tmdbid, doubanid=doubanid)
+            if not mediainfo:
+                return schemas.Response(success=False, message="无法识别媒体信息")
+    else:
+        # 标准模式：优先使用原生识别
+        mediainfo = MediaChain().recognize_media(meta=metainfo, tmdbid=tmdbid, doubanid=doubanid)
+        if not mediainfo:
+            # 尝试使用辅助识别，如果有注册响应事件的话
+            if eventmanager.check(ChainEventType.NameRecognize):
+                mediainfo = MediaChain().recognize_help(title=torrent_in.title, org_meta=metainfo)
+            if not mediainfo:
+                return schemas.Response(success=False, message="无法识别媒体信息")
     # 种子信息
     torrentinfo = TorrentInfo()
     torrentinfo.from_dict(torrent_in.model_dump())

--- a/app/api/endpoints/download.py
+++ b/app/api/endpoints/download.py
@@ -79,23 +79,22 @@ def add(
     metainfo = MetaInfo(title=torrent_in.title, subtitle=torrent_in.description)
     # 媒体信息
     mediainfo: MediaInfo = None
-    if settings.RECOGNIZE_PLUGIN_FIRST and eventmanager.check(ChainEventType.NameRecognize):
-        # 插件优先模式：优先使用辅助识别
-        mediainfo = MediaChain().recognize_help(title=torrent_in.title, org_meta=metainfo)
+    plugin_available = eventmanager.check(ChainEventType.NameRecognize)
+    # 定义识别函数
+    native_recognize = lambda: MediaChain().recognize_media(meta=metainfo, tmdbid=tmdbid, doubanid=doubanid)
+    plugin_recognize = lambda: MediaChain().recognize_help(title=torrent_in.title, org_meta=metainfo)
+    if settings.RECOGNIZE_PLUGIN_FIRST and plugin_available:
+        # 插件优先
+        mediainfo = plugin_recognize()
         if not mediainfo:
-            # 尝试使用原生识别
-            mediainfo = MediaChain().recognize_media(meta=metainfo, tmdbid=tmdbid, doubanid=doubanid)
-            if not mediainfo:
-                return schemas.Response(success=False, message="无法识别媒体信息")
+            mediainfo = native_recognize()
     else:
-        # 标准模式：优先使用原生识别
-        mediainfo = MediaChain().recognize_media(meta=metainfo, tmdbid=tmdbid, doubanid=doubanid)
-        if not mediainfo:
-            # 尝试使用辅助识别，如果有注册响应事件的话
-            if eventmanager.check(ChainEventType.NameRecognize):
-                mediainfo = MediaChain().recognize_help(title=torrent_in.title, org_meta=metainfo)
-            if not mediainfo:
-                return schemas.Response(success=False, message="无法识别媒体信息")
+        # 原生优先
+        mediainfo = native_recognize()
+        if not mediainfo and plugin_available:
+            mediainfo = plugin_recognize()
+    if not mediainfo:
+        return schemas.Response(success=False, message="无法识别媒体信息")
     # 种子信息
     torrentinfo = TorrentInfo()
     torrentinfo.from_dict(torrent_in.model_dump())

--- a/app/chain/media.py
+++ b/app/chain/media.py
@@ -91,28 +91,27 @@ class MediaChain(ChainBase):
         """
         title = metainfo.title
         mediainfo: MediaInfo = None
-        if settings.RECOGNIZE_PLUGIN_FIRST and eventmanager.check(ChainEventType.NameRecognize):
-            # 插件优先模式：优先使用辅助识别
+        plugin_available = eventmanager.check(ChainEventType.NameRecognize)
+        # 定义识别函数
+        native_recognize = lambda: self.recognize_media(meta=metainfo, episode_group=episode_group)
+        plugin_recognize = lambda: self.recognize_help(title=title, org_meta=metainfo)
+        if settings.RECOGNIZE_PLUGIN_FIRST and plugin_available:
+            # 插件优先
             logger.info(f"插件优先模式已开启。请求辅助识别，标题：{title} ...")
-            mediainfo = self.recognize_help(title=title, org_meta=metainfo)
+            mediainfo = plugin_recognize()
             if not mediainfo:
-                # 尝试使用原生识别
                 logger.info(f'辅助识别未识别到 {title} 的媒体信息，尝试使用原生识别')
-                mediainfo = self.recognize_media(meta=metainfo, episode_group=episode_group)
-                if not mediainfo:
-                    logger.warn(f'{title} 未识别到媒体信息')
-                    return None
+                mediainfo = native_recognize()
         else:
-            # 标准模式：优先使用原生识别
-            mediainfo = self.recognize_media(meta=metainfo, episode_group=episode_group)
-            if not mediainfo:
-                # 尝试使用辅助识别，如果有注册响应事件的话
-                if eventmanager.check(ChainEventType.NameRecognize):
-                    logger.info(f'请求辅助识别，标题：{title} ...')
-                    mediainfo = self.recognize_help(title=title, org_meta=metainfo)
-                if not mediainfo:
-                    logger.warn(f'{title} 未识别到媒体信息')
-                    return None
+            # 原生优先
+            logger.info(f"插件优先模式未开启。尝试原生识别，标题：{title} ...")
+            mediainfo = native_recognize()
+            if not mediainfo and plugin_available:
+                logger.info(f'原生识别未识别到 {title} 的媒体信息，尝试使用辅助识别')
+                mediainfo = plugin_recognize()
+        if not mediainfo:
+            logger.warn(f'{title} 未识别到媒体信息')
+            return None
         # 识别成功
         logger.info(f'{title} 识别到媒体信息：{mediainfo.type.value} {mediainfo.title_year}')
         # 更新媒体图片
@@ -177,28 +176,27 @@ class MediaChain(ChainBase):
         # 元数据
         file_meta = MetaInfoPath(file_path)
         mediainfo: MediaInfo = None
-        if settings.RECOGNIZE_PLUGIN_FIRST and eventmanager.check(ChainEventType.NameRecognize):
-            # 插件优先模式：优先使用辅助识别
+        plugin_available = eventmanager.check(ChainEventType.NameRecognize)
+        # 定义识别函数
+        native_recognize = lambda: self.recognize_media(meta=file_meta, episode_group=episode_group)
+        plugin_recognize = lambda: self.recognize_help(title=path, org_meta=file_meta)
+        if settings.RECOGNIZE_PLUGIN_FIRST and plugin_available:
+            # 插件优先
             logger.info(f"插件优先模式已开启。请求辅助识别，标题：{file_path.name} ...")
-            mediainfo = self.recognize_help(title=path, org_meta=file_meta)
+            mediainfo = plugin_recognize()
             if not mediainfo:
-                # 尝试使用原生识别
                 logger.info(f'辅助识别未识别到 {path} 的媒体信息，尝试使用原生识别')
-                mediainfo = self.recognize_media(meta=file_meta, episode_group=episode_group)
-                if not mediainfo:
-                    logger.warn(f'{path} 未识别到媒体信息')
-                    return Context(meta_info=file_meta)
+                mediainfo = native_recognize()
         else:
-            # 标准模式：优先使用原生识别
-            mediainfo = self.recognize_media(meta=file_meta, episode_group=episode_group)
-            if not mediainfo:
-                # 尝试使用辅助识别，如果有注册响应事件的话
-                if eventmanager.check(ChainEventType.NameRecognize):
-                    logger.info(f'请求辅助识别，标题：{file_path.name} ...')
-                    mediainfo = self.recognize_help(title=path, org_meta=file_meta)
-                if not mediainfo:
-                    logger.warn(f'{path} 未识别到媒体信息')
-                    return Context(meta_info=file_meta)
+            # 原生优先
+            logger.info(f"插件优先模式未开启。尝试原生识别，标题：{file_path.name} ...")
+            mediainfo = native_recognize()
+            if not mediainfo and plugin_available:
+                logger.info(f'原生识别未识别到 {path} 的媒体信息，尝试使用辅助识别')
+                mediainfo = plugin_recognize()
+        if not mediainfo:
+            logger.warn(f'{path} 未识别到媒体信息')
+            return Context(meta_info=file_meta)
         logger.info(f'{path} 识别到媒体信息：{mediainfo.type.value} {mediainfo.title_year}')
         # 更新媒体图片
         self.obtain_images(mediainfo=mediainfo)
@@ -853,28 +851,29 @@ class MediaChain(ChainBase):
         """
         title = metainfo.title
         mediainfo: MediaInfo = None
-        if settings.RECOGNIZE_PLUGIN_FIRST and eventmanager.check(ChainEventType.NameRecognize):
-            # 插件优先模式：优先使用辅助识别
+        plugin_available = eventmanager.check(ChainEventType.NameRecognize)
+        # 定义识别函数
+        async def native_recognize():
+            return await self.async_recognize_media(meta=metainfo, episode_group=episode_group)
+        async def plugin_recognize():
+            return await self.async_recognize_help(title=title, org_meta=metainfo)
+        if settings.RECOGNIZE_PLUGIN_FIRST and plugin_available:
+            # 插件优先
             logger.info(f"插件优先模式已开启。请求辅助识别，标题：{title} ...")
-            mediainfo = await self.async_recognize_help(title=title, org_meta=metainfo)
+            mediainfo = plugin_recognize()
             if not mediainfo:
-                # 尝试使用原生识别
                 logger.info(f'辅助识别未识别到 {title} 的媒体信息，尝试使用原生识别')
-                mediainfo = await self.async_recognize_media(meta=metainfo, episode_group=episode_group)
-                if not mediainfo:
-                    logger.warn(f'{title} 未识别到媒体信息')
-                    return None
+                mediainfo = native_recognize()
         else:
-            # 标准模式：优先使用原生识别
-            mediainfo = await self.async_recognize_media(meta=metainfo, episode_group=episode_group)
-            if not mediainfo:
-                # 尝试使用辅助识别，如果有注册响应事件的话
-                if eventmanager.check(ChainEventType.NameRecognize):
-                    logger.info(f'请求辅助识别，标题：{title} ...')
-                    mediainfo = await self.async_recognize_help(title=title, org_meta=metainfo)
-                if not mediainfo:
-                    logger.warn(f'{title} 未识别到媒体信息')
-                    return None
+            # 原生优先
+            logger.info(f"插件优先模式未开启。尝试原生识别，标题：{title} ...")
+            mediainfo = native_recognize()
+            if not mediainfo and plugin_available:
+                logger.info(f'原生识别未识别到 {title} 的媒体信息，尝试使用辅助识别')
+                mediainfo = plugin_recognize()
+        if not mediainfo:
+            logger.warn(f'{title} 未识别到媒体信息')
+            return None
         # 识别成功
         logger.info(f'{title} 识别到媒体信息：{mediainfo.type.value} {mediainfo.title_year}')
         # 更新媒体图片
@@ -939,28 +938,29 @@ class MediaChain(ChainBase):
         # 元数据
         file_meta = MetaInfoPath(file_path)
         mediainfo: MediaInfo = None
-        if settings.RECOGNIZE_PLUGIN_FIRST and eventmanager.check(ChainEventType.NameRecognize):
-            # 插件优先模式：优先使用辅助识别
+        plugin_available = eventmanager.check(ChainEventType.NameRecognize)
+        # 定义识别函数
+        async def native_recognize():
+            return await self.async_recognize_media(meta=file_meta, episode_group=episode_group)
+        async def plugin_recognize():
+            return await self.async_recognize_help(title=path, org_meta=file_meta)
+        if settings.RECOGNIZE_PLUGIN_FIRST and plugin_available:
+            # 插件优先
             logger.info(f"插件优先模式已开启。请求辅助识别，标题：{file_path.name} ...")
-            mediainfo = await self.async_recognize_help(title=path, org_meta=file_meta)
+            mediainfo = plugin_recognize()
             if not mediainfo:
-                # 尝试使用原生识别
                 logger.info(f'辅助识别未识别到 {path} 的媒体信息，尝试使用原生识别')
-                mediainfo = await self.async_recognize_media(meta=file_meta, episode_group=episode_group)
-                if not mediainfo:
-                    logger.warn(f'{path} 未识别到媒体信息')
-                    return Context(meta_info=file_meta)
+                mediainfo = native_recognize()
         else:
-            # 标准模式：优先使用原生识别
-            mediainfo = await self.async_recognize_media(meta=file_meta, episode_group=episode_group)
-            if not mediainfo:
-                # 尝试使用辅助识别，如果有注册响应事件的话
-                if eventmanager.check(ChainEventType.NameRecognize):
-                    logger.info(f'请求辅助识别，标题：{file_path.name} ...')
-                    mediainfo = await self.async_recognize_help(title=path, org_meta=file_meta)
-                if not mediainfo:
-                    logger.warn(f'{path} 未识别到媒体信息')
-                    return Context(meta_info=file_meta)
+            # 原生优先
+            logger.info(f"插件优先模式未开启。尝试原生识别，标题：{file_path.name} ...")
+            mediainfo = native_recognize()
+            if not mediainfo and plugin_available:
+                logger.info(f'原生识别未识别到 {path} 的媒体信息，尝试使用辅助识别')
+                mediainfo = plugin_recognize()
+        if not mediainfo:
+            logger.warn(f'{path} 未识别到媒体信息')
+            return Context(meta_info=file_meta)
         logger.info(f'{path} 识别到媒体信息：{mediainfo.type.value} {mediainfo.title_year}')
         # 更新媒体图片
         await self.async_obtain_images(mediainfo=mediainfo)

--- a/app/chain/media.py
+++ b/app/chain/media.py
@@ -85,30 +85,45 @@ class MediaChain(ChainBase):
         """
         return self.run_module("metadata_nfo", meta=meta, mediainfo=mediainfo, season=season, episode=episode)
 
+    def _select_recognize_source(self, log_name: str, log_context: str,
+                                 native_fn, plugin_fn) -> Optional[MediaInfo]:
+        """
+        选择识别模式，插件优先或原生优先
+        :param log_name: 用于日志“标题：...”处的名称（如 file_path.name 或 title）
+        :param log_context: 用于日志“未识别到...的媒体信息”处的上下文（如 path 或 title）
+        :param native_fn: 原生识别函数
+        :param plugin_fn: 插件识别函数
+        """
+        mediainfo = None
+        plugin_available = eventmanager.check(ChainEventType.NameRecognize)
+        if settings.RECOGNIZE_PLUGIN_FIRST and plugin_available:
+            # 插件优先
+            logger.info(f"插件优先模式已开启。请求辅助识别，标题：{log_name} ...")
+            mediainfo = plugin_fn()
+            if not mediainfo:
+                logger.info(f'辅助识别未识别到 {log_context} 的媒体信息，尝试使用原生识别')
+                mediainfo = native_fn()
+        else:
+            # 原生优先
+            logger.info(f"插件优先模式未开启。尝试原生识别，标题：{log_name} ...")
+            mediainfo = native_fn()
+            if not mediainfo and plugin_available:
+                logger.info(f'原生识别未识别到 {log_context} 的媒体信息，尝试使用辅助识别')
+                mediainfo = plugin_fn()    
+        return mediainfo
+
     def recognize_by_meta(self, metainfo: MetaBase, episode_group: Optional[str] = None) -> Optional[MediaInfo]:
         """
         根据主副标题识别媒体信息
         """
         title = metainfo.title
-        mediainfo: MediaInfo = None
-        plugin_available = eventmanager.check(ChainEventType.NameRecognize)
-        # 定义识别函数
-        native_recognize = lambda: self.recognize_media(meta=metainfo, episode_group=episode_group)
-        plugin_recognize = lambda: self.recognize_help(title=title, org_meta=metainfo)
-        if settings.RECOGNIZE_PLUGIN_FIRST and plugin_available:
-            # 插件优先
-            logger.info(f"插件优先模式已开启。请求辅助识别，标题：{title} ...")
-            mediainfo = plugin_recognize()
-            if not mediainfo:
-                logger.info(f'辅助识别未识别到 {title} 的媒体信息，尝试使用原生识别')
-                mediainfo = native_recognize()
-        else:
-            # 原生优先
-            logger.info(f"插件优先模式未开启。尝试原生识别，标题：{title} ...")
-            mediainfo = native_recognize()
-            if not mediainfo and plugin_available:
-                logger.info(f'原生识别未识别到 {title} 的媒体信息，尝试使用辅助识别')
-                mediainfo = plugin_recognize()
+         # 按 config 中设置的识别顺序识别
+        mediainfo = self._select_recognize_source(
+                        log_name=title,
+                        log_context=title,
+                        native_fn=lambda: self.recognize_media(meta=metainfo, episode_group=episode_group),
+                        plugin_fn=lambda: self.recognize_help(title=title, org_meta=metainfo)
+                    )
         if not mediainfo:
             logger.warn(f'{title} 未识别到媒体信息')
             return None
@@ -175,25 +190,13 @@ class MediaChain(ChainBase):
         file_path = Path(path)
         # 元数据
         file_meta = MetaInfoPath(file_path)
-        mediainfo: MediaInfo = None
-        plugin_available = eventmanager.check(ChainEventType.NameRecognize)
-        # 定义识别函数
-        native_recognize = lambda: self.recognize_media(meta=file_meta, episode_group=episode_group)
-        plugin_recognize = lambda: self.recognize_help(title=path, org_meta=file_meta)
-        if settings.RECOGNIZE_PLUGIN_FIRST and plugin_available:
-            # 插件优先
-            logger.info(f"插件优先模式已开启。请求辅助识别，标题：{file_path.name} ...")
-            mediainfo = plugin_recognize()
-            if not mediainfo:
-                logger.info(f'辅助识别未识别到 {path} 的媒体信息，尝试使用原生识别')
-                mediainfo = native_recognize()
-        else:
-            # 原生优先
-            logger.info(f"插件优先模式未开启。尝试原生识别，标题：{file_path.name} ...")
-            mediainfo = native_recognize()
-            if not mediainfo and plugin_available:
-                logger.info(f'原生识别未识别到 {path} 的媒体信息，尝试使用辅助识别')
-                mediainfo = plugin_recognize()
+         # 按 config 中设置的识别顺序识别
+        mediainfo = self._select_recognize_source(
+                        log_name=file_path.name,
+                        log_context=path,
+                        native_fn=lambda: self.recognize_media(meta=file_meta, episode_group=episode_group),
+                        plugin_fn=lambda: self.recognize_help(title=path, org_meta=file_meta)
+                    )
         if not mediainfo:
             logger.warn(f'{path} 未识别到媒体信息')
             return Context(meta_info=file_meta)
@@ -844,33 +847,51 @@ class MediaChain(ChainBase):
                         logger.warn("无法识别元数据，跳过")
         logger.info(f"{filepath.name} 刮削完成")
 
+    async def _async_select_recognize_source(self, log_name: str, log_context: str,
+                                             native_fn, plugin_fn) -> Optional[MediaInfo]:
+        """
+        选择识别模式，插件优先或原生优先（异步版本）
+        :param log_name: 用于日志“标题：...”处的名称（如 file_path.name 或 title）
+        :param log_context: 用于日志“未识别到...的媒体信息”处的上下文（如 path 或 title）
+        :param native_fn: 原生识别函数
+        :param plugin_fn: 插件识别函数
+        """
+        mediainfo = None
+        plugin_available = eventmanager.check(ChainEventType.NameRecognize)
+        if settings.RECOGNIZE_PLUGIN_FIRST and plugin_available:
+            # 插件优先
+            logger.info(f"插件优先模式已开启。请求辅助识别，标题：{log_name} ...")
+            mediainfo = await plugin_fn()
+            if not mediainfo:
+                logger.info(f'辅助识别未识别到 {log_context} 的媒体信息，尝试使用原生识别')
+                mediainfo = await native_fn()
+        else:
+            # 原生优先
+            logger.info(f"插件优先模式未开启。尝试原生识别，标题：{log_name} ...")
+            mediainfo = await native_fn()
+            if not mediainfo and plugin_available:
+                logger.info(f'原生识别未识别到 {log_context} 的媒体信息，尝试使用辅助识别')
+                mediainfo = await plugin_fn()    
+        return mediainfo
+    
     async def async_recognize_by_meta(self, metainfo: MetaBase,
                                       episode_group: Optional[str] = None) -> Optional[MediaInfo]:
         """
         根据主副标题识别媒体信息（异步版本）
         """
         title = metainfo.title
-        mediainfo: MediaInfo = None
-        plugin_available = eventmanager.check(ChainEventType.NameRecognize)
         # 定义识别函数
         async def native_recognize():
             return await self.async_recognize_media(meta=metainfo, episode_group=episode_group)
         async def plugin_recognize():
             return await self.async_recognize_help(title=title, org_meta=metainfo)
-        if settings.RECOGNIZE_PLUGIN_FIRST and plugin_available:
-            # 插件优先
-            logger.info(f"插件优先模式已开启。请求辅助识别，标题：{title} ...")
-            mediainfo = await plugin_recognize()
-            if not mediainfo:
-                logger.info(f'辅助识别未识别到 {title} 的媒体信息，尝试使用原生识别')
-                mediainfo = await native_recognize()
-        else:
-            # 原生优先
-            logger.info(f"插件优先模式未开启。尝试原生识别，标题：{title} ...")
-            mediainfo = await native_recognize()
-            if not mediainfo and plugin_available:
-                logger.info(f'原生识别未识别到 {title} 的媒体信息，尝试使用辅助识别')
-                mediainfo = await plugin_recognize()
+        # 按 config 中设置的识别顺序识别
+        mediainfo = await self._async_select_recognize_source(
+                              log_name=title,
+                              log_context=title,
+                              native_fn=native_recognize,
+                              plugin_fn=plugin_recognize
+                          )
         if not mediainfo:
             logger.warn(f'{title} 未识别到媒体信息')
             return None
@@ -937,27 +958,18 @@ class MediaChain(ChainBase):
         file_path = Path(path)
         # 元数据
         file_meta = MetaInfoPath(file_path)
-        mediainfo: MediaInfo = None
-        plugin_available = eventmanager.check(ChainEventType.NameRecognize)
         # 定义识别函数
         async def native_recognize():
             return await self.async_recognize_media(meta=file_meta, episode_group=episode_group)
         async def plugin_recognize():
             return await self.async_recognize_help(title=path, org_meta=file_meta)
-        if settings.RECOGNIZE_PLUGIN_FIRST and plugin_available:
-            # 插件优先
-            logger.info(f"插件优先模式已开启。请求辅助识别，标题：{file_path.name} ...")
-            mediainfo = await plugin_recognize()
-            if not mediainfo:
-                logger.info(f'辅助识别未识别到 {path} 的媒体信息，尝试使用原生识别')
-                mediainfo = await native_recognize()
-        else:
-            # 原生优先
-            logger.info(f"插件优先模式未开启。尝试原生识别，标题：{file_path.name} ...")
-            mediainfo = await native_recognize()
-            if not mediainfo and plugin_available:
-                logger.info(f'原生识别未识别到 {path} 的媒体信息，尝试使用辅助识别')
-                mediainfo = await plugin_recognize()
+        # 按 config 中设置的识别顺序识别
+        mediainfo = await self._async_select_recognize_source(
+                              log_name=file_path.name,
+                              log_context=path,
+                              native_fn=native_recognize,
+                              plugin_fn=plugin_recognize
+                          )
         if not mediainfo:
             logger.warn(f'{path} 未识别到媒体信息')
             return Context(meta_info=file_meta)

--- a/app/chain/media.py
+++ b/app/chain/media.py
@@ -85,7 +85,7 @@ class MediaChain(ChainBase):
         """
         return self.run_module("metadata_nfo", meta=meta, mediainfo=mediainfo, season=season, episode=episode)
 
-    def _select_recognize_source(self, log_name: str, log_context: str,
+    def select_recognize_source(self, log_name: str, log_context: str,
                                  native_fn, plugin_fn) -> Optional[MediaInfo]:
         """
         选择识别模式，插件优先或原生优先
@@ -118,7 +118,7 @@ class MediaChain(ChainBase):
         """
         title = metainfo.title
          # 按 config 中设置的识别顺序识别
-        mediainfo = self._select_recognize_source(
+        mediainfo = self.select_recognize_source(
                         log_name=title,
                         log_context=title,
                         native_fn=lambda: self.recognize_media(meta=metainfo, episode_group=episode_group),
@@ -191,7 +191,7 @@ class MediaChain(ChainBase):
         # 元数据
         file_meta = MetaInfoPath(file_path)
          # 按 config 中设置的识别顺序识别
-        mediainfo = self._select_recognize_source(
+        mediainfo = self.select_recognize_source(
                         log_name=file_path.name,
                         log_context=path,
                         native_fn=lambda: self.recognize_media(meta=file_meta, episode_group=episode_group),
@@ -847,7 +847,7 @@ class MediaChain(ChainBase):
                         logger.warn("无法识别元数据，跳过")
         logger.info(f"{filepath.name} 刮削完成")
 
-    async def _async_select_recognize_source(self, log_name: str, log_context: str,
+    async def async_select_recognize_source(self, log_name: str, log_context: str,
                                              native_fn, plugin_fn) -> Optional[MediaInfo]:
         """
         选择识别模式，插件优先或原生优先（异步版本）
@@ -886,7 +886,7 @@ class MediaChain(ChainBase):
         async def plugin_recognize():
             return await self.async_recognize_help(title=title, org_meta=metainfo)
         # 按 config 中设置的识别顺序识别
-        mediainfo = await self._async_select_recognize_source(
+        mediainfo = await self.async_select_recognize_source(
                               log_name=title,
                               log_context=title,
                               native_fn=native_recognize,
@@ -964,7 +964,7 @@ class MediaChain(ChainBase):
         async def plugin_recognize():
             return await self.async_recognize_help(title=path, org_meta=file_meta)
         # 按 config 中设置的识别顺序识别
-        mediainfo = await self._async_select_recognize_source(
+        mediainfo = await self.async_select_recognize_source(
                               log_name=file_path.name,
                               log_context=path,
                               native_fn=native_recognize,

--- a/app/chain/media.py
+++ b/app/chain/media.py
@@ -90,16 +90,29 @@ class MediaChain(ChainBase):
         根据主副标题识别媒体信息
         """
         title = metainfo.title
-        # 识别媒体信息
-        mediainfo: MediaInfo = self.recognize_media(meta=metainfo, episode_group=episode_group)
-        if not mediainfo:
-            # 尝试使用辅助识别，如果有注册响应事件的话
-            if eventmanager.check(ChainEventType.NameRecognize):
-                logger.info(f'请求辅助识别，标题：{title} ...')
-                mediainfo = self.recognize_help(title=title, org_meta=metainfo)
+        mediainfo: MediaInfo = None
+        if settings.RECOGNIZE_PLUGIN_FIRST and eventmanager.check(ChainEventType.NameRecognize):
+            # 插件优先模式：优先使用辅助识别
+            logger.info(f"插件优先模式已开启。请求辅助识别，标题：{title} ...")
+            mediainfo = self.recognize_help(title=title, org_meta=metainfo)
             if not mediainfo:
-                logger.warn(f'{title} 未识别到媒体信息')
-                return None
+                # 尝试使用原生识别
+                logger.info(f'辅助识别未识别到 {title} 的媒体信息，尝试使用原生识别')
+                mediainfo = self.recognize_media(meta=metainfo, episode_group=episode_group)
+                if not mediainfo:
+                    logger.warn(f'{title} 未识别到媒体信息')
+                    return None
+        else:
+            # 标准模式：优先使用原生识别
+            mediainfo = self.recognize_media(meta=metainfo, episode_group=episode_group)
+            if not mediainfo:
+                # 尝试使用辅助识别，如果有注册响应事件的话
+                if eventmanager.check(ChainEventType.NameRecognize):
+                    logger.info(f'请求辅助识别，标题：{title} ...')
+                    mediainfo = self.recognize_help(title=title, org_meta=metainfo)
+                if not mediainfo:
+                    logger.warn(f'{title} 未识别到媒体信息')
+                    return None
         # 识别成功
         logger.info(f'{title} 识别到媒体信息：{mediainfo.type.value} {mediainfo.title_year}')
         # 更新媒体图片
@@ -163,16 +176,29 @@ class MediaChain(ChainBase):
         file_path = Path(path)
         # 元数据
         file_meta = MetaInfoPath(file_path)
-        # 识别媒体信息
-        mediainfo = self.recognize_media(meta=file_meta, episode_group=episode_group)
-        if not mediainfo:
-            # 尝试使用辅助识别，如果有注册响应事件的话
-            if eventmanager.check(ChainEventType.NameRecognize):
-                logger.info(f'请求辅助识别，标题：{file_path.name} ...')
-                mediainfo = self.recognize_help(title=path, org_meta=file_meta)
+        mediainfo: MediaInfo = None
+        if settings.RECOGNIZE_PLUGIN_FIRST and eventmanager.check(ChainEventType.NameRecognize):
+            # 插件优先模式：优先使用辅助识别
+            logger.info(f"插件优先模式已开启。请求辅助识别，标题：{file_path.name} ...")
+            mediainfo = self.recognize_help(title=path, org_meta=file_meta)
             if not mediainfo:
-                logger.warn(f'{path} 未识别到媒体信息')
-                return Context(meta_info=file_meta)
+                # 尝试使用原生识别
+                logger.info(f'辅助识别未识别到 {path} 的媒体信息，尝试使用原生识别')
+                mediainfo = self.recognize_media(meta=file_meta, episode_group=episode_group)
+                if not mediainfo:
+                    logger.warn(f'{path} 未识别到媒体信息')
+                    return Context(meta_info=file_meta)
+        else:
+            # 标准模式：优先使用原生识别
+            mediainfo = self.recognize_media(meta=file_meta, episode_group=episode_group)
+            if not mediainfo:
+                # 尝试使用辅助识别，如果有注册响应事件的话
+                if eventmanager.check(ChainEventType.NameRecognize):
+                    logger.info(f'请求辅助识别，标题：{file_path.name} ...')
+                    mediainfo = self.recognize_help(title=path, org_meta=file_meta)
+                if not mediainfo:
+                    logger.warn(f'{path} 未识别到媒体信息')
+                    return Context(meta_info=file_meta)
         logger.info(f'{path} 识别到媒体信息：{mediainfo.type.value} {mediainfo.title_year}')
         # 更新媒体图片
         self.obtain_images(mediainfo=mediainfo)
@@ -826,16 +852,29 @@ class MediaChain(ChainBase):
         根据主副标题识别媒体信息（异步版本）
         """
         title = metainfo.title
-        # 识别媒体信息
-        mediainfo: MediaInfo = await self.async_recognize_media(meta=metainfo, episode_group=episode_group)
-        if not mediainfo:
-            # 尝试使用辅助识别，如果有注册响应事件的话
-            if eventmanager.check(ChainEventType.NameRecognize):
-                logger.info(f'请求辅助识别，标题：{title} ...')
-                mediainfo = await self.async_recognize_help(title=title, org_meta=metainfo)
+        mediainfo: MediaInfo = None
+        if settings.RECOGNIZE_PLUGIN_FIRST and eventmanager.check(ChainEventType.NameRecognize):
+            # 插件优先模式：优先使用辅助识别
+            logger.info(f"插件优先模式已开启。请求辅助识别，标题：{title} ...")
+            mediainfo = await self.async_recognize_help(title=title, org_meta=metainfo)
             if not mediainfo:
-                logger.warn(f'{title} 未识别到媒体信息')
-                return None
+                # 尝试使用原生识别
+                logger.info(f'辅助识别未识别到 {title} 的媒体信息，尝试使用原生识别')
+                mediainfo = await self.async_recognize_media(meta=metainfo, episode_group=episode_group)
+                if not mediainfo:
+                    logger.warn(f'{title} 未识别到媒体信息')
+                    return None
+        else:
+            # 标准模式：优先使用原生识别
+            mediainfo = await self.async_recognize_media(meta=metainfo, episode_group=episode_group)
+            if not mediainfo:
+                # 尝试使用辅助识别，如果有注册响应事件的话
+                if eventmanager.check(ChainEventType.NameRecognize):
+                    logger.info(f'请求辅助识别，标题：{title} ...')
+                    mediainfo = await self.async_recognize_help(title=title, org_meta=metainfo)
+                if not mediainfo:
+                    logger.warn(f'{title} 未识别到媒体信息')
+                    return None
         # 识别成功
         logger.info(f'{title} 识别到媒体信息：{mediainfo.type.value} {mediainfo.title_year}')
         # 更新媒体图片
@@ -899,16 +938,29 @@ class MediaChain(ChainBase):
         file_path = Path(path)
         # 元数据
         file_meta = MetaInfoPath(file_path)
-        # 识别媒体信息
-        mediainfo = await self.async_recognize_media(meta=file_meta, episode_group=episode_group)
-        if not mediainfo:
-            # 尝试使用辅助识别，如果有注册响应事件的话
-            if eventmanager.check(ChainEventType.NameRecognize):
-                logger.info(f'请求辅助识别，标题：{file_path.name} ...')
-                mediainfo = await self.async_recognize_help(title=path, org_meta=file_meta)
+        mediainfo: MediaInfo = None
+        if settings.RECOGNIZE_PLUGIN_FIRST and eventmanager.check(ChainEventType.NameRecognize):
+            # 插件优先模式：优先使用辅助识别
+            logger.info(f"插件优先模式已开启。请求辅助识别，标题：{file_path.name} ...")
+            mediainfo = await self.async_recognize_help(title=path, org_meta=file_meta)
             if not mediainfo:
-                logger.warn(f'{path} 未识别到媒体信息')
-                return Context(meta_info=file_meta)
+                # 尝试使用原生识别
+                logger.info(f'辅助识别未识别到 {path} 的媒体信息，尝试使用原生识别')
+                mediainfo = await self.async_recognize_media(meta=file_meta, episode_group=episode_group)
+                if not mediainfo:
+                    logger.warn(f'{path} 未识别到媒体信息')
+                    return Context(meta_info=file_meta)
+        else:
+            # 标准模式：优先使用原生识别
+            mediainfo = await self.async_recognize_media(meta=file_meta, episode_group=episode_group)
+            if not mediainfo:
+                # 尝试使用辅助识别，如果有注册响应事件的话
+                if eventmanager.check(ChainEventType.NameRecognize):
+                    logger.info(f'请求辅助识别，标题：{file_path.name} ...')
+                    mediainfo = await self.async_recognize_help(title=path, org_meta=file_meta)
+                if not mediainfo:
+                    logger.warn(f'{path} 未识别到媒体信息')
+                    return Context(meta_info=file_meta)
         logger.info(f'{path} 识别到媒体信息：{mediainfo.type.value} {mediainfo.title_year}')
         # 更新媒体图片
         await self.async_obtain_images(mediainfo=mediainfo)

--- a/app/chain/media.py
+++ b/app/chain/media.py
@@ -860,17 +860,17 @@ class MediaChain(ChainBase):
         if settings.RECOGNIZE_PLUGIN_FIRST and plugin_available:
             # 插件优先
             logger.info(f"插件优先模式已开启。请求辅助识别，标题：{title} ...")
-            mediainfo = plugin_recognize()
+            mediainfo = await plugin_recognize()
             if not mediainfo:
                 logger.info(f'辅助识别未识别到 {title} 的媒体信息，尝试使用原生识别')
-                mediainfo = native_recognize()
+                mediainfo = await native_recognize()
         else:
             # 原生优先
             logger.info(f"插件优先模式未开启。尝试原生识别，标题：{title} ...")
-            mediainfo = native_recognize()
+            mediainfo = await native_recognize()
             if not mediainfo and plugin_available:
                 logger.info(f'原生识别未识别到 {title} 的媒体信息，尝试使用辅助识别')
-                mediainfo = plugin_recognize()
+                mediainfo = await plugin_recognize()
         if not mediainfo:
             logger.warn(f'{title} 未识别到媒体信息')
             return None
@@ -947,17 +947,17 @@ class MediaChain(ChainBase):
         if settings.RECOGNIZE_PLUGIN_FIRST and plugin_available:
             # 插件优先
             logger.info(f"插件优先模式已开启。请求辅助识别，标题：{file_path.name} ...")
-            mediainfo = plugin_recognize()
+            mediainfo = await plugin_recognize()
             if not mediainfo:
                 logger.info(f'辅助识别未识别到 {path} 的媒体信息，尝试使用原生识别')
-                mediainfo = native_recognize()
+                mediainfo = await native_recognize()
         else:
             # 原生优先
             logger.info(f"插件优先模式未开启。尝试原生识别，标题：{file_path.name} ...")
-            mediainfo = native_recognize()
+            mediainfo = await native_recognize()
             if not mediainfo and plugin_available:
                 logger.info(f'原生识别未识别到 {path} 的媒体信息，尝试使用辅助识别')
-                mediainfo = plugin_recognize()
+                mediainfo = await plugin_recognize()
         if not mediainfo:
             logger.warn(f'{path} 未识别到媒体信息')
             return Context(meta_info=file_meta)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -322,6 +322,8 @@ class ConfigModel(BaseModel):
     DEFAULT_SUB: Optional[str] = "zh-cn"
     # 新增已入库媒体是否跟随TMDB信息变化
     SCRAP_FOLLOW_TMDB: bool = True
+    # 优先使用辅助识别
+    RECOGNIZE_PLUGIN_FIRST: bool = False
 
     # ==================== 服务地址配置 ====================
     # 服务器地址，对应 https://github.com/jxxghp/MoviePilot-Server 项目


### PR DESCRIPTION
## 功能动机

在现有的媒体识别逻辑中，程序优先在本地进行解析。如果原始文件名存在过度缩写（特别是少词）等问题的话，本地解析就可能会将仅有的几个词错认为另一部剧。

由于整个识别链的逻辑是“只要识别出结果就停”，所以这种情况不会触发 ChatGPT 等辅助识别插件进行纠错，导致这类视频的识别准确率受限。

## 改动逻辑

在‎ `app/core/config.py` 新增 `bool` 类型全局设置 `RECOGNIZE_PLUGIN_FIRST` 。（同时在前端同名 PR 中为该选项中添加了对应的按钮）

开启时检测是否注册了辅助识别的响应事件，如果注册了则优先调用辅助识别。如果辅助识别插件（如 ChatGPT）返回有效结果，则直接进入媒体匹配。若插件未命中，则回落至本地解析。

关闭时逻辑与原先相同，先本地解析，如果没有结果则尝试插件辅助。

## 预期效果

用户可以根据需求选择插件优先，充分发挥 LLM 的语义理解优势避免误判，为辅助识别插件的编写与使用提供更好的底层支持。