### PR TITLE
fix: 插件 remoteEntry 地址补齐 API 前缀，修复子路径代理加载失败

### DIFF
--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -5,6 +5,7 @@ import concurrent.futures
 import importlib.util
 import inspect
 import os
+import posixpath
 import sys
 import threading
 import time
@@ -775,11 +776,19 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         :param dist_path: 插件的分发路径
         :return: 远程入口地址
         """
-        if dist_path.startswith("/"):
-            dist_path = dist_path[1:]
-        if dist_path.endswith("/"):
-            dist_path = dist_path[:-1]
-        return f"{settings.API_V1_STR}/plugin/file/{plugin_id.lower()}/{dist_path}/remoteEntry.js"
+        dist_path = dist_path.strip("/")
+        api_prefix = settings.API_V1_STR.rstrip("/")
+        path = posixpath.join(
+            api_prefix,
+            "plugin",
+            "file",
+            plugin_id.lower(),
+            dist_path,
+            "remoteEntry.js",
+        )
+        if not path.startswith("/"):
+            path = "/" + path
+        return path
 
     def get_plugin_remotes(self, pid: Optional[str] = None) -> List[Dict[str, Any]]:
         """

--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -779,7 +779,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
             dist_path = dist_path[1:]
         if dist_path.endswith("/"):
             dist_path = dist_path[:-1]
-        return f"/plugin/file/{plugin_id.lower()}/{dist_path}/remoteEntry.js"
+        return f"{settings.API_V1_STR}/plugin/file/{plugin_id.lower()}/{dist_path}/remoteEntry.js"
 
     def get_plugin_remotes(self, pid: Optional[str] = None) -> List[Dict[str, Any]]:
         """


### PR DESCRIPTION
## 关联问题
- closes #5554

## 变更
- 修复 `PluginManager.get_plugin_remote_entry()` 返回的插件静态资源地址
- 原先返回 `/plugin/file/...`，在子路径代理场景下会丢失 API 前缀导致 404
- 现改为 `${settings.API_V1_STR}/plugin/file/...`，与后端路由保持一致

## 验证
- `python -m py_compile app/core/plugin.py` 通过
