### PR TITLE
fix: avoid match_season_episodes bound-method argument conflict

### DIFF
--- a/app/chain/search.py
+++ b/app/chain/search.py
@@ -280,7 +280,7 @@ class SearchChain(ChainBase):
                     logger.info(f"种子名称应用识别词后发生改变：{torrent.title} => {torrent_meta.org_string}")
                 # 季集数过滤
                 if season_episodes \
-                        and not torrenthelper.match_season_episodes(torrent=torrent,
+                        and not TorrentHelper.match_season_episodes(torrent=torrent,
                                                                     meta=torrent_meta,
                                                                     season_episodes=season_episodes):
                     continue


### PR DESCRIPTION
## Summary
- fix subscription search completion crash in issue #5567
- call `TorrentHelper.match_season_episodes(...)` via class instead of instance
- this avoids accidental bound-method argument injection that can trigger:
  `TypeError: ... got multiple values for argument 'torrent'`

## Why
The error stack points to the instance call in `SearchChain.__parse_result`.
Using class invocation keeps the call robust and avoids receiver binding side effects.

## Verification
- static check: `python -m py_compile app/chain/search.py`
- logic unchanged except invocation path

Closes #5567
