### PR TITLE
fix(workflow): allow decimal rating in filter medias action

### DIFF
--- a/app/workflow/actions/filter_medias.py
+++ b/app/workflow/actions/filter_medias.py
@@ -13,7 +13,7 @@ class FilterMediasParams(ActionParams):
     过滤媒体数据参数
     """
     type: Optional[str] = Field(default=None, description="媒体类型 (电影/电视剧)")
-    vote: Optional[float] = Field(default=0, description="评分（支持小数）")
+    vote: Optional[float] = Field(default=None, description="评分（支持小数）")
     year: Optional[str] = Field(default=None, description="年份")
 
 
@@ -55,7 +55,7 @@ class FilterMediasAction(BaseAction):
                 break
             if params.type and media.type != params.type:
                 continue
-            if params.vote and media.vote_average < params.vote:
+            if params.vote is not None and media.vote_average < params.vote:
                 continue
             if params.year and media.year != params.year:
                 continue

--- a/app/workflow/actions/filter_medias.py
+++ b/app/workflow/actions/filter_medias.py
@@ -13,7 +13,7 @@ class FilterMediasParams(ActionParams):
     过滤媒体数据参数
     """
     type: Optional[str] = Field(default=None, description="媒体类型 (电影/电视剧)")
-    vote: Optional[int] = Field(default=0, description="评分")
+    vote: Optional[float] = Field(default=0, description="评分（支持小数）")
     year: Optional[str] = Field(default=None, description="年份")
 
 


### PR DESCRIPTION
Closes #5442

## Summary
- Change `FilterMediasParams.vote` from `Optional[int]` to `Optional[float]`.
- This allows decimal rating values (e.g. `7.5`) in workflow '过滤媒体数据' action.

## Why
Issue #5442 reports validation failure when using decimal rating thresholds. The action already compares against `media.vote_average` (float), so accepting float input matches actual usage.

## Risk
Low: one-parameter type adjustment only; no behavior change for integer inputs.