### PR TITLE
fix(docker): optimize docker http proxy listener config for better network isolation

### DIFF
--- a/docker/docker_http_proxy.conf
+++ b/docker/docker_http_proxy.conf
@@ -13,7 +13,7 @@ http {
         server unix:/var/run/docker.sock fail_timeout=0;
     }
     server {
-        listen 38379;
+        listen 127.0.0.1:38379;
         server_name localhost;
 
         access_log /dev/stdout combined;


### PR DESCRIPTION
## 简介

本 PR 主要是优化现有的 Nginx Docker 内部代理配置。

在某些特定的网络编排环境（如 Docker 映射并采用 host 模式网络）下，原有的 Nginx 监听规则 listen 38379; 默认会绑定到了所有可用的网络接口（0.0.0.0）。这可能会导致用于进程间和工具间通信的内部代理意外暴露到非预期的物理路由器局域网内，引发网络隔离性不足的风险。

为了使得此代理行为严格控制在预期内，本提交将监听地址显式限制在了本地回环网络口。这能确保所有代理通信均彻底保留在宿主机本地，防止外部网络的非法嗅探或越权访问，加强了 Host 网络模式下对配置和系统的保护。

## 变更内容：
- 将项目文件 docker_http_proxy.conf 中的 listen 38379; 明确替换为 listen 127.0.0.1:38379;
