### PR TITLE
fix: 修复媒体服务器电视剧缓存ID失效回退

### DIFF
--- a/app/modules/emby/emby.py
+++ b/app/modules/emby/emby.py
@@ -407,6 +407,7 @@ class Emby:
         """
         if not self._host or not self._apikey:
             return None, None
+        cached_item_id = item_id
         # 电视剧
         if not item_id:
             item_id = self.__get_emby_series_id_by_name(title, year)
@@ -416,6 +417,17 @@ class Emby:
                 return None, {}
         # 验证tmdbid是否相同
         item_info = self.get_iteminfo(item_id)
+        if not item_info and cached_item_id and title:
+            # 媒体删除后重新入库会导致缓存ID失效，回退到标题搜索避免误判整部剧缺失。
+            logger.warning(f"Emby缓存的电视剧媒体ID {cached_item_id} 已失效，尝试按标题重新搜索：{title}")
+            item_id = self.__get_emby_series_id_by_name(title, year)
+            if item_id is None:
+                return None, None
+            if not item_id:
+                return None, {}
+            item_info = self.get_iteminfo(item_id)
+        if not item_info:
+            return None, {}
         if item_info:
             if tmdb_id and item_info.tmdbid:
                 if str(tmdb_id) != str(item_info.tmdbid):

--- a/app/modules/jellyfin/jellyfin.py
+++ b/app/modules/jellyfin/jellyfin.py
@@ -429,6 +429,7 @@ class Jellyfin:
         """
         if not self._host or not self._apikey or not self.user:
             return None, None
+        cached_item_id = item_id
         # 查TVID
         if not item_id:
             item_id = self.__get_jellyfin_series_id_by_name(title, year)
@@ -438,6 +439,17 @@ class Jellyfin:
                 return None, {}
         # 验证tmdbid是否相同
         item_info = self.get_iteminfo(item_id)
+        if not item_info and cached_item_id and title:
+            # 媒体删除后重新入库会导致缓存ID失效，回退到标题搜索避免误判整部剧缺失。
+            logger.warning(f"Jellyfin缓存的电视剧媒体ID {cached_item_id} 已失效，尝试按标题重新搜索：{title}")
+            item_id = self.__get_jellyfin_series_id_by_name(title, year)
+            if item_id is None:
+                return None, None
+            if not item_id:
+                return None, {}
+            item_info = self.get_iteminfo(item_id)
+        if not item_info:
+            return None, {}
         if item_info:
             if tmdb_id and item_info.tmdbid:
                 if str(tmdb_id) != str(item_info.tmdbid):

--- a/app/modules/plex/plex.py
+++ b/app/modules/plex/plex.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import List, Optional, Dict, Tuple, Generator, Any, Union
 from urllib.parse import quote_plus
 
+from plexapi.exceptions import NotFound
 from plexapi.myplex import MyPlexAccount
 from plexapi.server import PlexServer
 from requests import Response, Session
@@ -260,20 +261,18 @@ class Plex:
         if not self._plex:
             return None, {}
         if item_id:
-            videos = self.__fetch_item(item_id)
+            try:
+                videos = self.__fetch_item(item_id)
+            except NotFound:
+                # Plex删除并重新入库后metadata id会变化，缓存的旧item_id失效时回退到搜索路径。
+                logger.warning(f"Plex缓存的电视剧媒体ID {item_id} 已失效，尝试按标题重新搜索：{title}")
+                videos = self.__search_show(title=title,
+                                            original_title=original_title,
+                                            year=year)
         else:
-            # 兼容年份为空的场景
-            kwargs = {"year": year} if year else {}
-            # 根据标题和年份模糊搜索，该结果不够准确
-            videos = self._plex.library.search(title=title,
-                                               libtype="show",
-                                               **kwargs)
-            if (not videos
-                    and original_title
-                    and str(original_title) != str(title)):
-                videos = self._plex.library.search(title=original_title,
-                                                   libtype="show",
-                                                   **kwargs)
+            videos = self.__search_show(title=title,
+                                        original_title=original_title,
+                                        year=year)
 
         if not videos:
             return None, {}
@@ -292,6 +291,31 @@ class Plex:
                 season_episodes[episode.seasonNumber] = []
             season_episodes[episode.seasonNumber].append(episode.index)
         return videos.key, season_episodes
+
+    def __search_show(self,
+                      title: Optional[str] = None,
+                      original_title: Optional[str] = None,
+                      year: Optional[str] = None) -> Any:
+        """
+        按标题搜索Plex电视剧条目，供常规查询和缓存item_id失效后的回退查询复用。
+        :param title: 标题
+        :param original_title: 原产地标题
+        :param year: 年份，可以为空，为空时不按年份过滤
+        :return: Plex搜索返回的电视剧条目列表
+        """
+        # 兼容年份为空的场景
+        kwargs = {"year": year} if year else {}
+        # 根据标题和年份模糊搜索，该结果不够准确，后续仍会通过tmdb_id校验。
+        videos = self._plex.library.search(title=title,
+                                           libtype="show",
+                                           **kwargs)
+        if (not videos
+                and original_title
+                and str(original_title) != str(title)):
+            videos = self._plex.library.search(title=original_title,
+                                               libtype="show",
+                                               **kwargs)
+        return videos
 
     def get_remote_image_by_id(self,
                                item_id: str,

--- a/app/modules/trimemedia/trimemedia.py
+++ b/app/modules/trimemedia/trimemedia.py
@@ -307,12 +307,20 @@ class TrimeMedia:
         if not self.is_authenticated():
             return None, None
 
+        cached_item_id = item_id
         if not item_id:
             item_id = self.__get_series_id_by_name(title, year)
             if item_id is None:
                 return None, None
 
         item_info = self.get_iteminfo(item_id)
+        if not item_info and cached_item_id and title:
+            # 媒体删除后重新入库会导致缓存ID失效，回退到标题搜索避免误判整部剧缺失。
+            logger.warning(f"飞牛影视缓存的电视剧媒体ID {cached_item_id} 已失效，尝试按标题重新搜索：{title}")
+            item_id = self.__get_series_id_by_name(title, year)
+            if item_id is None:
+                return None, None
+            item_info = self.get_iteminfo(item_id)
         if not item_info:
             return None, {}
 

--- a/app/modules/ugreen/ugreen.py
+++ b/app/modules/ugreen/ugreen.py
@@ -653,9 +653,19 @@ class Ugreen:
         tmdb_id: Optional[int] = None,
         season: Optional[int] = None,
     ) -> tuple[Optional[str], Optional[Dict[int, list]]]:
+        """
+        根据标题、年份、TMDB ID和季号查询绿联媒体库中的电视剧已入库集数。
+        :param item_id: 绿联媒体库中的剧集ID，存在缓存ID时优先使用
+        :param title: 标题
+        :param year: 年份
+        :param tmdb_id: TMDB ID
+        :param season: 季号
+        :return: 命中的剧集ID及每季已入库集数
+        """
         if not self.is_authenticated() or not self._api:
             return None, None
 
+        cached_item_id = item_id
         if not item_id:
             if not title:
                 return None, None
@@ -669,6 +679,16 @@ class Ugreen:
             item_id = str(item_id)
 
         item_info = self.get_iteminfo(item_id)
+        if not item_info and cached_item_id and title:
+            # 媒体删除后重新入库会导致缓存ID失效，回退到标题搜索避免误判整部剧缺失。
+            logger.warning(f"绿联缓存的电视剧媒体ID {cached_item_id} 已失效，尝试按标题重新搜索：{title}")
+            if not (tv_info := self.__search_tv_item(title, year, tmdb_id)):
+                return None, {}
+            found_item_id = tv_info.get("ug_video_info_id")
+            if found_item_id is None:
+                return None, {}
+            item_id = str(found_item_id)
+            item_info = self.get_iteminfo(item_id)
         if not item_info:
             return None, {}
         if tmdb_id and item_info.tmdbid and tmdb_id != item_info.tmdbid:

--- a/tests/test_mediaserver_tv_stale_itemid.py
+++ b/tests/test_mediaserver_tv_stale_itemid.py
@@ -1,0 +1,203 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from plexapi.exceptions import NotFound
+
+from app.modules.emby.emby import Emby
+from app.modules.jellyfin.jellyfin import Jellyfin
+from app.modules.plex.plex import Plex
+from app.modules.trimemedia.trimemedia import TrimeMedia
+from app.modules.ugreen.ugreen import Ugreen
+
+
+class _FakeResponse:
+    """提供媒体服务器接口响应的最小json封装。"""
+
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def json(self):
+        """返回测试预置的响应体。"""
+        return self._payload
+
+
+class MediaServerTvStaleItemIdTest(unittest.TestCase):
+    """验证电视剧缓存ID失效后，各媒体服务器适配器会回退到标题搜索。"""
+
+    @staticmethod
+    def _build_plex():
+        """构造绕过真实连接的Plex实例，便于单测直接注入plexapi mock。"""
+        plex = Plex.__new__(Plex)
+        plex._host = "http://192.168.8.254:32400/"
+        plex._playhost = None
+        plex._token = "plex-token"
+        plex._plex = Mock()
+        return plex
+
+    def test_plex_tv_episodes_fallback_when_cached_item_id_not_found(self):
+        """Plex缓存ID失效时，应按标题重新搜索并返回新条目的季集。"""
+        plex = self._build_plex()
+        plex._plex.fetchItem.side_effect = NotFound("not found")
+
+        show = Mock()
+        show.key = "/library/metadata/200"
+        show.guids = [{"id": "tmdb://12345"}]
+        show.episodes.return_value = [
+            Mock(seasonNumber=1, index=1),
+            Mock(seasonNumber=1, index=2),
+            Mock(seasonNumber=2, index=1),
+        ]
+        plex._plex.library.search.return_value = [show]
+
+        item_id, episodes = plex.get_tv_episodes(
+            item_id="107797",
+            title="测试剧集",
+            original_title="Test Show",
+            year="2026",
+            tmdb_id=12345,
+            season=1,
+        )
+
+        self.assertEqual(item_id, "/library/metadata/200")
+        self.assertEqual(episodes, {1: [1, 2]})
+        plex._plex.fetchItem.assert_called_once_with(107797)
+        plex._plex.library.search.assert_called_once_with(title="测试剧集", libtype="show", year="2026")
+
+    def test_plex_tv_episodes_returns_empty_when_stale_item_id_search_misses(self):
+        """Plex缓存ID失效且标题搜索不到时，应返回未入库结果而不是继续抛出404。"""
+        plex = self._build_plex()
+        plex._plex.fetchItem.side_effect = NotFound("not found")
+        plex._plex.library.search.side_effect = [[], []]
+
+        item_id, episodes = plex.get_tv_episodes(
+            item_id="107797",
+            title="测试剧集",
+            original_title="Test Show",
+            year="2026",
+        )
+
+        self.assertIsNone(item_id)
+        self.assertEqual(episodes, {})
+        self.assertEqual(plex._plex.library.search.call_count, 2)
+
+    def test_plex_tv_episodes_uses_valid_item_id_without_search(self):
+        """Plex缓存ID仍有效时，应保持直接查询路径，避免额外模糊搜索。"""
+        plex = self._build_plex()
+
+        show = Mock()
+        show.key = "/library/metadata/107797"
+        show.guids = [{"id": "tmdb://12345"}]
+        show.episodes.return_value = [Mock(seasonNumber=1, index=1)]
+        plex._plex.fetchItem.return_value = show
+
+        item_id, episodes = plex.get_tv_episodes(
+            item_id="107797",
+            title="测试剧集",
+            tmdb_id=12345,
+        )
+
+        self.assertEqual(item_id, "/library/metadata/107797")
+        self.assertEqual(episodes, {1: [1]})
+        plex._plex.fetchItem.assert_called_once_with(107797)
+        plex._plex.library.search.assert_not_called()
+
+    def test_emby_tv_episodes_fallback_when_cached_item_id_missing(self):
+        """Emby缓存ID失效时，应重新搜索剧集ID后再查询集信息。"""
+        client = Emby.__new__(Emby)
+        client._host = "http://emby.local/"
+        client._apikey = "api-key"
+        client.user = "user-id"
+        client.get_iteminfo = Mock(side_effect=[None, SimpleNamespace(tmdbid=12345)])
+        client._Emby__get_emby_series_id_by_name = Mock(return_value="new-series-id")
+
+        with patch("app.modules.emby.emby.RequestUtils") as request_utils_cls:
+            request_utils_cls.return_value.get_res.return_value = _FakeResponse({
+                "Items": [{"ParentIndexNumber": 1, "IndexNumber": 1}]
+            })
+
+            item_id, episodes = client.get_tv_episodes(
+                item_id="old-series-id",
+                title="测试剧集",
+                year="2026",
+                tmdb_id=12345,
+            )
+
+        self.assertEqual(item_id, "new-series-id")
+        self.assertEqual(episodes, {1: [1]})
+        client._Emby__get_emby_series_id_by_name.assert_called_once_with("测试剧集", "2026")
+
+    def test_jellyfin_tv_episodes_fallback_when_cached_item_id_missing(self):
+        """Jellyfin缓存ID失效时，应重新搜索剧集ID后再查询集信息。"""
+        client = Jellyfin.__new__(Jellyfin)
+        client._host = "http://jellyfin.local/"
+        client._apikey = "api-key"
+        client.user = "user-id"
+        client.get_iteminfo = Mock(side_effect=[None, SimpleNamespace(tmdbid=12345)])
+        client._Jellyfin__get_jellyfin_series_id_by_name = Mock(return_value="new-series-id")
+
+        with patch("app.modules.jellyfin.jellyfin.RequestUtils") as request_utils_cls:
+            request_utils_cls.return_value.get_res.return_value = _FakeResponse({
+                "Items": [{"ParentIndexNumber": 1, "IndexNumber": 1}]
+            })
+
+            item_id, episodes = client.get_tv_episodes(
+                item_id="old-series-id",
+                title="测试剧集",
+                year="2026",
+                tmdb_id=12345,
+            )
+
+        self.assertEqual(item_id, "new-series-id")
+        self.assertEqual(episodes, {1: [1]})
+        client._Jellyfin__get_jellyfin_series_id_by_name.assert_called_once_with("测试剧集", "2026")
+
+    def test_ugreen_tv_episodes_fallback_when_cached_item_id_missing(self):
+        """绿联缓存ID失效时，应重新搜索剧集ID后再查询集信息。"""
+        client = Ugreen.__new__(Ugreen)
+        client._api = Mock()
+        client.is_authenticated = Mock(return_value=True)
+        client.get_iteminfo = Mock(side_effect=[None, SimpleNamespace(tmdbid=12345)])
+        client._Ugreen__search_tv_item = Mock(return_value={"ug_video_info_id": "new-series-id"})
+        client._api.get_tv.return_value = {
+            "season_info": [{"category_id": "season-1", "season_num": 1}],
+            "tv_info": [{"category_id": "season-1", "episode": 1}],
+        }
+
+        item_id, episodes = client.get_tv_episodes(
+            item_id="old-series-id",
+            title="测试剧集",
+            year="2026",
+            tmdb_id=12345,
+        )
+
+        self.assertEqual(item_id, "new-series-id")
+        self.assertEqual(episodes, {1: [1]})
+        client._Ugreen__search_tv_item.assert_called_once_with("测试剧集", "2026", 12345)
+
+    def test_trime_media_tv_episodes_fallback_when_cached_item_id_missing(self):
+        """飞牛影视缓存ID失效时，应重新搜索剧集ID后再查询集信息。"""
+        client = TrimeMedia.__new__(TrimeMedia)
+        client._api = Mock()
+        client.is_authenticated = Mock(return_value=True)
+        client.get_iteminfo = Mock(side_effect=[None, SimpleNamespace(tmdbid=12345)])
+        client._TrimeMedia__get_series_id_by_name = Mock(return_value="new-series-id")
+        client._api.season_list.return_value = [SimpleNamespace(season_number=1, guid="season-1")]
+        client._api.episode_list.return_value = [
+            SimpleNamespace(season_number=1, episode_number=1)
+        ]
+
+        item_id, episodes = client.get_tv_episodes(
+            item_id="old-series-id",
+            title="测试剧集",
+            year="2026",
+            tmdb_id=12345,
+        )
+
+        self.assertEqual(item_id, "new-series-id")
+        self.assertEqual(episodes, {1: [1]})
+        client._TrimeMedia__get_series_id_by_name.assert_called_once_with("测试剧集", "2026")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plex_image_lookup.py
+++ b/tests/test_plex_image_lookup.py
@@ -5,12 +5,18 @@ from app.modules.plex.plex import Plex
 
 
 class PlexImageLookupTest(unittest.TestCase):
-    def test_get_remote_image_by_id_uses_item_arts_for_children_key(self):
+    @staticmethod
+    def _build_plex():
+        """构造绕过真实连接的Plex实例，便于单测直接注入plexapi mock。"""
         plex = Plex.__new__(Plex)
         plex._host = "http://192.168.8.254:32400/"
         plex._playhost = None
         plex._token = "plex-token"
         plex._plex = Mock()
+        return plex
+
+    def test_get_remote_image_by_id_uses_item_arts_for_children_key(self):
+        plex = self._build_plex()
         plex._plex.fetchItems.side_effect = AssertionError("should not use raw fetchItems with /children key")
 
         item = Mock()
@@ -31,11 +37,7 @@ class PlexImageLookupTest(unittest.TestCase):
         plex._plex.fetchItem.assert_called_once_with(ekey="/library/metadata/29242/children")
 
     def test_get_remote_image_by_id_falls_back_to_local_art_url(self):
-        plex = Plex.__new__(Plex)
-        plex._host = "http://192.168.8.254:32400/"
-        plex._playhost = None
-        plex._token = "plex-token"
-        plex._plex = Mock()
+        plex = self._build_plex()
 
         item = Mock()
         item.TYPE = "show"


### PR DESCRIPTION
## 变更说明

修复媒体服务器中电视剧缓存 `item_id` 失效后，订阅/下载检查可能直接报错或误判的问题。

本次覆盖 Plex、Emby、Jellyfin、绿联和飞牛影视的电视剧查询路径：当缓存中的剧集 ID 已无法查到详情时，按标题、年份和 TMDB 信息重新搜索剧集 ID，再继续查询已入库季集。

## 原因

用户在媒体服务器中删除剧集后重新入库时，媒体服务器内部 metadata/item id 可能发生变化。MoviePilot 的媒体服务器缓存可能短时间仍保存旧 ID，导致电视剧路径直接使用旧 ID 查询失败。

电影路径已有 `get_iteminfo` 失败后继续标题搜索的 fallback，本次主要补齐电视剧路径。

## 验证

- `/Users/chengyu/GitHub/MoviePilot/.venv/bin/python -m unittest tests.test_plex_image_lookup tests.test_mediaserver_tv_stale_itemid`
- `/Users/chengyu/GitHub/MoviePilot/.venv/bin/python -m py_compile app/modules/plex/plex.py app/modules/emby/emby.py app/modules/jellyfin/jellyfin.py app/modules/ugreen/ugreen.py app/modules/trimemedia/trimemedia.py tests/test_plex_image_lookup.py tests/test_mediaserver_tv_stale_itemid.py`
- `git diff --check`

本 PR 为 codex 协作提交
