### PR TITLE
Keep traceback in _create_agent

### DIFF
--- a/app/agent/__init__.py
+++ b/app/agent/__init__.py
@@ -302,7 +302,7 @@ class MoviePilotAgent:
             )
         except Exception as e:
             logger.error(f"创建 Agent 失败: {e}")
-            raise e
+            raise
 
     async def process(
         self,


### PR DESCRIPTION
Was reading through app/agent/__init__.py and it re-raises the caught exception object and loses the cleaner traceback shape. this patch changes that to a plain raise so the original stack stays intact. Not sure if this is intentional, so feel free to ignore.
Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.