### PR TITLE
fix(http): 统一同步与异步 HTTP 响应语义

### DIFF
--- a/app/api/endpoints/system.py
+++ b/app/api/endpoints/system.py
@@ -493,7 +493,7 @@ async def latest_version(_: schemas.TokenPayload = Depends(verify_token)):
     version_res = await AsyncRequestUtils(
         proxies=settings.PROXY, headers=settings.GITHUB_HEADERS
     ).get_res(f"https://api.github.com/repos/jxxghp/MoviePilot/releases")
-    if version_res:
+    if version_res is not None and version_res.status_code == 200:
         ver_json = version_res.json()
         if ver_json:
             return schemas.Response(success=True, data=ver_json)

--- a/app/helper/image.py
+++ b/app/helper/image.py
@@ -238,7 +238,7 @@ class ImageHelper(metaclass=Singleton):
         # 请求远程图片
         params = self._get_request_params(url, proxy, cookies)
         response = RequestUtils(**params).get_res(url=url)
-        if not response:
+        if response is None or response.status_code != 200:
             logger.warn(f"Failed to fetch image from URL: {url}")
             return None
 
@@ -274,7 +274,7 @@ class ImageHelper(metaclass=Singleton):
         # 请求远程图片
         params = self._get_request_params(url, proxy, cookies)
         response = await AsyncRequestUtils(**params).get_res(url=url)
-        if not response:
+        if response is None or response.status_code != 200:
             logger.warn(f"Failed to fetch image from URL: {url}")
             return None
 

--- a/app/helper/plugin.py
+++ b/app/helper/plugin.py
@@ -146,7 +146,7 @@ class PluginHelper(metaclass=WeakSingleton):
         if not settings.PLUGIN_STATISTIC_SHARE:
             return {}
         res = RequestUtils(proxies=settings.PROXY, timeout=10).get_res(self._install_statistic)
-        if res and res.status_code == 200:
+        if res is not None and res.status_code == 200:
             return res.json()
         return {}
 
@@ -167,7 +167,7 @@ class PluginHelper(metaclass=WeakSingleton):
             "plugin_id": pid,
             "repo_url": repo_url
         })
-        if res and res.status_code == 200:
+        if res is not None and res.status_code == 200:
             return True
         return False
 
@@ -192,7 +192,7 @@ class PluginHelper(metaclass=WeakSingleton):
                            content_type="application/json",
                            timeout=5).post(self._install_report,
                                            json={"plugins": payload_plugins})
-        return True if res else False
+        return bool(res is not None and res.status_code == 200)
 
     def install(self, pid: str, repo_url: str, package_version: Optional[str] = None, force_install: bool = False) \
             -> Tuple[bool, str]:
@@ -1002,7 +1002,7 @@ class PluginHelper(metaclass=WeakSingleton):
         if not settings.PLUGIN_STATISTIC_SHARE:
             return {}
         res = await AsyncRequestUtils(proxies=settings.PROXY, timeout=10).get_res(self._install_statistic)
-        if res and res.status_code == 200:
+        if res is not None and res.status_code == 200:
             return res.json()
         return {}
 
@@ -1023,7 +1023,7 @@ class PluginHelper(metaclass=WeakSingleton):
             "plugin_id": pid,
             "repo_url": repo_url
         })
-        if res and res.status_code == 200:
+        if res is not None and res.status_code == 200:
             return True
         return False
 
@@ -1048,7 +1048,7 @@ class PluginHelper(metaclass=WeakSingleton):
                                       content_type="application/json",
                                       timeout=5).post(self._install_report,
                                                       json={"plugins": payload_plugins})
-        return True if res else False
+        return bool(res is not None and res.status_code == 200)
 
     async def __async_get_file_list(self, pid: str, user_repo: str, package_version: Optional[str] = None) -> \
             Tuple[Optional[list], Optional[str]]:

--- a/app/helper/subscribe.py
+++ b/app/helper/subscribe.py
@@ -108,7 +108,7 @@ class SubscribeHelper(metaclass=WeakSingleton):
             return False, "连接MoviePilot服务器失败"
 
         # 检查响应状态
-        if res and res.status_code == 200:
+        if res.status_code == 200:
             # 清除缓存
             if clear_cache:
                 self.get_shares.cache_clear()
@@ -126,7 +126,7 @@ class SubscribeHelper(metaclass=WeakSingleton):
         """
         处理返回List的HTTP响应
         """
-        if res and res.status_code == 200:
+        if res is not None and res.status_code == 200:
             return res.json()
         return []
 
@@ -202,7 +202,7 @@ class SubscribeHelper(metaclass=WeakSingleton):
         res = RequestUtils(proxies=settings.PROXY, timeout=5, headers={
             "Content-Type": "application/json"
         }).post_res(self._sub_reg, json=sub)
-        if res and res.status_code == 200:
+        if res is not None and res.status_code == 200:
             return True
         return False
 
@@ -216,7 +216,7 @@ class SubscribeHelper(metaclass=WeakSingleton):
         res = await AsyncRequestUtils(proxies=settings.PROXY, timeout=5, headers={
             "Content-Type": "application/json"
         }).post_res(self._sub_reg, json=sub)
-        if res and res.status_code == 200:
+        if res is not None and res.status_code == 200:
             return True
         return False
 
@@ -267,7 +267,7 @@ class SubscribeHelper(metaclass=WeakSingleton):
                                                     sub.to_dict() for sub in subscribes
                                                 ]
                                             })
-        return True if res else False
+        return bool(res is not None and res.status_code == 200)
 
     def sub_share(self, subscribe_id: int,
                   share_title: str, share_comment: str, share_user: str) -> Tuple[bool, str]:

--- a/app/modules/bangumi/bangumi.py
+++ b/app/modules/bangumi/bangumi.py
@@ -39,7 +39,7 @@ class BangumiApi(object):
             params.update(kwargs)
         resp = self._req.get_res(url=req_url, params=params)
         try:
-            if not resp:
+            if resp is None or resp.status_code != 200:
                 return None
             result = resp.json()
             return result.get(key) if key else result
@@ -55,7 +55,7 @@ class BangumiApi(object):
             params.update(kwargs)
         resp = await self._async_req.get_res(url=req_url, params=params)
         try:
-            if not resp:
+            if resp is None or resp.status_code != 200:
                 return None
             result = resp.json()
             return result.get(key) if key else result

--- a/app/utils/http.py
+++ b/app/utils/http.py
@@ -206,16 +206,18 @@ class RequestUtils:
         :return: 响应的内容，若发生RequestException则返回None
         """
         response = self.request(method="get", url=url, params=params, **kwargs)
-        if response:
-            try:
-                content = str(response.content, "utf-8")
-                return content
-            except Exception as e:
-                logger.debug(f"处理响应内容失败: {e}")
-                return None
-            finally:
+        try:
+            if response:
+                try:
+                    content = str(response.content, "utf-8")
+                    return content
+                except Exception as e:
+                    logger.debug(f"处理响应内容失败: {e}")
+                    return None
+            return None
+        finally:
+            if response is not None:
                 response.close()
-        return None
 
     def post(self, url: str, data: Any = None, json: dict = None, **kwargs) -> Optional[Response]:
         """
@@ -382,16 +384,18 @@ class RequestUtils:
         :return: JSON数据，若发生异常则返回None
         """
         response = self.request(method="get", url=url, params=params, **kwargs)
-        if response:
-            try:
-                data = response.json()
-                return data
-            except Exception as e:
-                logger.debug(f"解析JSON失败: {e}")
-                return None
-            finally:
+        try:
+            if response:
+                try:
+                    data = response.json()
+                    return data
+                except Exception as e:
+                    logger.debug(f"解析JSON失败: {e}")
+                    return None
+            return None
+        finally:
+            if response is not None:
                 response.close()
-        return None
 
     def post_json(self, url: str, data: Any = None, json: dict = None, **kwargs) -> Optional[dict]:
         """
@@ -405,16 +409,18 @@ class RequestUtils:
         if json is None:
             json = {}
         response = self.request(method="post", url=url, data=data, json=json, **kwargs)
-        if response:
-            try:
-                data = response.json()
-                return data
-            except Exception as e:
-                logger.debug(f"解析JSON失败: {e}")
-                return None
-            finally:
+        try:
+            if response:
+                try:
+                    data = response.json()
+                    return data
+                except Exception as e:
+                    logger.debug(f"解析JSON失败: {e}")
+                    return None
+            return None
+        finally:
+            if response is not None:
                 response.close()
-        return None
 
     @staticmethod
     def parse_cache_control(header: str) -> Tuple[str, Optional[int]]:
@@ -711,16 +717,18 @@ class AsyncRequestUtils:
         :return: 响应的内容，若发生RequestError则返回None
         """
         response = await self.request(method="get", url=url, params=params, **kwargs)
-        if response:
-            try:
-                content = response.text
-                return content
-            except Exception as e:
-                logger.debug(f"处理异步响应内容失败: {e}")
-                return None
-            finally:
-                await response.aclose()  # 确保连接被关闭
-        return None
+        try:
+            if response:
+                try:
+                    content = response.text
+                    return content
+                except Exception as e:
+                    logger.debug(f"处理异步响应内容失败: {e}")
+                    return None
+            return None
+        finally:
+            if response is not None:
+                await response.aclose()
 
     async def post(self, url: str, data: Any = None, json: dict = None, **kwargs) -> Optional[httpx.Response]:
         """
@@ -887,16 +895,18 @@ class AsyncRequestUtils:
         :return: JSON数据，若发生异常则返回None
         """
         response = await self.request(method="get", url=url, params=params, **kwargs)
-        if response:
-            try:
-                data = response.json()
-                return data
-            except Exception as e:
-                logger.debug(f"解析异步JSON失败: {e}")
-                return None
-            finally:
+        try:
+            if response:
+                try:
+                    data = response.json()
+                    return data
+                except Exception as e:
+                    logger.debug(f"解析异步JSON失败: {e}")
+                    return None
+            return None
+        finally:
+            if response is not None:
                 await response.aclose()
-        return None
 
     async def post_json(self, url: str, data: Any = None, json: dict = None, **kwargs) -> Optional[dict]:
         """
@@ -910,13 +920,15 @@ class AsyncRequestUtils:
         if json is None:
             json = {}
         response = await self.request(method="post", url=url, data=data, json=json, **kwargs)
-        if response:
-            try:
-                data = response.json()
-                return data
-            except Exception as e:
-                logger.debug(f"解析异步JSON失败: {e}")
-                return None
-            finally:
+        try:
+            if response:
+                try:
+                    data = response.json()
+                    return data
+                except Exception as e:
+                    logger.debug(f"解析异步JSON失败: {e}")
+                    return None
+            return None
+        finally:
+            if response is not None:
                 await response.aclose()
-        return None

--- a/app/utils/http.py
+++ b/app/utils/http.py
@@ -161,7 +161,7 @@ class RequestUtils:
             response = self.request(method=method, url=url, **kwargs)
             yield response
         finally:
-            if response:
+            if response is not None:
                 try:
                     response.close()
                 except Exception as e:
@@ -280,7 +280,7 @@ class RequestUtils:
         try:
             yield response
         finally:
-            if response:
+            if response is not None:
                 response.close()
 
     def post_res(self,
@@ -654,7 +654,7 @@ class AsyncRequestUtils:
             response = await self.request(method=method, url=url, **kwargs)
             yield response
         finally:
-            if response:
+            if response is not None:
                 try:
                     await response.aclose()
                 except Exception as e:
@@ -785,7 +785,7 @@ class AsyncRequestUtils:
         try:
             yield response
         finally:
-            if response:
+            if response is not None:
                 await response.aclose()
 
     async def post_res(self,


### PR DESCRIPTION
## 概要
- 在不改变 `get()` / `get_json()` 公开返回语义的前提下，修正非成功响应的关闭路径
- 在少量高风险调用点改为显式 `200` 成功判断，避免 `requests` 与 `httpx` 的 truthy 语义差异造成误判
- 将插件和订阅的上报请求改为仅在返回 `200` 时视为成功

## 验证
- `python3 -m py_compile app/utils/http.py`
- `python3 -m py_compile app/modules/bangumi/bangumi.py app/helper/image.py app/api/endpoints/system.py`
- `python3 -m py_compile app/helper/plugin.py app/helper/subscribe.py`

Prepared with Codex.