### PR TITLE
perf(modules): set a timeout on alipan HTTP calls

### DIFF
--- a/app/modules/filemanager/storages/alipan.py
+++ b/app/modules/filemanager/storages/alipan.py
@@ -558,7 +558,7 @@ class AliPan(StorageBase, metaclass=WeakSingleton):
         """
         上传单个分片
         """
-        return requests.put(upload_url, data=data, timeout=10.0)
+        return requests.put(upload_url, data=data, timeout=60.0)
 
     def _list_uploaded_parts(self, drive_id: str, file_id: str, upload_id: str) -> dict:
         """

--- a/app/modules/filemanager/storages/alipan.py
+++ b/app/modules/filemanager/storages/alipan.py
@@ -558,7 +558,7 @@ class AliPan(StorageBase, metaclass=WeakSingleton):
         """
         上传单个分片
         """
-        return requests.put(upload_url, data=data)
+        return requests.put(upload_url, data=data, timeout=10.0)
 
     def _list_uploaded_parts(self, drive_id: str, file_id: str, upload_id: str) -> dict:
         """


### PR DESCRIPTION
Adds an HTTP request timeout to app/modules/filemanager/storages/alipan.py to prevent indefinite hangs.

Reason: Network calls without a timeout can hang a worker indefinitely.

Validation: `modules/filemanager/storages/alipan.py`.

Context: py-http-timeout at app/modules/filemanager/storages/alipan.py:561.