### PR TITLE
fix: handle None items in alipan list to prevent TypeError

### DIFF
--- a/app/modules/filemanager/storages/alipan.py
+++ b/app/modules/filemanager/storages/alipan.py
@@ -378,9 +378,10 @@ class AliPan(StorageBase, metaclass=WeakSingleton):
             if not resp:
                 break
             next_marker = resp.get("next_marker")
-            for item in resp.get("items", []):
+            current_items = resp.get("items") or []
+            for item in current_items:
                 items.append(self.__get_fileitem(item, parent=str(fileitem.path)))
-            if len(resp.get("items")) < 100:
+            if len(current_items) < 100:
                 break
         return items
 


### PR DESCRIPTION
When the Aliyun Drive API returns an error response (e.g. UserNotAllowedAccessDrive), resp.get("items") is None, causing len() to raise TypeError. Extract items with a safe default to fix the crash and avoid a potential infinite loop.

Fix https://github.com/jxxghp/MoviePilot/issues/5664