### PR TITLE
fix: falsy values incorrectly deleted/skipped in UserConfigOper and ProgressHelper

### DIFF
--- a/app/agent/__init__.py
+++ b/app/agent/__init__.py
@@ -302,7 +302,7 @@ class MoviePilotAgent:
             )
         except Exception as e:
             logger.error(f"创建 Agent 失败: {e}")
-            raise e
+            raise
 
     async def process(
         self,

--- a/app/db/userconfig_oper.py
+++ b/app/db/userconfig_oper.py
@@ -30,7 +30,7 @@ class UserConfigOper(DbOper, metaclass=Singleton):
         # 写入数据库
         conf = UserConfig.get_by_key(db=self._db, username=username, key=key)
         if conf:
-            if value:
+            if value is not None:
                 conf.update(self._db, {"value": value})
             else:
                 conf.delete(self._db, conf.id)

--- a/app/helper/progress.py
+++ b/app/helper/progress.py
@@ -61,11 +61,11 @@ class ProgressHelper:
         current = self._progress.get(self._key)
         if not current or not current.get('enable'):
             return
-        if value:
+        if value is not None:
             current['value'] = value
-        if text:
+        if text is not None:
             current['text'] = text
-        if data:
+        if data is not None:
             if not current.get('data'):
                 current['data'] = {}
             current['data'].update(data)


### PR DESCRIPTION
Two related logic bugs where falsy values (`False`, `0`, `""`, `[]`) are treated as absent rather than as valid stored values.

---

### Fix 1 — `UserConfigOper.set()` deletes the row instead of updating it for falsy values

**File:** `app/db/userconfig_oper.py:33`

```python
# Before — deletes the DB row when value is False, 0, or ""
if value:
    conf.update(self._db, {"value": value})
else:
    conf.delete(self._db, conf.id)

# After
if value is not None:
    conf.update(self._db, {"value": value})
else:
    conf.delete(self._db, conf.id)
```

Setting a boolean user config to `False` or a numeric config to `0` would silently delete the DB row. The in-memory cache stores the value correctly, but after a restart the cache is rebuilt from DB — so the value was permanently lost across restarts. The intent of deletion should only be when `None` is passed explicitly.

---

### Fix 2 — `ProgressHelper.update()` silently ignores `value=0`, empty `text`, and empty `data`

**File:** `app/helper/progress.py:64-68`

```python
# Before — drops 0%, "", {}
if value:        → if value is not None:
if text:         → if text is not None:
if data:         → if data is not None:
```

A task resetting its progress to 0% or clearing its status text would leave the UI stuck at whatever the previous value was. Changed to explicit `None` checks.

---

Both changes are minimal — one condition each. Happy to revise if there are cases where the old behavior was intentional.