### PR TITLE
fix(docker): 优化容器进程生命周期管理，并替换初始化程序为 tini

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     wget \
     busybox \
-    dumb-init \
+    tini \
     jq \
     fuse3 \
     rsync \
@@ -130,4 +130,4 @@ RUN cp -f /app/docker/nginx.common.conf /etc/nginx/common.conf \
 
 EXPOSE 3000
 VOLUME [ "${CONFIG_DIR}" ]
-ENTRYPOINT [ "/entrypoint.sh" ]
+ENTRYPOINT [ "/usr/bin/tini", "-g", "--", "/entrypoint.sh" ]

--- a/docker/docker_http_proxy.conf
+++ b/docker/docker_http_proxy.conf
@@ -1,6 +1,7 @@
 worker_processes 1;
 user root;
 daemon on;
+pid /var/run/nginx_proxy.pid;
 
 events {
     worker_connections  1024;

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -173,6 +173,49 @@ function load_config_from_app_env() {
     INFO "配置加载流程执行完毕。"
 }
 
+# 优雅退出
+function graceful_exit() {
+    local exit_code=${1:-0}
+    local reason=${2:-python_exit}
+
+    if [ "$reason" = "signal" ]; then
+        INFO "→ 收到停止信号，执行精准清理程序..."
+    else
+        INFO "→ 主进程已退出 (代码: $exit_code)，执行清理程序..."
+    fi
+
+    # 第一步：停止前端 Nginx
+    # 默认配置启动的 Nginx，默认 PID 在 /var/run/nginx.pid
+    INFO "→ [1/3] 正在关闭前端 Nginx..."
+    nginx -c /etc/nginx/nginx.conf -s stop 2>/dev/null || true
+
+    # 第二步：等待 Python 退出
+    # 由于使用了 tini -g，Python 已经收到了信号，我们只需等待
+    if [ -n "$PYTHON_PID" ] && ps -p "$PYTHON_PID" > /dev/null; then
+        INFO "→ [2/3] 正在等待 Python (PID: $PYTHON_PID) 完成清理..."
+        # 这里的 wait 会阻塞，直到 Python 真正退出
+        wait "$PYTHON_PID" 2>/dev/null || true
+    fi
+
+    # 第三步：最后关闭 Docker Proxy
+    # 必须指定配置文件路径，否则 nginx -s stop 找不到它
+    INFO "→ [3/3] 后端已安全退出，正在关闭 Docker Proxy..."
+    if [ -S "/var/run/docker.sock" ]; then
+        nginx -c /etc/nginx/docker_http_proxy.conf -s stop 2>/dev/null || true
+    fi
+
+    # 根据退出码判断最终日志性质
+    # 0: 正常退出
+    # 130/143: 被系统信号终止（通常也视为预期的清理退出）
+    if [ "$exit_code" -eq 0 ] || [ "$exit_code" -eq 130 ] || [ "$exit_code" -eq 143 ]; then
+        INFO "→ 所有服务已按序清理，容器正常退出 (ExitCode: $exit_code)。"
+    else
+        # 非预期退出码，使用 ERROR 级别并加重提示
+        ERROR "→ 清理完成，但主进程检测到异常退出 (ExitCode: $exit_code)！"
+    fi
+    exit "$exit_code"
+}
+
 # 使用env配置
 load_config_from_app_env
 
@@ -243,6 +286,10 @@ source /app/docker/cert.sh
 INFO "→ 启动前端nginx服务..."
 nginx
 
+# 捕获信号并跳转到函数
+trap 'graceful_exit 130 "signal"' SIGINT
+trap 'graceful_exit 143 "signal"' SIGTERM
+
 # 启动docker http proxy nginx
 if [ -S "/var/run/docker.sock" ]; then
     INFO "→ 启动 Docker Proxy..."
@@ -275,7 +322,16 @@ fi
 # 启动后端服务
 INFO "→ 启动后端服务..."
 if [ "${START_NOGOSU:-false}" = "true" ]; then
-    exec dumb-init "${VENV_PATH}/bin/python3" app/main.py
+    "${VENV_PATH}/bin/python3" app/main.py > /dev/stdout 2> /dev/stderr &
 else
-    exec dumb-init gosu moviepilot:moviepilot "${VENV_PATH}/bin/python3" app/main.py
-fi
+    gosu moviepilot:moviepilot "${VENV_PATH}/bin/python3" app/main.py > /dev/stdout 2> /dev/stderr &
+PYTHON_PID=$!
+
+# 等待 Python 进程退出。
+# 如果收到信号，trap 会中断 wait，并执行 graceful_exit。
+# 如果 Python 正常退出，wait 会结束，然后我们手动调用 graceful_exit。
+wait "$PYTHON_PID" 2>/dev/null
+exit_code=$?
+
+# 如果 Python 自己退出了（非信号触发），执行清理
+graceful_exit "$exit_code" "python_exit"

--- a/docker/nginx.template.conf
+++ b/docker/nginx.template.conf
@@ -1,5 +1,6 @@
 user moviepilot;
 worker_processes auto;
+pid /var/run/nginx.pid; 
 worker_cpu_affinity auto;
 
 


### PR DESCRIPTION
### 1. 基础设施升级：`dumb-init` -> `tini`
- **变更**：将 Dockerfile 中的初始化程序更换为 `tini`。
- **原因**：`tini` 作为 Docker 官方原生支持的方案，在处理信号转发和收割僵尸进程方面更为轻量且稳健，符合容器最佳实践。

### 2. 进程管控逻辑重构 (Entrypoint 优化)
- **解耦主进程启动**：移除 `exec` 启动方式，改为后台运行 + `wait` 阻塞。
- **全时段信号覆盖**：将 `trap` 挂载时机大幅提前至前端 Nginx 启动后，消除了容器启动初期（如权限更改、依赖下载阶段）的信号响应真空期。
- **精准级联关闭顺序**：在 `graceful_exit` 中强制执行 **前端 Nginx -> 后端 Python -> Docker Proxy** 的顺序，确保流量先切断、业务后释放、底座最后销毁。

### 3. Nginx 多实例冲突修复 (PID 隔离)
- **问题修复**：为前端 Nginx 和 Docker Proxy 分别指定独立的 PID 文件路径 (`/var/run/nginx.pid` 与 `/var/run/nginx_proxy.pid`)。
- **精准控制**：在清理阶段统一使用 `nginx -c [conf] -s stop` 指令，彻底解决了可能发生的因 PID 文件覆盖导致的马”误杀进程问题，确保两个实例均能优雅关闭。

### 4. 状态码透传与可观测性优化
- **状态码透明化**：通过 `wait` 捕获 Python 主进程的真实退出码并透传给容器，解决了此前无论业务是否崩溃容器始终返回 `0` 的逻辑缺陷。
- **对齐 Unix 标准**：
    - 捕获 `SIGINT` 返回 `130`。
    - 捕获 `SIGTERM` 返回 `143`。
- **动态语义日志**：根据退出码自动切换日志级别。正常/信号退出输出 `INFO`，非预期崩溃输出 `ERROR`，极大提升了自动化运维（如 K8s）环境下的故障辨识度。