### PR TITLE
fix(plugin): 修复插件加载失败后热重载复用旧模块

### DIFF
--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -141,16 +141,19 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
             logger.info(f"正在停止插件 {pid}...")
             plugin_obj = self._running_plugins.get(pid)
             if not plugin_obj:
+                # 指定插件可能在上次加载时已导入模块但初始化失败，此时不会进入运行态列表。
+                # 仍需继续清理类缓存和 sys.modules，避免后续热重载反复复用旧模块。
                 logger.debug(f"插件 {pid} 不存在或未加载")
-                return
-            plugins = {pid: plugin_obj}
+                plugins = {}
+            else:
+                plugins = {pid: plugin_obj}
         else:
             logger.info("正在停止所有插件...")
             plugins = self._running_plugins
         for plugin_id, plugin in plugins.items():
             eventmanager.disable_event_handler(type(plugin))
             self.__stop_plugin(plugin)
-        # 清空对像
+        # 清空对象
         if pid:
             # 清空指定插件
             self._plugins.pop(pid, None)


### PR DESCRIPTION
## 变更说明

- 修复指定插件 stop 时，如果插件未进入运行态会提前返回的问题
- 插件上次导入后初始化失败时，仍继续清理插件类缓存和 sys.modules 模块缓存
- 避免插件源码修复后热重载继续复用旧模块，导致必须重启后端才能恢复

## 验证

- /Users/chengyu/GitHub/MoviePilot/.venv/bin/python -m py_compile app/core/plugin.py
- git diff --check
- 模拟 _plugins 存在、_running_plugins 缺失、sys.modules 存在旧插件模块的失败加载场景，确认 stop(pid) 会清理缓存

本 PR 为 codex 协作提交