### PR TITLE
test: 补充媒体刮削路径、图片与事件流程测试

### DIFF
--- a/tests/test_mediascrape.py
+++ b/tests/test_mediascrape.py
@@ -2,7 +2,7 @@ import sys
 import unittest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
-
+# ruff: noqa: E402
 sys.modules['app.helper.sites'] = MagicMock()
 sys.modules['app.db.systemconfig_oper'] = MagicMock()
 sys.modules['app.db.systemconfig_oper'].SystemConfigOper.return_value.get.return_value = None
@@ -172,6 +172,62 @@ class TestMediaScrapingImages(unittest.TestCase):
         self.assertEqual(len(calls), 1)
         self.assertEqual(calls[0].kwargs["url"], "http://season01")
 
+    def test_scrape_episode_thumb_image_path(self):
+        fileitem = schemas.FileItem(path="/tv/Show/Season 1/S01E01.mp4", name="S01E01.mp4", type="file", storage="local")
+        parent_item = schemas.FileItem(path="/tv/Show/Season 1", name="Season 1", type="dir", storage="local")
+        mediainfo = MediaInfo()
+        self.media_chain.metadata_img.return_value = {
+            "thumb.jpg": "http://episode-thumb"
+        }
+        self.media_chain.scraping_policies.option.return_value = ScrapingOption("episode", "thumb", ScrapingPolicy.OVERWRITE)
+        self.media_chain.storagechain.get_file_item.return_value = None
+
+        self.media_chain._scrape_images_generic(
+            fileitem,
+            mediainfo,
+            ScrapingTarget.EPISODE,
+            parent_fileitem=parent_item,
+            season_number=1,
+            episode_number=1
+        )
+
+        self.media_chain.metadata_img.assert_called_once_with(
+            mediainfo=mediainfo,
+            season=1,
+            episode=1
+        )
+        self.media_chain._download_and_save_image.assert_called_once_with(
+            fileitem=parent_item,
+            path=Path("/tv/Show/Season 1/S01E01.jpg"),
+            url="http://episode-thumb"
+        )
+
+    def test_scrape_episode_thumb_image_path_via_parent_lookup(self):
+        fileitem = schemas.FileItem(path="/tv/Show/Season 1/S01E01.mp4", name="S01E01.mp4", type="file", storage="local")
+        parent_item = schemas.FileItem(path="/tv/Show/Season 1", name="Season 1", type="dir", storage="local")
+        mediainfo = MediaInfo()
+        self.media_chain.metadata_img.return_value = {
+            "thumb.jpg": "http://episode-thumb"
+        }
+        self.media_chain.scraping_policies.option.return_value = ScrapingOption("episode", "thumb", ScrapingPolicy.OVERWRITE)
+        self.media_chain.storagechain.get_parent_item.return_value = parent_item
+        self.media_chain.storagechain.get_file_item.return_value = None
+
+        self.media_chain._scrape_images_generic(
+            fileitem,
+            mediainfo,
+            ScrapingTarget.EPISODE,
+            season_number=1,
+            episode_number=1
+        )
+
+        self.media_chain.storagechain.get_parent_item.assert_called_once_with(fileitem)
+        self.media_chain._download_and_save_image.assert_called_once_with(
+            fileitem=parent_item,
+            path=Path("/tv/Show/Season 1/S01E01.jpg"),
+            url="http://episode-thumb"
+        )
+
     @patch("app.chain.media.RequestUtils")
     @patch("app.chain.media.NamedTemporaryFile")
     @patch("app.chain.media.Path.chmod")
@@ -225,16 +281,22 @@ class TestMediaScrapingTVDirectory(unittest.TestCase):
     def test_initialize_tv_directory_specials(self, mock_settings):
         # mock specials directory recognition
         mock_settings.RENAME_FORMAT_S0_NAMES = ["Specials", "SPs"]
-        mock_settings.RMT_MEDIAEXT = [".mp4", ".mkv"]
 
         fileitem = schemas.FileItem(path="/tv/Show/Specials", name="Specials", type="dir", storage="local")
         meta = MetaInfo("Show")
         mediainfo = MediaInfo(type=MediaType.TV)
-        self.media_chain.storagechain.list_files.return_value = []
+        filepath = Path(fileitem.path)
 
-        self.media_chain._handle_tv_scraping(fileitem, meta, mediainfo, init_folder=True, parent=None, overwrite=False, recursive=True)
+        self.media_chain._initialize_tv_directory_metadata(
+            fileitem=fileitem,
+            filepath=filepath,
+            meta=meta,
+            mediainfo=mediainfo,
+            parent=None,
+            overwrite=False,
+        )
 
-        self.media_chain._scrape_nfo_generic.assert_called_with(
+        self.media_chain._scrape_nfo_generic.assert_called_once_with(
             current_fileitem=fileitem,
             meta=meta,
             mediainfo=mediainfo,
@@ -242,7 +304,7 @@ class TestMediaScrapingTVDirectory(unittest.TestCase):
             overwrite=False,
             season_number=0
         )
-        self.media_chain._scrape_images_generic.assert_called_with(
+        self.media_chain._scrape_images_generic.assert_called_once_with(
             current_fileitem=fileitem,
             mediainfo=mediainfo,
             item_type=ScrapingTarget.SEASON,
@@ -251,15 +313,25 @@ class TestMediaScrapingTVDirectory(unittest.TestCase):
             season_number=0
         )
 
-    def test_initialize_tv_directory_season(self):
+    @patch("app.chain.media.settings")
+    def test_initialize_tv_directory_season(self, mock_settings):
+        mock_settings.RENAME_FORMAT_S0_NAMES = ["Specials", "SPs"]
+
         fileitem = schemas.FileItem(path="/tv/Show/Season 1", name="Season 1", type="dir", storage="local")
         meta = MetaInfo("Show")
         mediainfo = MediaInfo(type=MediaType.TV)
-        self.media_chain.storagechain.list_files.return_value = []
+        filepath = Path(fileitem.path)
 
-        self.media_chain._handle_tv_scraping(fileitem, meta, mediainfo, init_folder=True, parent=None, overwrite=False, recursive=True)
+        self.media_chain._initialize_tv_directory_metadata(
+            fileitem=fileitem,
+            filepath=filepath,
+            meta=meta,
+            mediainfo=mediainfo,
+            parent=None,
+            overwrite=False,
+        )
 
-        self.media_chain._scrape_nfo_generic.assert_called_with(
+        self.media_chain._scrape_nfo_generic.assert_called_once_with(
             current_fileitem=fileitem,
             meta=meta,
             mediainfo=mediainfo,
@@ -272,18 +344,17 @@ class TestMediaScrapingTVDirectory(unittest.TestCase):
 class TestMediaScrapeEvents(unittest.TestCase):
     def setUp(self):
         self.media_chain = MediaChain()
+        self.media_chain.storagechain = MagicMock()
 
     @patch("app.chain.media.MediaChain.scrape_metadata")
-    @patch("app.chain.media.StorageChain.get_item")
-    @patch("app.chain.media.StorageChain.get_parent_item")
     def test_scrape_metadata_event_file(
-        self, mock_get_parent, mock_get_item, mock_scrape_metadata
+        self, mock_scrape_metadata
     ):
         fileitem = schemas.FileItem(path="/movies/movie.mkv", name="movie.mkv", type="file", storage="local")
         parent_item = schemas.FileItem(path="/movies", name="movies", type="dir", storage="local")
 
-        mock_get_item.return_value = fileitem
-        mock_get_parent.return_value = parent_item
+        self.media_chain.storagechain.get_item.return_value = fileitem
+        self.media_chain.storagechain.get_parent_item.return_value = parent_item
 
         mediainfo = MediaInfo()
         event = Event(
@@ -306,15 +377,13 @@ class TestMediaScrapeEvents(unittest.TestCase):
         )
 
     @patch("app.chain.media.MediaChain.scrape_metadata")
-    @patch("app.chain.media.StorageChain.get_item")
-    @patch("app.chain.media.StorageChain.is_bluray_folder")
     def test_scrape_metadata_event_dir_bluray(
-        self, mock_is_bluray, mock_get_item, mock_scrape_metadata
+        self, mock_scrape_metadata
     ):
         fileitem = schemas.FileItem(path="/movies/bluray_movie", name="bluray_movie", type="dir", storage="local")
 
-        mock_get_item.return_value = fileitem
-        mock_is_bluray.return_value = True
+        self.media_chain.storagechain.get_item.return_value = fileitem
+        self.media_chain.storagechain.is_bluray_folder.return_value = True
 
         mediainfo = MediaInfo()
         event = Event(
@@ -338,22 +407,19 @@ class TestMediaScrapeEvents(unittest.TestCase):
         )
 
     @patch("app.chain.media.MediaChain.scrape_metadata")
-    @patch("app.chain.media.StorageChain.get_item")
-    @patch("app.chain.media.StorageChain.is_bluray_folder")
-    @patch("app.chain.media.StorageChain.get_file_item")
     def test_scrape_metadata_event_dir_with_filelist(
-        self, mock_get_file_item, mock_is_bluray, mock_get_item, mock_scrape_metadata
+        self, mock_scrape_metadata
     ):
         fileitem = schemas.FileItem(path="/tv/show", name="show", type="dir", storage="local")
 
-        mock_get_item.return_value = fileitem
-        mock_is_bluray.return_value = False
+        self.media_chain.storagechain.get_item.return_value = fileitem
+        self.media_chain.storagechain.is_bluray_folder.return_value = False
 
         def side_effect_get_file_item(storage, path):
             path_str = str(path)
             return schemas.FileItem(path=path_str, name=Path(path_str).name, type="dir" if "." not in path_str else "file", storage="local")
 
-        mock_get_file_item.side_effect = side_effect_get_file_item
+        self.media_chain.storagechain.get_file_item.side_effect = side_effect_get_file_item
 
         mediainfo = MediaInfo()
         event = Event(
@@ -377,13 +443,12 @@ class TestMediaScrapeEvents(unittest.TestCase):
         self.assertIn("/tv/show/Season 1/S01E01.mp4", paths)
 
     @patch("app.chain.media.MediaChain.scrape_metadata")
-    @patch("app.chain.media.StorageChain.get_item")
     def test_scrape_metadata_event_dir_full(
-        self, mock_get_item, mock_scrape_metadata
+        self, mock_scrape_metadata
     ):
         fileitem = schemas.FileItem(path="/movies/movie", name="movie", type="dir", storage="local")
 
-        mock_get_item.return_value = fileitem
+        self.media_chain.storagechain.get_item.return_value = fileitem
 
         mediainfo = MediaInfo()
         meta = MetaInfo("movie")
@@ -501,22 +566,19 @@ class TestMediaScrapeEvents(unittest.TestCase):
         mock_handle_tv.assert_not_called()
 
     @patch("app.chain.media.MediaChain.scrape_metadata")
-    @patch("app.chain.media.StorageChain.get_item")
-    @patch("app.chain.media.StorageChain.is_bluray_folder")
-    @patch("app.chain.media.StorageChain.get_file_item")
     def test_scrape_metadata_event_dir_with_multiple_files(
-        self, mock_get_file_item, mock_is_bluray, mock_get_item, mock_scrape_metadata
+        self, mock_scrape_metadata
     ):
         fileitem = schemas.FileItem(path="/movies/collection", name="collection", type="dir", storage="local")
 
-        mock_get_item.return_value = fileitem
-        mock_is_bluray.return_value = False
+        self.media_chain.storagechain.get_item.return_value = fileitem
+        self.media_chain.storagechain.is_bluray_folder.return_value = False
 
         def side_effect_get_file_item(storage, path):
             path_str = str(path)
             return schemas.FileItem(path=path_str, name=Path(path_str).name, type="dir" if "." not in path_str else "file", storage="local")
 
-        mock_get_file_item.side_effect = side_effect_get_file_item
+        self.media_chain.storagechain.get_file_item.side_effect = side_effect_get_file_item
 
         mediainfo = MediaInfo()
         event = Event(
@@ -546,22 +608,19 @@ class TestMediaScrapeEvents(unittest.TestCase):
         self.assertIn("/movies/collection/movie3.avi", paths)
 
     @patch("app.chain.media.MediaChain.scrape_metadata")
-    @patch("app.chain.media.StorageChain.get_item")
-    @patch("app.chain.media.StorageChain.is_bluray_folder")
-    @patch("app.chain.media.StorageChain.get_file_item")
     def test_scrape_metadata_event_dir_with_tv_multi_seasons_episodes(
-        self, mock_get_file_item, mock_is_bluray, mock_get_item, mock_scrape_metadata
+        self, mock_scrape_metadata
     ):
         fileitem = schemas.FileItem(path="/tv/MultiSeasonShow", name="MultiSeasonShow", type="dir", storage="local")
 
-        mock_get_item.return_value = fileitem
-        mock_is_bluray.return_value = False
+        self.media_chain.storagechain.get_item.return_value = fileitem
+        self.media_chain.storagechain.is_bluray_folder.return_value = False
 
         def side_effect_get_file_item(storage, path):
             path_str = str(path)
             return schemas.FileItem(path=path_str, name=Path(path_str).name, type="dir" if "." not in path_str else "file", storage="local")
 
-        mock_get_file_item.side_effect = side_effect_get_file_item
+        self.media_chain.storagechain.get_file_item.side_effect = side_effect_get_file_item
 
         mediainfo = MediaInfo()
         event = Event(


### PR DESCRIPTION
## 变更说明
本次提交为媒体刮削流程补充测试用例，修复电影、剧集、季、单集等场景下的 NFO 与图片路径测试逻辑，以及事件触发后的元数据刮削分发行为。

## 主要内容
- 补充单集缩略图抓取映射、保存路径测试
- 补充图片下载与上传流程的单测覆盖

## 价值
- 提升测试对关键刮削分支的覆盖率
- 降低路径拼接、目录初始化和事件分发逻辑回归风险
- 为后续重构相关媒体刮削逻辑提供更稳定的回归保障