### PR TITLE
fix(subscribe): 修复旧总集数导致的误完成与历史复用偏差

### DIFF
--- a/app/api/endpoints/subscribe.py
+++ b/app/api/endpoints/subscribe.py
@@ -399,7 +399,15 @@ async def subscribe_history(
     """
     查询电影/电视剧订阅历史
     """
-    return await SubscribeHistory.async_list_by_type(db, mtype=mtype, page=page, count=count)
+    histories = await SubscribeHistory.async_list_by_type(db, mtype=mtype, page=page, count=count)
+    result = []
+    for history in histories:
+        history_item = schemas.Subscribe.model_validate(history, from_attributes=True)
+        if history_item.type == MediaType.TV.value:
+            history_item.total_episode = 0
+            history_item.lack_episode = 0
+        result.append(history_item)
+    return result
 
 
 @router.delete("/history/{history_id}", summary="删除订阅历史", response_model=schemas.Response)

--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -1855,12 +1855,15 @@ class SubscribeChain(ChainBase):
 
         old_lack_episode = subscribe.lack_episode or 0
         new_lack_episode = old_lack_episode + (new_total_episode - old_total_episode)
+        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         SubscribeOper().update(subscribe.id, {
             "total_episode": new_total_episode,
-            "lack_episode": new_lack_episode
+            "lack_episode": new_lack_episode,
+            "last_update": now
         })
         subscribe.total_episode = new_total_episode
         subscribe.lack_episode = new_lack_episode
+        subscribe.last_update = now
         logger.info(
             f"订阅 {subscribe.name} 第{subscribe.season}季 总集数更新为 {new_total_episode}，缺失集数更新为 {new_lack_episode}"
         )

--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -1766,6 +1766,8 @@ class SubscribeChain(ChainBase):
             - exist_flag (bool): 布尔值，表示媒体是否已经完全下载或已存在
             - no_exists (dict): 缺失的媒体信息，包含缺失的集数或其他相关信息
         """
+        self.__refresh_total_episode_before_completion(subscribe=subscribe, mediainfo=mediainfo)
+
         # 非洗版
         if not subscribe.best_version:
             # 每季总集数
@@ -1833,6 +1835,35 @@ class SubscribeChain(ChainBase):
 
         # 返回结果，表示媒体未完全下载或存在
         return False, no_exists
+
+    @staticmethod
+    def __refresh_total_episode_before_completion(subscribe: Subscribe, mediainfo: MediaInfo):
+        """
+        在完成判断前，按最新识别结果兜底修正订阅总集数，防止旧总集数导致误完成。
+        """
+        if subscribe.type != MediaType.TV.value:
+            return
+        if subscribe.manual_total_episode:
+            return
+        if subscribe.season is None:
+            return
+
+        new_total_episode = len((mediainfo.seasons or {}).get(subscribe.season) or [])
+        old_total_episode = subscribe.total_episode or 0
+        if not new_total_episode or new_total_episode <= old_total_episode:
+            return
+
+        old_lack_episode = subscribe.lack_episode or 0
+        new_lack_episode = old_lack_episode + (new_total_episode - old_total_episode)
+        SubscribeOper().update(subscribe.id, {
+            "total_episode": new_total_episode,
+            "lack_episode": new_lack_episode
+        })
+        subscribe.total_episode = new_total_episode
+        subscribe.lack_episode = new_lack_episode
+        logger.info(
+            f"订阅 {subscribe.name} 第{subscribe.season}季 总集数更新为 {new_total_episode}，缺失集数更新为 {new_lack_episode}"
+        )
 
     @staticmethod
     def _is_episode_range_covered(meta: MetaBase, subscribe: Subscribe) -> bool:


### PR DESCRIPTION
## 变更说明
- 在订阅完成判断前增加总集数兜底刷新，避免旧 `total_episode` 导致误判完成。
- 对订阅历史接口返回的电视剧项统一清零 `total_episode/lack_episode`，复用时触发按最新元数据重算。

## 具体改动
- 在 `SubscribeChain.check_and_handle_existing_media` 中新增预检查纠偏逻辑：
  - 仅电视剧生效
  - `manual_total_episode=1` 时不覆盖
  - 仅当最新总集数大于旧值时更新
  - 同步更新数据库与当前对象，确保本轮判断立即生效
- 在 `GET /subscribe/history/{mtype}` 返回前处理电视剧历史项：
  - `total_episode = 0`
  - `lack_episode = 0`

## 验证
- `python3 -m py_compile app/chain/subscribe.py app/api/endpoints/subscribe.py`

Closes #5465

---
Generated with Codex.
