### PR TITLE
feat(plugin): support local plugin sources

### DIFF
--- a/app/api/endpoints/plugin.py
+++ b/app/api/endpoints/plugin.py
@@ -155,12 +155,12 @@ async def all_plugins(_: User = Depends(get_current_active_superuser_async),
 
     # 未安装的本地插件
     not_installed_plugins = [plugin for plugin in local_plugins if not plugin.installed]
-    # 本地插件来源目录中的插件
-    local_source_plugins = plugin_manager.get_local_source_plugins()
+    # 本地插件仓库目录中的插件
+    local_repo_plugins = plugin_manager.get_local_repo_plugins()
     # 在线插件
     online_plugins = await plugin_manager.async_get_online_plugins(force)
-    candidate_plugins = plugin_manager._process_plugins_list(online_plugins + local_source_plugins, []) \
-        if online_plugins or local_source_plugins else []
+    candidate_plugins = plugin_manager._process_plugins_list(online_plugins + local_repo_plugins, []) \
+        if online_plugins or local_repo_plugins else []
     if not candidate_plugins:
         # 没有获取在线插件
         if state == "market":

--- a/app/api/endpoints/plugin.py
+++ b/app/api/endpoints/plugin.py
@@ -159,7 +159,7 @@ async def all_plugins(_: User = Depends(get_current_active_superuser_async),
     local_repo_plugins = plugin_manager.get_local_repo_plugins()
     # 在线插件
     online_plugins = await plugin_manager.async_get_online_plugins(force)
-    candidate_plugins = plugin_manager._process_plugins_list(online_plugins + local_repo_plugins, []) \
+    candidate_plugins = plugin_manager.process_plugins_list(online_plugins + local_repo_plugins, []) \
         if online_plugins or local_repo_plugins else []
     if not candidate_plugins:
         # 没有获取在线插件

--- a/app/api/endpoints/plugin.py
+++ b/app/api/endpoints/plugin.py
@@ -232,22 +232,16 @@ async def install(plugin_id: str,
     install_plugins = SystemConfigOper().get(SystemConfigKey.UserInstalledPlugins) or []
     # 首先检查插件是否已经存在，并且是否强制安装，否则只进行安装统计
     plugin_helper = PluginHelper()
-    is_local_install = plugin_helper.is_local_repo_url(repo_url)
-    if not force and plugin_id in PluginManager().get_plugin_ids() and not is_local_install:
-        await plugin_helper.async_install_reg(pid=plugin_id)
+    if not force and plugin_id in PluginManager().get_plugin_ids():
+        await plugin_helper.async_install_reg(pid=plugin_id, repo_url=repo_url)
     else:
         # 插件不存在或需要强制安装，下载安装并注册插件
-        if is_local_install:
-            state, msg = await run_in_threadpool(
-                plugin_helper.install_local,
-                plugin_id,
-                repo_url,
-                force
+        if repo_url:
+            state, msg = await plugin_helper.async_install(
+                pid=plugin_id,
+                repo_url=repo_url,
+                force_install=force
             )
-            if not state:
-                return schemas.Response(success=False, message=msg)
-        elif repo_url:
-            state, msg = await plugin_helper.async_install(pid=plugin_id, repo_url=repo_url)
             # 安装失败则直接响应
             if not state:
                 return schemas.Response(success=False, message=msg)

--- a/app/api/endpoints/plugin.py
+++ b/app/api/endpoints/plugin.py
@@ -155,9 +155,13 @@ async def all_plugins(_: User = Depends(get_current_active_superuser_async),
 
     # 未安装的本地插件
     not_installed_plugins = [plugin for plugin in local_plugins if not plugin.installed]
+    # 本地插件来源目录中的插件
+    local_source_plugins = plugin_manager.get_local_source_plugins()
     # 在线插件
     online_plugins = await plugin_manager.async_get_online_plugins(force)
-    if not online_plugins:
+    candidate_plugins = plugin_manager._process_plugins_list(online_plugins + local_source_plugins, []) \
+        if online_plugins or local_source_plugins else []
+    if not candidate_plugins:
         # 没有获取在线插件
         if state == "market":
             # 返回未安装的本地插件
@@ -169,7 +173,7 @@ async def all_plugins(_: User = Depends(get_current_active_superuser_async),
     # 已安装插件IDS
     _installed_ids = [plugin.id for plugin in installed_plugins]
     # 未安装的线上插件或者有更新的插件
-    for plugin in online_plugins:
+    for plugin in candidate_plugins:
         if plugin.id not in _installed_ids:
             market_plugins.append(plugin)
         elif plugin.has_update:
@@ -228,11 +232,21 @@ async def install(plugin_id: str,
     install_plugins = SystemConfigOper().get(SystemConfigKey.UserInstalledPlugins) or []
     # 首先检查插件是否已经存在，并且是否强制安装，否则只进行安装统计
     plugin_helper = PluginHelper()
-    if not force and plugin_id in PluginManager().get_plugin_ids():
+    is_local_install = plugin_helper.is_local_repo_url(repo_url)
+    if not force and plugin_id in PluginManager().get_plugin_ids() and not is_local_install:
         await plugin_helper.async_install_reg(pid=plugin_id)
     else:
         # 插件不存在或需要强制安装，下载安装并注册插件
-        if repo_url:
+        if is_local_install:
+            state, msg = await run_in_threadpool(
+                plugin_helper.install_local,
+                plugin_id,
+                repo_url,
+                force
+            )
+            if not state:
+                return schemas.Response(success=False, message=msg)
+        elif repo_url:
             state, msg = await plugin_helper.async_install(pid=plugin_id, repo_url=repo_url)
             # 安装失败则直接响应
             if not state:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -418,7 +418,7 @@ class ConfigModel(BaseModel):
     # 是否开启插件热加载
     PLUGIN_AUTO_RELOAD: bool = False
     # 本地插件仓库目录，多个地址使用,分隔
-    PLUGIN_LOCAL_PATHS: Optional[str] = None
+    PLUGIN_LOCAL_REPO_PATHS: Optional[str] = None
 
     # ==================== Github & PIP ====================
     # Github token，提高请求api限流阈值 ghp_****

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -417,6 +417,8 @@ class ConfigModel(BaseModel):
     PLUGIN_STATISTIC_SHARE: bool = True
     # 是否开启插件热加载
     PLUGIN_AUTO_RELOAD: bool = False
+    # 本地插件仓库目录，多个地址使用,分隔
+    PLUGIN_LOCAL_PATHS: Optional[str] = None
 
     # ==================== Github & PIP ====================
     # Github token，提高请求api限流阈值 ghp_****

--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -1245,7 +1245,11 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
             plugin = self._process_plugin_info(
                 pid=pid,
                 plugin_info=plugin_info,
-                market=PluginHelper.make_local_repo_url(pid),
+                market=PluginHelper.make_local_repo_url(
+                    pid,
+                    plugin_info.get("repo_path"),
+                    package_version
+                ),
                 installed_apps=installed_apps,
                 add_time=0,
                 package_version=package_version

--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -39,7 +39,7 @@ from app.utils.system import SystemUtils
 
 class PluginManager(ConfigReloadMixin, metaclass=Singleton):
     """插件管理器"""
-    CONFIG_WATCH = {"DEV", "PLUGIN_AUTO_RELOAD"}
+    CONFIG_WATCH = {"DEV", "PLUGIN_AUTO_RELOAD", "PLUGIN_LOCAL_PATHS"}
 
     def __init__(self):
         # 插件列表

--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -39,7 +39,7 @@ from app.utils.system import SystemUtils
 
 class PluginManager(ConfigReloadMixin, metaclass=Singleton):
     """插件管理器"""
-    CONFIG_WATCH = {"DEV", "PLUGIN_AUTO_RELOAD", "PLUGIN_LOCAL_PATHS"}
+    CONFIG_WATCH = {"DEV", "PLUGIN_AUTO_RELOAD", "PLUGIN_LOCAL_REPO_PATHS"}
 
     def __init__(self):
         # 插件列表

--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -312,9 +312,9 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         """
         # 监视插件目录
         plugin_paths = [str(settings.ROOT_PATH / "app" / "plugins")]
-        for local_path in PluginHelper.get_local_source_paths():
-            if local_path.exists() and local_path.is_dir():
-                plugin_paths.append(str(local_path))
+        for local_repo_path in PluginHelper.get_local_repo_paths():
+            if local_repo_path.exists() and local_repo_path.is_dir():
+                plugin_paths.append(str(local_repo_path))
         logger.info(">>> 监控线程已启动，准备进入watch循环...")
         # 使用 watchfiles 监视目录变化，并响应变化事件
         # Todo: yield_on_timeout = True 时，每秒检查停止事件，会返回空集合；后续可以考虑用来做心跳之类的功能？
@@ -437,17 +437,17 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
     @staticmethod
     def _get_local_plugin_candidate_from_path(event_path: Path) -> Optional[dict]:
         """
-        根据本地插件来源路径解析具体插件候选，保留 plugins/plugins.v2 来源差异。
+        根据本地插件仓库路径解析具体插件候选，保留 plugins/plugins.v2 来源差异。
         """
         try:
             event_path = event_path.resolve()
-            for local_path in PluginHelper.get_local_source_paths():
-                if not local_path.exists() or not local_path.is_dir():
+            for local_repo_path in PluginHelper.get_local_repo_paths():
+                if not local_repo_path.exists() or not local_repo_path.is_dir():
                     continue
-                if not event_path.is_relative_to(local_path):
+                if not event_path.is_relative_to(local_repo_path):
                     continue
                 try:
-                    relative_parts = event_path.relative_to(local_path).parts
+                    relative_parts = event_path.relative_to(local_repo_path).parts
                 except (ValueError, IndexError):
                     continue
                 if len(relative_parts) < 2:
@@ -462,14 +462,14 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                 candidate = PluginHelper().get_local_plugin_candidate(
                     pid=plugin_dir_name,
                     package_version=package_version,
-                    source_path=local_path,
+                    repo_path=local_repo_path,
                     strict_compat=False
                 )
                 if candidate:
                     return candidate
             return None
         except Exception as e:
-            logger.error(f"从本地来源路径解析插件候选时出错: {e}")
+            logger.error(f"从本地插件仓库路径解析插件候选时出错: {e}")
             return None
 
     @staticmethod
@@ -1233,9 +1233,9 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         plugins.sort(key=lambda x: x.plugin_order if hasattr(x, "plugin_order") else 0)
         return plugins
 
-    def get_local_source_plugins(self) -> List[schemas.Plugin]:
+    def get_local_repo_plugins(self) -> List[schemas.Plugin]:
         """
-        获取本地插件来源目录中的插件信息。
+        获取本地插件仓库目录中的插件信息。
         """
         plugins = []
         installed_apps = SystemConfigOper().get(SystemConfigKey.UserInstalledPlugins) or []

--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -437,7 +437,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
     @staticmethod
     def _get_local_plugin_candidate_from_path(event_path: Path) -> Optional[dict]:
         """
-        根据本地插件仓库路径解析具体插件候选，保留 plugins/plugins.v2 来源差异。
+        根据本地插件仓库路径解析具体插件候选，保留 plugins/plugins.v2 来源差异
         """
         try:
             event_path = event_path.resolve()
@@ -475,7 +475,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
     @staticmethod
     def _sync_local_plugin_if_installed(pid: str, candidate: Optional[dict] = None) -> bool:
         """
-        已安装本地插件源码变化时，同步到运行目录。
+        已安装本地插件源码变化时，同步到运行目录
         """
         installed_plugins = SystemConfigOper().get(SystemConfigKey.UserInstalledPlugins) or []
         if pid not in installed_plugins:
@@ -1158,7 +1158,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                     else:
                         base_version_plugins.extend(plugins)  # 收集 v1 版本插件
 
-        return self._process_plugins_list(higher_version_plugins, base_version_plugins)
+        return self.process_plugins_list(higher_version_plugins, base_version_plugins)
 
     def get_local_plugins(self) -> List[schemas.Plugin]:
         """
@@ -1235,7 +1235,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
 
     def get_local_repo_plugins(self) -> List[schemas.Plugin]:
         """
-        获取本地插件仓库目录中的插件信息。
+        获取本地插件仓库目录中的插件信息
         """
         plugins = []
         installed_apps = SystemConfigOper().get(SystemConfigKey.UserInstalledPlugins) or []
@@ -1326,8 +1326,8 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         return ret_plugins
 
     @staticmethod
-    def _process_plugins_list(higher_version_plugins: List[schemas.Plugin],
-                              base_version_plugins: List[schemas.Plugin]) -> List[schemas.Plugin]:
+    def process_plugins_list(higher_version_plugins: List[schemas.Plugin],
+                             base_version_plugins: List[schemas.Plugin]) -> List[schemas.Plugin]:
         """
         处理插件列表：合并、去重、排序、保留最高版本
         :param higher_version_plugins: 高版本插件列表
@@ -1523,7 +1523,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                     else:
                         base_version_plugins.extend(plugins)  # 收集 v1 版本插件
 
-        return self._process_plugins_list(higher_version_plugins, base_version_plugins)
+        return self.process_plugins_list(higher_version_plugins, base_version_plugins)
 
     async def async_get_plugins_from_market(self, market: str,
                                             package_version: Optional[str] = None,

--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -601,11 +601,14 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
 
         # 获取已安装插件列表
         install_plugins = SystemConfigOper().get(SystemConfigKey.UserInstalledPlugins) or []
-        # 获取在线插件列表
+        # 获取远程和本地仓库来源插件列表
         online_plugins = self.get_online_plugins()
+        local_repo_plugins = self.get_local_repo_plugins()
+        candidate_plugins = self.process_plugins_list(online_plugins + local_repo_plugins, []) \
+            if online_plugins or local_repo_plugins else []
         # 确定需要安装的插件
         plugins_to_install = [
-            plugin for plugin in online_plugins
+            plugin for plugin in candidate_plugins
             if plugin.id in install_plugins and not self.is_plugin_exists(plugin.id, plugin.plugin_version)
         ]
 
@@ -1158,7 +1161,9 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                     else:
                         base_version_plugins.extend(plugins)  # 收集 v1 版本插件
 
-        return self.process_plugins_list(higher_version_plugins, base_version_plugins)
+        result = self.process_plugins_list(higher_version_plugins, base_version_plugins)
+        logger.info(f"获取到 {len(result)} 个线上插件")
+        return result
 
     def get_local_plugins(self) -> List[schemas.Plugin]:
         """
@@ -1240,6 +1245,8 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         plugins = []
         installed_apps = SystemConfigOper().get(SystemConfigKey.UserInstalledPlugins) or []
         local_candidates = PluginHelper().get_local_plugin_candidates()
+        if not local_candidates:
+            return []
         for pid, plugin_info in local_candidates.items():
             package_version = plugin_info.get("package_version")
             plugin = self._process_plugin_info(
@@ -1260,6 +1267,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
             plugins.append(plugin)
 
         plugins.sort(key=lambda x: x.plugin_order if hasattr(x, "plugin_order") else 0)
+        logger.info(f"获取到 {len(plugins)} 个本地插件")
         return plugins
 
     @staticmethod
@@ -1374,9 +1382,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                     and not PluginHelper.is_local_repo_url(plugin.repo_url):
                 result_by_id[plugin.id] = plugin
 
-        result = list(result_by_id.values())
-        logger.info(f"共获取到 {len(result)} 个线上插件")
-        return result
+        return list(result_by_id.values())
 
     def _process_plugin_info(self, pid: str, plugin_info: dict, market: str,
                              installed_apps: List[str], add_time: int,
@@ -1523,7 +1529,9 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                     else:
                         base_version_plugins.extend(plugins)  # 收集 v1 版本插件
 
-        return self.process_plugins_list(higher_version_plugins, base_version_plugins)
+        result = self.process_plugins_list(higher_version_plugins, base_version_plugins)
+        logger.info(f"获取到 {len(result)} 个线上插件")
+        return result
 
     async def async_get_plugins_from_market(self, market: str,
                                             package_version: Optional[str] = None,

--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -6,6 +6,7 @@ import importlib.util
 import inspect
 import os
 import posixpath
+import shutil
 import sys
 import threading
 import time
@@ -51,6 +52,8 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         self._monitor_thread: Optional[threading.Thread] = None
         # 监控停止事件
         self._stop_monitor_event = threading.Event()
+        # 本地插件同步写入运行目录后的短时忽略窗口
+        self._recent_local_sync: Dict[str, float] = {}
         # 开发者模式监测插件修改
         if settings.DEV or settings.PLUGIN_AUTO_RELOAD:
             self.__start_monitor()
@@ -308,11 +311,14 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         运行 watchfiles 监视器的主循环。
         """
         # 监视插件目录
-        plugins_path = str(settings.ROOT_PATH / "app" / "plugins")
+        plugin_paths = [str(settings.ROOT_PATH / "app" / "plugins")]
+        for local_path in PluginHelper.get_local_source_paths():
+            if local_path.exists() and local_path.is_dir():
+                plugin_paths.append(str(local_path))
         logger.info(">>> 监控线程已启动，准备进入watch循环...")
         # 使用 watchfiles 监视目录变化，并响应变化事件
         # Todo: yield_on_timeout = True 时，每秒检查停止事件，会返回空集合；后续可以考虑用来做心跳之类的功能？
-        for changes in watch(plugins_path, stop_event=self._stop_monitor_event, rust_timeout=1000,
+        for changes in watch(*plugin_paths, stop_event=self._stop_monitor_event, rust_timeout=1000,
                              yield_on_timeout=True):
             # 如果收到停止事件，退出循环
             if not changes:
@@ -320,18 +326,56 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
 
             # 处理变化事件
             plugins_to_reload = set()
+            local_plugins_to_sync = {}
             for _change_type, path_str in changes:
                 event_path = Path(path_str)
 
-                # 跳过非 .py 文件以及 pycache 目录中的文件
-                if not event_path.name.endswith(".py") or "__pycache__" in event_path.parts:
+                # 跳过 pycache 目录中的文件
+                if "__pycache__" in event_path.parts:
+                    continue
+
+                if event_path.name == "requirements.txt":
+                    candidate = self._get_local_plugin_candidate_from_path(event_path)
+                    if candidate:
+                        if candidate.get("compatible") is False:
+                            logger.info(
+                                f"检测到本地插件 {candidate.get('id')} 依赖文件变化，"
+                                f"但跳过处理：{candidate.get('skip_reason')}"
+                            )
+                            continue
+                        logger.warning(f"检测到本地插件 {candidate.get('id')} 依赖文件变化，请重新安装本地插件以安装依赖")
+                    continue
+
+                # 跳过非 .py 文件
+                if not event_path.name.endswith(".py"):
                     continue
 
                 # 解析插件ID
-                pid = self._get_plugin_id_from_path(event_path)
-                # 跳过无效插件文件
-                if pid:
-                    # 收集需要重载的插件ID，自动去重，避免重复重载
+                runtime_pid = self._get_plugin_id_from_path(event_path)
+                local_candidate = self._get_local_plugin_candidate_from_path(event_path) if not runtime_pid else None
+                if runtime_pid:
+                    last_sync_time = self._recent_local_sync.get(runtime_pid)
+                    if last_sync_time and time.time() - last_sync_time < 2:
+                        logger.debug(f"忽略本地插件同步产生的运行目录变化：{runtime_pid}")
+                        continue
+                    # 运行目录变化只重载，不能反向触发本地同步。
+                    plugins_to_reload.add(runtime_pid)
+                elif local_candidate:
+                    if local_candidate.get("compatible") is False:
+                        package_version = local_candidate.get("package_version")
+                        source_root = f"plugins.{package_version}" if package_version else "plugins"
+                        logger.info(
+                            f"检测到本地插件 {local_candidate.get('id')} 文件变化，来源：{source_root}，"
+                            f"文件：{event_path}，但跳过同步：{local_candidate.get('skip_reason')}"
+                        )
+                        continue
+                    local_plugins_to_sync[local_candidate.get("id")] = (local_candidate, event_path)
+
+            for pid, (candidate, event_path) in local_plugins_to_sync.items():
+                package_version = candidate.get("package_version")
+                source_root = f"plugins.{package_version}" if package_version else "plugins"
+                logger.info(f"检测到本地插件 {pid} 文件变化，来源：{source_root}，文件：{event_path}")
+                if self._sync_local_plugin_if_installed(pid, candidate):
                     plugins_to_reload.add(pid)
 
             # 触发重载
@@ -351,6 +395,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         :return: 插件ID字符串，如果不是有效插件文件则返回 None。
         """
         try:
+            event_path = event_path.resolve()
             plugins_root = settings.ROOT_PATH / "app" / "plugins"
             # 确保修改的文件在 plugins 目录下
             if not event_path.is_relative_to(plugins_root):
@@ -388,6 +433,78 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         except Exception as e:
             logger.error(f"从路径解析插件ID时出错: {e}")
             return None
+
+    @staticmethod
+    def _get_local_plugin_candidate_from_path(event_path: Path) -> Optional[dict]:
+        """
+        根据本地插件来源路径解析具体插件候选，保留 plugins/plugins.v2 来源差异。
+        """
+        try:
+            event_path = event_path.resolve()
+            for local_path in PluginHelper.get_local_source_paths():
+                if not local_path.exists() or not local_path.is_dir():
+                    continue
+                if not event_path.is_relative_to(local_path):
+                    continue
+                try:
+                    relative_parts = event_path.relative_to(local_path).parts
+                except (ValueError, IndexError):
+                    continue
+                if len(relative_parts) < 2:
+                    continue
+                if relative_parts[0] == "plugins":
+                    package_version = ""
+                elif relative_parts[0].startswith("plugins."):
+                    package_version = relative_parts[0].split(".", 1)[1]
+                else:
+                    continue
+                plugin_dir_name = relative_parts[1]
+                candidate = PluginHelper().get_local_plugin_candidate(
+                    pid=plugin_dir_name,
+                    package_version=package_version,
+                    source_path=local_path,
+                    strict_compat=False
+                )
+                if candidate:
+                    return candidate
+            return None
+        except Exception as e:
+            logger.error(f"从本地来源路径解析插件候选时出错: {e}")
+            return None
+
+    @staticmethod
+    def _sync_local_plugin_if_installed(pid: str, candidate: Optional[dict] = None) -> bool:
+        """
+        已安装本地插件源码变化时，同步到运行目录。
+        """
+        installed_plugins = SystemConfigOper().get(SystemConfigKey.UserInstalledPlugins) or []
+        if pid not in installed_plugins:
+            logger.info(f"本地插件 {pid} 尚未安装，跳过自动同步和热重载")
+            return False
+
+        candidate = candidate or PluginHelper().get_local_plugin_candidate(pid)
+        if not candidate:
+            return False
+
+        source_dir = Path(candidate.get("path"))
+        dest_dir = settings.ROOT_PATH / "app" / "plugins" / pid.lower()
+        try:
+            if source_dir.resolve() == dest_dir.resolve():
+                return True
+            if dest_dir.exists():
+                shutil.rmtree(dest_dir, ignore_errors=True)
+            shutil.copytree(
+                source_dir,
+                dest_dir,
+                dirs_exist_ok=True,
+                ignore=shutil.ignore_patterns("__pycache__", "*.pyc", ".DS_Store")
+            )
+            PluginManager()._recent_local_sync[pid] = time.time()
+            logger.info(f"已同步本地插件 {pid}：{source_dir} -> {dest_dir}")
+            return True
+        except Exception as e:
+            logger.error(f"同步本地插件 {pid} 失败：{e}")
+            return False
 
     @staticmethod
     def __stop_plugin(plugin: Any):
@@ -1116,6 +1233,31 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         plugins.sort(key=lambda x: x.plugin_order if hasattr(x, "plugin_order") else 0)
         return plugins
 
+    def get_local_source_plugins(self) -> List[schemas.Plugin]:
+        """
+        获取本地插件来源目录中的插件信息。
+        """
+        plugins = []
+        installed_apps = SystemConfigOper().get(SystemConfigKey.UserInstalledPlugins) or []
+        local_candidates = PluginHelper().get_local_plugin_candidates()
+        for pid, plugin_info in local_candidates.items():
+            package_version = plugin_info.get("package_version")
+            plugin = self._process_plugin_info(
+                pid=pid,
+                plugin_info=plugin_info,
+                market=PluginHelper.make_local_repo_url(pid),
+                installed_apps=installed_apps,
+                add_time=0,
+                package_version=package_version
+            )
+            if not plugin:
+                continue
+            plugin.is_local = True
+            plugins.append(plugin)
+
+        plugins.sort(key=lambda x: x.plugin_order if hasattr(x, "plugin_order") else 0)
+        return plugins
+
     @staticmethod
     def is_plugin_exists(pid: str, version: str = None) -> bool:
         """
@@ -1194,18 +1336,41 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         # 将未出现在高版本插件列表中的 v1 插件加入 all_plugins
         higher_plugin_ids = {f"{p.id}{p.plugin_version}" for p in higher_version_plugins}
         all_plugins.extend([p for p in base_version_plugins if f"{p.id}{p.plugin_version}" not in higher_plugin_ids])
-        # 去重
-        all_plugins = list({f"{p.id}{p.plugin_version}": p for p in all_plugins}.values())
-        # 所有插件按 repo 在设置中的顺序排序
-        all_plugins.sort(
-            key=lambda x: settings.PLUGIN_MARKET.split(",").index(x.repo_url) if x.repo_url else 0
-        )
-        # 相同 ID 的插件保留版本号最大的版本
-        max_versions = {}
-        for p in all_plugins:
-            if p.id not in max_versions or StringUtils.compare_version(p.plugin_version, ">", max_versions[p.id]):
-                max_versions[p.id] = p.plugin_version
-        result = [p for p in all_plugins if p.plugin_version == max_versions[p.id]]
+        markets = [item for item in settings.PLUGIN_MARKET.split(",") if item]
+
+        def repo_order(plugin: schemas.Plugin) -> int:
+            if PluginHelper.is_local_repo_url(plugin.repo_url):
+                return len(markets) + 1
+            if plugin.repo_url in markets:
+                return markets.index(plugin.repo_url)
+            return len(markets)
+
+        # 去重：同 ID + 版本优先保留市场来源，其次按来源顺序稳定保留。
+        dedup_plugins = {}
+        for plugin in sorted(all_plugins, key=repo_order):
+            key = f"{plugin.id}{plugin.plugin_version}"
+            exists = dedup_plugins.get(key)
+            if not exists:
+                dedup_plugins[key] = plugin
+                continue
+            if PluginHelper.is_local_repo_url(exists.repo_url) and not PluginHelper.is_local_repo_url(plugin.repo_url):
+                dedup_plugins[key] = plugin
+
+        # 相同 ID 的插件保留版本号最大的版本；同版本市场来源优先。
+        result_by_id = {}
+        for plugin in sorted(dedup_plugins.values(), key=repo_order):
+            exists = result_by_id.get(plugin.id)
+            if not exists:
+                result_by_id[plugin.id] = plugin
+                continue
+            if StringUtils.compare_version(plugin.plugin_version, ">", exists.plugin_version):
+                result_by_id[plugin.id] = plugin
+            elif plugin.plugin_version == exists.plugin_version \
+                    and PluginHelper.is_local_repo_url(exists.repo_url) \
+                    and not PluginHelper.is_local_repo_url(plugin.repo_url):
+                result_by_id[plugin.id] = plugin
+
+        result = list(result_by_id.values())
         logger.info(f"共获取到 {len(result)} 个线上插件")
         return result
 

--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -343,7 +343,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                                 f"但跳过处理：{candidate.get('skip_reason')}"
                             )
                             continue
-                        logger.warning(f"检测到本地插件 {candidate.get('id')} 依赖文件变化，请重新安装本地插件以安装依赖")
+                        logger.warn(f"检测到本地插件 {candidate.get('id')} 依赖文件变化，请重新安装本地插件以安装依赖")
                     continue
 
                 # 跳过非 .py 文件

--- a/app/helper/plugin.py
+++ b/app/helper/plugin.py
@@ -9,6 +9,7 @@ import traceback
 import zipfile
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Set, Callable, Awaitable
+from urllib.parse import parse_qs, quote, unquote, urlsplit
 
 import aiofiles
 import aioshutil
@@ -55,31 +56,77 @@ class PluginHelper(metaclass=WeakSingleton):
     @staticmethod
     def is_local_repo_url(repo_url: Optional[str]) -> bool:
         """
-        判断是否为本地插件来源标识。
+        判断是否为本地插件来源标识
         """
         return bool(repo_url and repo_url.startswith(LOCAL_REPO_PREFIX))
 
     @staticmethod
-    def make_local_repo_url(pid: str) -> str:
+    def make_local_repo_url(pid: str, repo_path: Optional[Path] = None,
+                            package_version: Optional[str] = None) -> str:
         """
-        生成本地插件安装来源标识。
+        生成本地插件安装来源标识
         """
-        return f"{LOCAL_REPO_PREFIX}{pid}"
+        repo_url = f"{LOCAL_REPO_PREFIX}{quote(pid, safe='')}"
+        params = []
+        if repo_path:
+            params.append(f"path={quote(str(repo_path), safe='/:~')}")
+        if package_version:
+            params.append(f"version={quote(package_version, safe='')}")
+        if params:
+            repo_url = f"{repo_url}?{'&'.join(params)}"
+        return repo_url
 
     @staticmethod
     def parse_local_repo_url(repo_url: str) -> Optional[str]:
         """
-        从本地插件来源标识中解析插件ID。
+        从本地插件来源标识中解析插件ID
         """
         if not PluginHelper.is_local_repo_url(repo_url):
             return None
-        pid = repo_url[len(LOCAL_REPO_PREFIX):].strip("/")
+        try:
+            parts = urlsplit(repo_url)
+            pid = unquote(parts.netloc or parts.path.strip("/"))
+        except Exception:
+            pid = repo_url[len(LOCAL_REPO_PREFIX):].split("?", 1)[0].strip("/")
         return pid or None
+
+    @staticmethod
+    def parse_local_repo_path(repo_url: str) -> Optional[Path]:
+        """
+        从本地插件来源标识中解析仓库路径
+        """
+        if not PluginHelper.is_local_repo_url(repo_url):
+            return None
+        try:
+            values = parse_qs(urlsplit(repo_url).query).get("path")
+            if not values:
+                return None
+            path = Path(values[0]).expanduser()
+            if not path.is_absolute():
+                path = settings.ROOT_PATH / path
+            return path.resolve()
+        except Exception:
+            return None
+
+    @staticmethod
+    def parse_local_repo_package_version(repo_url: str) -> Optional[str]:
+        """
+        从本地插件来源标识中解析 package 版本
+        """
+        if not PluginHelper.is_local_repo_url(repo_url):
+            return None
+        try:
+            values = parse_qs(urlsplit(repo_url).query).get("version")
+            if not values:
+                return None
+            return values[0]
+        except Exception:
+            return None
 
     @staticmethod
     def get_local_repo_paths() -> List[Path]:
         """
-        获取本地插件仓库目录列表。
+        获取本地插件仓库目录列表
         """
         if not settings.PLUGIN_LOCAL_REPO_PATHS:
             return []
@@ -97,7 +144,7 @@ class PluginHelper(metaclass=WeakSingleton):
     @staticmethod
     def __get_local_package(repo_path: Path, package_version: Optional[str] = None) -> Optional[Dict[str, dict]]:
         """
-        从本地插件仓库读取 package.json 或 package.{version}.json。
+        从本地插件仓库读取 package.json 或 package.{version}.json
         """
         package_file = repo_path / (
             f"package.{package_version}.json" if package_version else "package.json"
@@ -108,10 +155,10 @@ class PluginHelper(metaclass=WeakSingleton):
             content = package_file.read_text(encoding="utf-8")
             payload = json.loads(content)
         except Exception as e:
-            logger.warning(f"读取本地插件包 {package_file} 失败：{e}")
+            logger.warn(f"读取本地插件包 {package_file} 失败：{e}")
             return None
         if not isinstance(payload, dict):
-            logger.warning(f"本地插件包 {package_file} 格式不正确")
+            logger.warn(f"本地插件包 {package_file} 格式不正确")
             return None
         return payload
 
@@ -122,12 +169,12 @@ class PluginHelper(metaclass=WeakSingleton):
 
     def get_local_plugin_candidates(self) -> Dict[str, dict]:
         """
-        扫描本地插件仓库，按插件ID保留版本号最高的候选。
+        扫描本地插件仓库，按插件ID保留版本号最高的候选
         """
         candidates: Dict[str, dict] = {}
-        for source_order, repo_path in enumerate(self.get_local_repo_paths()):
+        for repo_order, repo_path in enumerate(self.get_local_repo_paths()):
             if not repo_path.exists() or not repo_path.is_dir():
-                logger.warning(f"本地插件仓库目录不存在或不可读：{repo_path}")
+                logger.warn(f"本地插件仓库目录不存在或不可读：{repo_path}")
                 continue
 
             package_candidates = []
@@ -158,7 +205,7 @@ class PluginHelper(metaclass=WeakSingleton):
                     candidate = plugin_info.copy()
                     candidate["id"] = pid
                     candidate["package_version"] = package_version
-                    candidate["source_order"] = source_order
+                    candidate["repo_order"] = repo_order
                     candidate["repo_path"] = repo_path
                     candidate["path"] = plugin_dir
                     candidate_version = str(candidate.get("version") or "0")
@@ -173,7 +220,7 @@ class PluginHelper(metaclass=WeakSingleton):
                         candidates[pid] = candidate
                     elif (
                         candidate_version == existing_version
-                        and source_order < int(existing.get("source_order", source_order))
+                        and repo_order < int(existing.get("repo_order", repo_order))
                     ):
                         logger.info(f"本地插件 {pid} 存在同版本来源，使用靠前目录：{repo_path}")
                         candidates[pid] = candidate
@@ -184,42 +231,58 @@ class PluginHelper(metaclass=WeakSingleton):
                                    repo_path: Optional[Path] = None,
                                    strict_compat: bool = True) -> Optional[dict]:
         """
-        获取指定插件ID的本地插件候选。
+        获取指定插件ID的本地插件候选
         """
         if not pid:
             return None
         if package_version is not None or repo_path is not None:
             repo_paths = [repo_path.resolve()] if repo_path else self.get_local_repo_paths()
-            for source_order, local_repo_path in enumerate(self.get_local_repo_paths()):
+            package_versions = [package_version] if package_version is not None else []
+            if package_version is None:
+                if settings.VERSION_FLAG:
+                    package_versions.append(settings.VERSION_FLAG)
+                package_versions.append("")
+            selected_candidate = None
+            for repo_order, local_repo_path in enumerate(self.get_local_repo_paths()):
                 if local_repo_path not in repo_paths:
                     continue
-                local_plugins = self.__get_local_package(local_repo_path, package_version or "")
-                if not local_plugins:
-                    continue
-                for candidate_pid, plugin_info in local_plugins.items():
-                    if candidate_pid.lower() != pid.lower() or not isinstance(plugin_info, dict):
+                for current_package_version in package_versions:
+                    local_plugins = self.__get_local_package(local_repo_path, current_package_version or "")
+                    if not local_plugins:
                         continue
-                    is_compatible = not (
-                            not package_version
-                            and settings.VERSION_FLAG
-                            and plugin_info.get(settings.VERSION_FLAG) is not True
-                    )
-                    if not is_compatible and strict_compat:
-                        return None
-                    plugin_dir = self.__get_local_plugin_dir(local_repo_path, candidate_pid, package_version or "")
-                    if not plugin_dir.is_dir():
-                        return None
-                    candidate = plugin_info.copy()
-                    candidate["id"] = candidate_pid
-                    candidate["package_version"] = package_version or ""
-                    candidate["source_order"] = source_order
-                    candidate["repo_path"] = local_repo_path
-                    candidate["path"] = plugin_dir
-                    if not is_compatible:
-                        candidate["compatible"] = False
-                        candidate["skip_reason"] = f"package.json 未声明 {settings.VERSION_FLAG} 兼容"
-                    return candidate
-            return None
+                    for candidate_pid, plugin_info in local_plugins.items():
+                        if candidate_pid.lower() != pid.lower() or not isinstance(plugin_info, dict):
+                            continue
+                        is_compatible = not (
+                                not current_package_version
+                                and settings.VERSION_FLAG
+                                and plugin_info.get(settings.VERSION_FLAG) is not True
+                        )
+                        if not is_compatible and strict_compat:
+                            continue
+                        plugin_dir = self.__get_local_plugin_dir(local_repo_path, candidate_pid,
+                                                                 current_package_version or "")
+                        if not plugin_dir.is_dir():
+                            continue
+                        candidate = plugin_info.copy()
+                        candidate["id"] = candidate_pid
+                        candidate["package_version"] = current_package_version or ""
+                        candidate["repo_order"] = repo_order
+                        candidate["repo_path"] = local_repo_path
+                        candidate["path"] = plugin_dir
+                        if not is_compatible:
+                            candidate["compatible"] = False
+                            candidate["skip_reason"] = f"package.json 未声明 {settings.VERSION_FLAG} 兼容"
+                        if package_version is not None:
+                            return candidate
+                        if not selected_candidate:
+                            selected_candidate = candidate
+                            continue
+                        selected_version = str(selected_candidate.get("version") or "0")
+                        candidate_version = str(candidate.get("version") or "0")
+                        if StringUtils.compare_version(candidate_version, ">", selected_version):
+                            selected_candidate = candidate
+            return selected_candidate
 
         candidates = self.get_local_plugin_candidates()
         for candidate_pid, candidate in candidates.items():
@@ -454,13 +517,19 @@ class PluginHelper(metaclass=WeakSingleton):
 
     def install_local(self, pid: str, repo_url: str = "", force_install: bool = False) -> Tuple[bool, str]:
         """
-        从本地插件仓库目录安装插件。
+        从本地插件仓库目录安装插件
         """
         local_pid = self.parse_local_repo_url(repo_url) if repo_url else pid
         if not local_pid or local_pid.lower() != pid.lower():
             return False, "本地插件来源与插件ID不匹配"
 
-        candidate = self.get_local_plugin_candidate(pid)
+        repo_path = self.parse_local_repo_path(repo_url) if repo_url else None
+        package_version = self.parse_local_repo_package_version(repo_url) if repo_url else None
+        candidate = self.get_local_plugin_candidate(
+            pid,
+            package_version=package_version,
+            repo_path=repo_path
+        )
         if not candidate:
             return False, f"未找到本地插件：{pid}"
 
@@ -489,7 +558,11 @@ class PluginHelper(metaclass=WeakSingleton):
             pid=pid,
             force_install=force_install,
             prepare_content=prepare_local,
-            repo_url=None
+            repo_url=repo_url or self.make_local_repo_url(
+                pid,
+                candidate.get("repo_path"),
+                candidate.get("package_version")
+            )
         )
 
     def __get_file_list(self, pid: str, user_repo: str, package_version: Optional[str] = None) -> \

--- a/app/helper/plugin.py
+++ b/app/helper/plugin.py
@@ -80,10 +80,10 @@ class PluginHelper(metaclass=WeakSingleton):
         """
         获取本地插件来源目录列表。
         """
-        if not settings.PLUGIN_LOCAL_PATHS:
+        if not settings.PLUGIN_LOCAL_REPO_PATHS:
             return []
         paths = []
-        for item in settings.PLUGIN_LOCAL_PATHS.split(","):
+        for item in settings.PLUGIN_LOCAL_REPO_PATHS.split(","):
             local_path = item.strip()
             if not local_path:
                 continue

--- a/app/helper/plugin.py
+++ b/app/helper/plugin.py
@@ -124,6 +124,25 @@ class PluginHelper(metaclass=WeakSingleton):
             return None
 
     @staticmethod
+    def sanitize_repo_url_for_statistic(repo_url: Optional[str]) -> Optional[str]:
+        """
+        统计上报前脱敏 repo_url，避免泄露本地仓库绝对路径
+        """
+        if not repo_url:
+            return repo_url
+        if not PluginHelper.is_local_repo_url(repo_url):
+            return repo_url
+
+        pid = PluginHelper.parse_local_repo_url(repo_url)
+        if not pid:
+            return LOCAL_REPO_PREFIX.rstrip("/")
+
+        return PluginHelper.make_local_repo_url(
+            pid=pid,
+            package_version=PluginHelper.parse_local_repo_package_version(repo_url)
+        )
+
+    @staticmethod
     def get_local_repo_paths() -> List[Path]:
         """
         获取本地插件仓库目录列表
@@ -410,7 +429,7 @@ class PluginHelper(metaclass=WeakSingleton):
             timeout=5
         ).post(install_reg_url, json={
             "plugin_id": pid,
-            "repo_url": repo_url
+            "repo_url": self.sanitize_repo_url_for_statistic(repo_url)
         })
         if res is not None and res.status_code == 200:
             return True
@@ -427,7 +446,10 @@ class PluginHelper(metaclass=WeakSingleton):
         if items:
             for pid, repo_url in items:
                 if pid:
-                    payload_plugins.append({"plugin_id": pid, "repo_url": repo_url})
+                    payload_plugins.append({
+                        "plugin_id": pid,
+                        "repo_url": self.sanitize_repo_url_for_statistic(repo_url)
+                    })
         else:
             plugins = self.systemconfig.get(SystemConfigKey.UserInstalledPlugins)
             if not plugins:
@@ -1323,7 +1345,7 @@ class PluginHelper(metaclass=WeakSingleton):
             timeout=5
         ).post(install_reg_url, json={
             "plugin_id": pid,
-            "repo_url": repo_url
+            "repo_url": self.sanitize_repo_url_for_statistic(repo_url)
         })
         if res is not None and res.status_code == 200:
             return True
@@ -1340,7 +1362,10 @@ class PluginHelper(metaclass=WeakSingleton):
         if items:
             for pid, repo_url in items:
                 if pid:
-                    payload_plugins.append({"plugin_id": pid, "repo_url": repo_url})
+                    payload_plugins.append({
+                        "plugin_id": pid,
+                        "repo_url": self.sanitize_repo_url_for_statistic(repo_url)
+                    })
         else:
             plugins = self.systemconfig.get(SystemConfigKey.UserInstalledPlugins)
             if not plugins:

--- a/app/helper/plugin.py
+++ b/app/helper/plugin.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 import io
 import json
@@ -391,6 +392,9 @@ class PluginHelper(metaclass=WeakSingleton):
         :param force_install: 是否强制安装插件，默认不启用，启用时不进行备份和恢复操作
         :return: (是否成功, 错误信息)
         """
+        if self.is_local_repo_url(repo_url):
+            return self.install_local(pid=pid, repo_url=repo_url, force_install=force_install)
+
         if SystemUtils.is_frozen():
             return False, "可执行文件模式下，只能安装本地插件"
 
@@ -840,10 +844,10 @@ class PluginHelper(metaclass=WeakSingleton):
             logger.error(f"{pid} 准备插件内容失败：{message}")
             if backup_dir:
                 self.__restore_plugin(pid, backup_dir)
-                logger.warning(f"{pid} 插件安装失败，已还原备份插件")
+                logger.warn(f"{pid} 插件安装失败，已还原备份插件")
             else:
                 self.__remove_old_plugin(pid)
-                logger.warning(f"{pid} 已清理对应插件目录，请尝试重新安装")
+                logger.warn(f"{pid} 已清理对应插件目录，请尝试重新安装")
             return False, message
 
         dependencies_exist, dep_ok, dep_msg = self.__install_dependencies_if_required(pid)
@@ -851,10 +855,10 @@ class PluginHelper(metaclass=WeakSingleton):
             logger.error(f"{pid} 依赖安装失败：{dep_msg}")
             if backup_dir:
                 self.__restore_plugin(pid, backup_dir)
-                logger.warning(f"{pid} 插件安装失败，已还原备份插件")
+                logger.warn(f"{pid} 插件安装失败，已还原备份插件")
             else:
                 self.__remove_old_plugin(pid)
-                logger.warning(f"{pid} 已清理对应插件目录，请尝试重新安装")
+                logger.warn(f"{pid} 已清理对应插件目录，请尝试重新安装")
             return False, dep_msg
 
         self.install_reg(pid, repo_url)
@@ -1635,6 +1639,9 @@ class PluginHelper(metaclass=WeakSingleton):
         :param force_install: 是否强制安装插件，默认不启用，启用时不进行备份和恢复操作
         :return: (是否成功, 错误信息)
         """
+        if self.is_local_repo_url(repo_url):
+            return await asyncio.to_thread(self.install_local, pid, repo_url, force_install)
+
         if SystemUtils.is_frozen():
             return False, "可执行文件模式下，只能安装本地插件"
 
@@ -1722,10 +1729,10 @@ class PluginHelper(metaclass=WeakSingleton):
             logger.error(f"{pid} 准备插件内容失败：{message}")
             if backup_dir:
                 await self.__async_restore_plugin(pid, backup_dir)
-                logger.warning(f"{pid} 插件安装失败，已还原备份插件")
+                logger.warn(f"{pid} 插件安装失败，已还原备份插件")
             else:
                 await self.__async_remove_old_plugin(pid)
-                logger.warning(f"{pid} 已清理对应插件目录，请尝试重新安装")
+                logger.warn(f"{pid} 已清理对应插件目录，请尝试重新安装")
             return False, message
 
         dependencies_exist, dep_ok, dep_msg = await self.__async_install_dependencies_if_required(pid)
@@ -1733,10 +1740,10 @@ class PluginHelper(metaclass=WeakSingleton):
             logger.error(f"{pid} 依赖安装失败：{dep_msg}")
             if backup_dir:
                 await self.__async_restore_plugin(pid, backup_dir)
-                logger.warning(f"{pid} 插件安装失败，已还原备份插件")
+                logger.warn(f"{pid} 插件安装失败，已还原备份插件")
             else:
                 await self.__async_remove_old_plugin(pid)
-                logger.warning(f"{pid} 已清理对应插件目录，请尝试重新安装")
+                logger.warn(f"{pid} 已清理对应插件目录，请尝试重新安装")
             return False, dep_msg
 
         await self.async_install_reg(pid, repo_url)

--- a/app/helper/plugin.py
+++ b/app/helper/plugin.py
@@ -76,29 +76,29 @@ class PluginHelper(metaclass=WeakSingleton):
         return pid or None
 
     @staticmethod
-    def get_local_source_paths() -> List[Path]:
+    def get_local_repo_paths() -> List[Path]:
         """
-        获取本地插件来源目录列表。
+        获取本地插件仓库目录列表。
         """
         if not settings.PLUGIN_LOCAL_REPO_PATHS:
             return []
         paths = []
         for item in settings.PLUGIN_LOCAL_REPO_PATHS.split(","):
-            local_path = item.strip()
-            if not local_path:
+            local_repo_path = item.strip()
+            if not local_repo_path:
                 continue
-            path = Path(local_path).expanduser()
+            path = Path(local_repo_path).expanduser()
             if not path.is_absolute():
                 path = settings.ROOT_PATH / path
             paths.append(path.resolve())
         return paths
 
     @staticmethod
-    def __get_local_package(source_path: Path, package_version: Optional[str] = None) -> Optional[Dict[str, dict]]:
+    def __get_local_package(repo_path: Path, package_version: Optional[str] = None) -> Optional[Dict[str, dict]]:
         """
         从本地插件仓库读取 package.json 或 package.{version}.json。
         """
-        package_file = source_path / (
+        package_file = repo_path / (
             f"package.{package_version}.json" if package_version else "package.json"
         )
         if not package_file.exists():
@@ -115,25 +115,25 @@ class PluginHelper(metaclass=WeakSingleton):
         return payload
 
     @staticmethod
-    def __get_local_plugin_dir(source_path: Path, pid: str, package_version: Optional[str]) -> Path:
+    def __get_local_plugin_dir(repo_path: Path, pid: str, package_version: Optional[str]) -> Path:
         plugin_root = f"plugins.{package_version}" if package_version else "plugins"
-        return source_path / plugin_root / pid.lower()
+        return repo_path / plugin_root / pid.lower()
 
     def get_local_plugin_candidates(self) -> Dict[str, dict]:
         """
         扫描本地插件仓库，按插件ID保留版本号最高的候选。
         """
         candidates: Dict[str, dict] = {}
-        for source_order, source_path in enumerate(self.get_local_source_paths()):
-            if not source_path.exists() or not source_path.is_dir():
-                logger.warning(f"本地插件来源目录不存在或不可读：{source_path}")
+        for source_order, repo_path in enumerate(self.get_local_repo_paths()):
+            if not repo_path.exists() or not repo_path.is_dir():
+                logger.warning(f"本地插件仓库目录不存在或不可读：{repo_path}")
                 continue
 
             package_candidates = []
             if settings.VERSION_FLAG:
-                package_candidates.append((settings.VERSION_FLAG, self.__get_local_package(source_path,
+                package_candidates.append((settings.VERSION_FLAG, self.__get_local_package(repo_path,
                                                                                            settings.VERSION_FLAG)))
-            package_candidates.append(("", self.__get_local_package(source_path)))
+            package_candidates.append(("", self.__get_local_package(repo_path)))
 
             for package_version, local_plugins in package_candidates:
                 if local_plugins is None:
@@ -149,7 +149,7 @@ class PluginHelper(metaclass=WeakSingleton):
                     ):
                         continue
 
-                    plugin_dir = self.__get_local_plugin_dir(source_path, pid, package_version)
+                    plugin_dir = self.__get_local_plugin_dir(repo_path, pid, package_version)
                     if not plugin_dir.is_dir():
                         logger.debug(f"跳过本地插件 {pid}：插件目录不存在 {plugin_dir}")
                         continue
@@ -158,7 +158,7 @@ class PluginHelper(metaclass=WeakSingleton):
                     candidate["id"] = pid
                     candidate["package_version"] = package_version
                     candidate["source_order"] = source_order
-                    candidate["source_path"] = source_path
+                    candidate["repo_path"] = repo_path
                     candidate["path"] = plugin_dir
                     candidate_version = str(candidate.get("version") or "0")
 
@@ -174,25 +174,25 @@ class PluginHelper(metaclass=WeakSingleton):
                         candidate_version == existing_version
                         and source_order < int(existing.get("source_order", source_order))
                     ):
-                        logger.info(f"本地插件 {pid} 存在同版本来源，使用靠前目录：{source_path}")
+                        logger.info(f"本地插件 {pid} 存在同版本来源，使用靠前目录：{repo_path}")
                         candidates[pid] = candidate
 
         return candidates
 
     def get_local_plugin_candidate(self, pid: str, package_version: Optional[str] = None,
-                                   source_path: Optional[Path] = None,
+                                   repo_path: Optional[Path] = None,
                                    strict_compat: bool = True) -> Optional[dict]:
         """
         获取指定插件ID的本地插件候选。
         """
         if not pid:
             return None
-        if package_version is not None or source_path is not None:
-            source_paths = [source_path.resolve()] if source_path else self.get_local_source_paths()
-            for source_order, local_source_path in enumerate(self.get_local_source_paths()):
-                if local_source_path not in source_paths:
+        if package_version is not None or repo_path is not None:
+            repo_paths = [repo_path.resolve()] if repo_path else self.get_local_repo_paths()
+            for source_order, local_repo_path in enumerate(self.get_local_repo_paths()):
+                if local_repo_path not in repo_paths:
                     continue
-                local_plugins = self.__get_local_package(local_source_path, package_version or "")
+                local_plugins = self.__get_local_package(local_repo_path, package_version or "")
                 if not local_plugins:
                     continue
                 for candidate_pid, plugin_info in local_plugins.items():
@@ -205,14 +205,14 @@ class PluginHelper(metaclass=WeakSingleton):
                     )
                     if not is_compatible and strict_compat:
                         return None
-                    plugin_dir = self.__get_local_plugin_dir(local_source_path, candidate_pid, package_version or "")
+                    plugin_dir = self.__get_local_plugin_dir(local_repo_path, candidate_pid, package_version or "")
                     if not plugin_dir.is_dir():
                         return None
                     candidate = plugin_info.copy()
                     candidate["id"] = candidate_pid
                     candidate["package_version"] = package_version or ""
                     candidate["source_order"] = source_order
-                    candidate["source_path"] = local_source_path
+                    candidate["repo_path"] = local_repo_path
                     candidate["path"] = plugin_dir
                     if not is_compatible:
                         candidate["compatible"] = False
@@ -450,7 +450,7 @@ class PluginHelper(metaclass=WeakSingleton):
 
     def install_local(self, pid: str, repo_url: str = "", force_install: bool = False) -> Tuple[bool, str]:
         """
-        从本地插件来源目录安装插件。
+        从本地插件仓库目录安装插件。
         """
         local_pid = self.parse_local_repo_url(repo_url) if repo_url else pid
         if not local_pid or local_pid.lower() != pid.lower():

--- a/app/helper/plugin.py
+++ b/app/helper/plugin.py
@@ -26,10 +26,12 @@ from app.log import logger
 from app.schemas.types import SystemConfigKey
 from app.utils.http import RequestUtils, AsyncRequestUtils
 from app.utils.singleton import WeakSingleton
+from app.utils.string import StringUtils
 from app.utils.system import SystemUtils
 from app.utils.url import UrlUtils
 
 PLUGIN_DIR = Path(settings.ROOT_PATH) / "app" / "plugins"
+LOCAL_REPO_PREFIX = "local://"
 
 
 class PluginHelper(metaclass=WeakSingleton):
@@ -48,6 +50,181 @@ class PluginHelper(metaclass=WeakSingleton):
             if not self.systemconfig.get(SystemConfigKey.PluginInstallReport):
                 if self.install_report():
                     self.systemconfig.set(SystemConfigKey.PluginInstallReport, "1")
+
+    @staticmethod
+    def is_local_repo_url(repo_url: Optional[str]) -> bool:
+        """
+        判断是否为本地插件来源标识。
+        """
+        return bool(repo_url and repo_url.startswith(LOCAL_REPO_PREFIX))
+
+    @staticmethod
+    def make_local_repo_url(pid: str) -> str:
+        """
+        生成本地插件安装来源标识。
+        """
+        return f"{LOCAL_REPO_PREFIX}{pid}"
+
+    @staticmethod
+    def parse_local_repo_url(repo_url: str) -> Optional[str]:
+        """
+        从本地插件来源标识中解析插件ID。
+        """
+        if not PluginHelper.is_local_repo_url(repo_url):
+            return None
+        pid = repo_url[len(LOCAL_REPO_PREFIX):].strip("/")
+        return pid or None
+
+    @staticmethod
+    def get_local_source_paths() -> List[Path]:
+        """
+        获取本地插件来源目录列表。
+        """
+        if not settings.PLUGIN_LOCAL_PATHS:
+            return []
+        paths = []
+        for item in settings.PLUGIN_LOCAL_PATHS.split(","):
+            local_path = item.strip()
+            if not local_path:
+                continue
+            path = Path(local_path).expanduser()
+            if not path.is_absolute():
+                path = settings.ROOT_PATH / path
+            paths.append(path.resolve())
+        return paths
+
+    @staticmethod
+    def __get_local_package(source_path: Path, package_version: Optional[str] = None) -> Optional[Dict[str, dict]]:
+        """
+        从本地插件仓库读取 package.json 或 package.{version}.json。
+        """
+        package_file = source_path / (
+            f"package.{package_version}.json" if package_version else "package.json"
+        )
+        if not package_file.exists():
+            return {}
+        try:
+            content = package_file.read_text(encoding="utf-8")
+            payload = json.loads(content)
+        except Exception as e:
+            logger.warning(f"读取本地插件包 {package_file} 失败：{e}")
+            return None
+        if not isinstance(payload, dict):
+            logger.warning(f"本地插件包 {package_file} 格式不正确")
+            return None
+        return payload
+
+    @staticmethod
+    def __get_local_plugin_dir(source_path: Path, pid: str, package_version: Optional[str]) -> Path:
+        plugin_root = f"plugins.{package_version}" if package_version else "plugins"
+        return source_path / plugin_root / pid.lower()
+
+    def get_local_plugin_candidates(self) -> Dict[str, dict]:
+        """
+        扫描本地插件仓库，按插件ID保留版本号最高的候选。
+        """
+        candidates: Dict[str, dict] = {}
+        for source_order, source_path in enumerate(self.get_local_source_paths()):
+            if not source_path.exists() or not source_path.is_dir():
+                logger.warning(f"本地插件来源目录不存在或不可读：{source_path}")
+                continue
+
+            package_candidates = []
+            if settings.VERSION_FLAG:
+                package_candidates.append((settings.VERSION_FLAG, self.__get_local_package(source_path,
+                                                                                           settings.VERSION_FLAG)))
+            package_candidates.append(("", self.__get_local_package(source_path)))
+
+            for package_version, local_plugins in package_candidates:
+                if local_plugins is None:
+                    continue
+                for pid, plugin_info in local_plugins.items():
+                    if not isinstance(plugin_info, dict):
+                        continue
+                    # package.json 中的旧结构需要声明兼容当前版本。
+                    if (
+                            not package_version
+                            and settings.VERSION_FLAG
+                            and plugin_info.get(settings.VERSION_FLAG) is not True
+                    ):
+                        continue
+
+                    plugin_dir = self.__get_local_plugin_dir(source_path, pid, package_version)
+                    if not plugin_dir.is_dir():
+                        logger.debug(f"跳过本地插件 {pid}：插件目录不存在 {plugin_dir}")
+                        continue
+
+                    candidate = plugin_info.copy()
+                    candidate["id"] = pid
+                    candidate["package_version"] = package_version
+                    candidate["source_order"] = source_order
+                    candidate["source_path"] = source_path
+                    candidate["path"] = plugin_dir
+                    candidate_version = str(candidate.get("version") or "0")
+
+                    existing = candidates.get(pid)
+                    if not existing:
+                        candidates[pid] = candidate
+                        continue
+
+                    existing_version = str(existing.get("version") or "0")
+                    if StringUtils.compare_version(candidate_version, ">", existing_version):
+                        candidates[pid] = candidate
+                    elif (
+                        candidate_version == existing_version
+                        and source_order < int(existing.get("source_order", source_order))
+                    ):
+                        logger.info(f"本地插件 {pid} 存在同版本来源，使用靠前目录：{source_path}")
+                        candidates[pid] = candidate
+
+        return candidates
+
+    def get_local_plugin_candidate(self, pid: str, package_version: Optional[str] = None,
+                                   source_path: Optional[Path] = None,
+                                   strict_compat: bool = True) -> Optional[dict]:
+        """
+        获取指定插件ID的本地插件候选。
+        """
+        if not pid:
+            return None
+        if package_version is not None or source_path is not None:
+            source_paths = [source_path.resolve()] if source_path else self.get_local_source_paths()
+            for source_order, local_source_path in enumerate(self.get_local_source_paths()):
+                if local_source_path not in source_paths:
+                    continue
+                local_plugins = self.__get_local_package(local_source_path, package_version or "")
+                if not local_plugins:
+                    continue
+                for candidate_pid, plugin_info in local_plugins.items():
+                    if candidate_pid.lower() != pid.lower() or not isinstance(plugin_info, dict):
+                        continue
+                    is_compatible = not (
+                            not package_version
+                            and settings.VERSION_FLAG
+                            and plugin_info.get(settings.VERSION_FLAG) is not True
+                    )
+                    if not is_compatible and strict_compat:
+                        return None
+                    plugin_dir = self.__get_local_plugin_dir(local_source_path, candidate_pid, package_version or "")
+                    if not plugin_dir.is_dir():
+                        return None
+                    candidate = plugin_info.copy()
+                    candidate["id"] = candidate_pid
+                    candidate["package_version"] = package_version or ""
+                    candidate["source_order"] = source_order
+                    candidate["source_path"] = local_source_path
+                    candidate["path"] = plugin_dir
+                    if not is_compatible:
+                        candidate["compatible"] = False
+                        candidate["skip_reason"] = f"package.json 未声明 {settings.VERSION_FLAG} 兼容"
+                    return candidate
+            return None
+
+        candidates = self.get_local_plugin_candidates()
+        for candidate_pid, candidate in candidates.items():
+            if candidate_pid.lower() == pid.lower():
+                return candidate
+        return None
 
     @staticmethod
     def __parse_plugin_index_response(content: str) -> Optional[Dict[str, dict]]:
@@ -270,6 +447,46 @@ class PluginHelper(metaclass=WeakSingleton):
                 return self.__prepare_content_via_filelist_sync(pid.lower(), user_repo, package_version)
 
             return self.__install_flow_sync(pid, force_install, prepare_filelist, repo_url)
+
+    def install_local(self, pid: str, repo_url: str = "", force_install: bool = False) -> Tuple[bool, str]:
+        """
+        从本地插件来源目录安装插件。
+        """
+        local_pid = self.parse_local_repo_url(repo_url) if repo_url else pid
+        if not local_pid or local_pid.lower() != pid.lower():
+            return False, "本地插件来源与插件ID不匹配"
+
+        candidate = self.get_local_plugin_candidate(pid)
+        if not candidate:
+            return False, f"未找到本地插件：{pid}"
+
+        source_dir = Path(candidate.get("path"))
+        dest_dir = PLUGIN_DIR / pid.lower()
+        try:
+            if source_dir.resolve() == dest_dir.resolve():
+                return False, "本地插件来源不能与运行目录相同"
+        except Exception:
+            return False, "本地插件来源路径无效"
+
+        def prepare_local() -> Tuple[bool, str]:
+            try:
+                shutil.copytree(
+                    source_dir,
+                    dest_dir,
+                    dirs_exist_ok=True,
+                    ignore=shutil.ignore_patterns("__pycache__", "*.pyc", ".DS_Store")
+                )
+                return True, ""
+            except Exception as e:
+                logger.error(f"复制本地插件 {pid} 失败：{e}")
+                return False, f"复制本地插件失败：{e}"
+
+        return self.__install_flow_sync(
+            pid=pid,
+            force_install=force_install,
+            prepare_content=prepare_local,
+            repo_url=None
+        )
 
     def __get_file_list(self, pid: str, user_repo: str, package_version: Optional[str] = None) -> \
             Tuple[Optional[list], Optional[str]]:

--- a/tests/test_plugin_helper.py
+++ b/tests/test_plugin_helper.py
@@ -1,0 +1,23 @@
+from unittest import TestCase
+
+
+class PluginHelperTest(TestCase):
+
+    def test_sanitize_repo_url_for_statistic_keeps_remote_url(self):
+        try:
+            from app.helper.plugin import PluginHelper
+        except ModuleNotFoundError as exc:
+            self.skipTest(f"missing dependency: {exc}")
+        repo_url = "https://github.com/InfinityPacer/MoviePilot-Plugins"
+        self.assertEqual(repo_url, PluginHelper.sanitize_repo_url_for_statistic(repo_url))
+
+    def test_sanitize_repo_url_for_statistic_strips_local_path(self):
+        try:
+            from app.helper.plugin import PluginHelper
+        except ModuleNotFoundError as exc:
+            self.skipTest(f"missing dependency: {exc}")
+        repo_url = "local://TestPlugin?path=/Users/InfinityPacer/GitHub/MoviePilot/MoviePilot-Plugins&version=v2"
+        self.assertEqual(
+            "local://TestPlugin?version=v2",
+            PluginHelper.sanitize_repo_url_for_statistic(repo_url)
+        )


### PR DESCRIPTION
## 变更说明
- 支持通过 `PLUGIN_LOCAL_REPO_PATHS` 配置本地插件仓库目录，读取本地 `package/package.v2` 索引并复用现有插件安装流程
- 启动同步纳入本地仓库来源，容器运行目录缺失时可按现有来源优先逻辑补装插件
- 支持本地插件源码同步与热加载，未安装插件不触发重载
- 本地插件与市场插件按现有版本优先逻辑合并展示

## 验证
- `python -m py_compile app/helper/plugin.py app/core/plugin.py app/api/endpoints/plugin.py app/core/config.py`
- `python -m py_compile app/core/plugin.py`
- `git diff --check`

本 PR 为 codex 协作提交
