### PR TITLE
fix(subtitle): create missing download root before saving subtitles

### DIFF
--- a/app/chain/storage.py
+++ b/app/chain/storage.py
@@ -61,6 +61,12 @@ class StorageChain(ChainBase):
         """
         return self.run_module("create_folder", fileitem=fileitem, name=name)
 
+    def get_folder(self, storage: str, path: Path) -> Optional[schemas.FileItem]:
+        """
+        获取目录，不存在则递归创建
+        """
+        return self.run_module("get_folder", storage=storage, path=path)
+
     def download_file(self, fileitem: schemas.FileItem, path: Path = None) -> Optional[Path]:
         """
         下载文件

--- a/app/modules/subtitle/__init__.py
+++ b/app/modules/subtitle/__init__.py
@@ -162,7 +162,7 @@ class SubtitleModule(_ModuleBase):
             time.sleep(1)
         # 目录仍然不存在，且有文件夹名，则创建目录
         if not working_dir_item and folder_name:
-            parent_dir_item = storageChain.get_file_item(storage, download_dir)
+            parent_dir_item = storageChain.get_folder(storage, download_dir)
             if parent_dir_item:
                 working_dir_item = storageChain.create_folder(
                     parent_dir_item,


### PR DESCRIPTION
## Problem
When qBittorrent is configured to download into a temporary directory first and move files to the final save path after completion, the subtitle module may start too early.
In this case, the configured categorized download root such as `/media/downloads/电视剧/国产剧` may not exist yet. The previous logic only created the final torrent subfolder when its parent directory already existed, so subtitle download failed with:
`下载根目录不存在，无法创建字幕文件夹`
## Fix
This change reuses the existing storage-layer recursive folder creation capability instead of adding subtitle-specific path creation logic.
- add `StorageChain.get_folder(storage, path)` as a thin wrapper around the existing storage module capability
- replace `storageChain.get_file_item(storage, download_dir)` with `storageChain.get_folder(storage, download_dir)` in the subtitle module
- keep the existing behavior of creating the torrent subfolder once the download root is available
This lets the subtitle module create the missing download root chain before saving subtitle files.
## Validation
Verified locally.
Validation scenario:
- qBittorrent downloads incomplete files into a temporary directory
- the final categorized path does not exist in advance
- MoviePilot starts subtitle download right after the task is added
Result:
- the categorized download root is created automatically
- the previous `下载根目录不存在，无法创建字幕文件夹` error no longer appears
---
## 问题
当 qBittorrent 配置为先下载到临时目录、完成后再移动到最终保存目录时，字幕模块可能会过早介入。
此时，像 `/media/downloads/电视剧/国产剧` 这样的分类下载根目录可能尚未存在。此前的逻辑只会在父目录已存在时创建最后一级种子目录，因此会报错：
`下载根目录不存在，无法创建字幕文件夹`
## 修复
本次修改复用了项目现有的存储层递归建目录能力，而不是在字幕模块里增加一套专用的目录创建逻辑。
- 在 `StorageChain` 中增加 `get_folder(storage, path)` 包装方法
- 在字幕模块中，将 `storageChain.get_file_item(storage, download_dir)` 改为 `storageChain.get_folder(storage, download_dir)`
- 保留原有逻辑：在下载根目录可用后继续创建种子子目录
这样字幕模块在保存字幕前，就可以先把缺失的下载根目录链路创建出来。
## 验证
已在本地验证通过。
验证场景：
- qBittorrent 使用临时目录下载未完成文件
- 最终分类下载目录事先不存在
- MoviePilot 在添加下载任务后立即开始站点字幕下载
验证结果：
- 分类下载根目录会被自动创建
- 不再出现 `下载根目录不存在，无法创建字幕文件夹` 错误