### PR TITLE
fix: avoid tnode seeding JSONDecodeError on invalid API response

### DIFF
--- a/app/modules/indexer/parser/tnode.py
+++ b/app/modules/indexer/parser/tnode.py
@@ -3,6 +3,7 @@ import json
 import re
 from typing import Optional
 
+from app.log import logger
 from app.modules.indexer.parser import SiteParserBase, SiteSchema
 from app.utils.string import StringUtils
 
@@ -65,10 +66,12 @@ class TNodeSiteUserInfo(SiteParserBase):
         """
         try:
             seeding_info = json.loads(html_text)
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as e:
+            logger.warning(f"{self._site_name}: Failed to decode seeding info JSON: {e}")
             return None
 
         if not isinstance(seeding_info, dict):
+            logger.warning(f"{self._site_name}: Seeding info payload is not a dictionary")
             return None
 
         if seeding_info.get("status") != 200:

--- a/app/modules/indexer/parser/tnode.py
+++ b/app/modules/indexer/parser/tnode.py
@@ -63,7 +63,14 @@ class TNodeSiteUserInfo(SiteParserBase):
         """
         解析用户做种信息
         """
-        seeding_info = json.loads(html_text)
+        try:
+            seeding_info = json.loads(html_text)
+        except json.JSONDecodeError:
+            return None
+
+        if not isinstance(seeding_info, dict):
+            return None
+
         if seeding_info.get("status") != 200:
             return None
 


### PR DESCRIPTION
## Summary
- guard `TNodeSiteUserInfo._parse_user_torrent_seeding_info` against invalid/non-JSON API responses
- return early when parsed payload is not a dict
- avoid JSONDecodeError bubbling up and breaking indexer refresh workflow

## Related
- closes #5495

## Validation
- `python -m py_compile app/modules/indexer/parser/tnode.py`
