### PR TITLE
fix(subscribe): 修复订阅电视剧季数判断逻辑

### DIFF
--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -2348,7 +2348,7 @@ class SubscribeChain(ChainBase):
                         )
                         if subscribe.type == MediaType.TV.value:
                             season_number = file_meta.begin_season
-                            if season_number and season_number != subscribe.season:
+                            if season_number is not None and season_number != subscribe.season:
                                 continue
                             episode_number = file_meta.begin_episode
                             if episode_number and episodes.get(episode_number):
@@ -2389,7 +2389,7 @@ class SubscribeChain(ChainBase):
                 )
                 if subscribe.type == MediaType.TV.value:
                     season_number = file_meta.begin_season
-                    if season_number and season_number != subscribe.season:
+                    if season_number is not None and season_number != subscribe.season:
                         continue
                     episode_number = file_meta.begin_episode
                     if episode_number and episodes.get(episode_number):


### PR DESCRIPTION
## 简版摘要
修复电视剧订阅时的季数判断方式，将 [`season_number`]() 从 truthy 判断改为显式判空，避免第 0 季资源被错误当作当前查询季。

如下图②, 季0出现在第四季的文件列表中

<img width="688" height="396" alt="image" src="https://github.com/user-attachments/assets/4b5ade1c-f7d7-4254-8ba7-18d79e71970f" />


## 变更说明

原逻辑使用 [`if season_number and season_number != subscribe.season:`]() 进行判断，这会把值为 0 的季数视为假值，导致部分场景下季数校验失效。

修改后统一改为 [`if season_number is not None and season_number != subscribe.season:`]()，仅在季数字段确实存在时才进行比对，从而正确处理第 0 季（Specials）等情况。

## 问题背景
在电视剧订阅匹配过程中，解析出的季数来自 [`file_meta.begin_season`]()。当季数为 0 时，原先基于 truthy 的判断会把该值当作“未提供季数”，从而绕过预期的季数过滤逻辑，可能导致：

- 第 0 季资源与其他季订阅发生误匹配
- 特别篇 / SP 资源在订阅筛选时行为异常
- 相同逻辑路径下出现不一致的订阅命中结果

## 修改内容
- 将两处季数判断从 truthy 判断改为显式空值判断
- 保证 [`season_number = 0`]() 时仍会参与季数比对
- 统一两个匹配分支的行为，降低电视剧订阅筛选的误判概率

## 影响范围
该修改仅影响电视剧订阅场景下的季数过滤逻辑，不影响电影订阅逻辑。主要提升以下场景的准确性：

- 包含第 0 季的剧集订阅
- Specials / SP 资源识别