### PR TITLE
feat(subscribe): support best-version modes

### DIFF
--- a/app/agent/tools/impl/query_subscribes.py
+++ b/app/agent/tools/impl/query_subscribes.py
@@ -33,6 +33,7 @@ QUERY_SUBSCRIBE_OUTPUT_FIELDS = [
     "sites",
     "downloader",
     "best_version",
+    "best_version_mode",
     "current_priority",
     "episode_priority",
     "save_path",

--- a/app/agent/tools/impl/update_subscribe.py
+++ b/app/agent/tools/impl/update_subscribe.py
@@ -10,7 +10,7 @@ from app.core.event import eventmanager
 from app.db import AsyncSessionFactory
 from app.db.models.subscribe import Subscribe
 from app.log import logger
-from app.schemas.types import EventType
+from app.schemas.types import BestVersionMode, EventType
 
 
 class UpdateSubscribeInput(BaseModel):
@@ -74,6 +74,10 @@ class UpdateSubscribeInput(BaseModel):
         None,
         description="Whether to upgrade to best version: 0 for no, 1 for yes (optional)",
     )
+    best_version_mode: Optional[str] = Field(
+        None,
+        description="Best-version mode for TV subscriptions: episode or whole_only (optional)",
+    )
     custom_words: Optional[str] = Field(
         None, description="Custom recognition words (optional)"
     )
@@ -115,6 +119,8 @@ class UpdateSubscribeTool(MoviePilotTool):
             fields_updated.append("站点")
         if kwargs.get("downloader"):
             fields_updated.append("下载器")
+        if kwargs.get("best_version_mode"):
+            fields_updated.append("洗版模式")
 
         if fields_updated:
             return f"更新订阅 #{subscribe_id}: {', '.join(fields_updated)}"
@@ -140,6 +146,7 @@ class UpdateSubscribeTool(MoviePilotTool):
         downloader: Optional[str] = None,
         save_path: Optional[str] = None,
         best_version: Optional[int] = None,
+        best_version_mode: Optional[str] = None,
         custom_words: Optional[str] = None,
         media_category: Optional[str] = None,
         episode_group: Optional[str] = None,
@@ -230,6 +237,17 @@ class UpdateSubscribeTool(MoviePilotTool):
                     subscribe_dict["save_path"] = save_path
                 if best_version is not None:
                     subscribe_dict["best_version"] = best_version
+                if best_version_mode is not None:
+                    valid_best_version_modes = [*BestVersionMode.values(), ""]
+                    if best_version_mode not in valid_best_version_modes:
+                        return json.dumps(
+                            {
+                                "success": False,
+                                "message": f"无效的洗版模式: {best_version_mode}，有效模式: episode, whole_only",
+                            },
+                            ensure_ascii=False,
+                        )
+                    subscribe_dict["best_version_mode"] = BestVersionMode.normalize(best_version_mode)
 
                 # 其他配置
                 if custom_words is not None:

--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -38,8 +38,8 @@ from app.helper.subscribe import SubscribeHelper
 from app.helper.torrent import TorrentHelper
 from app.log import logger
 from app.schemas import MediaRecognizeConvertEventData
-from app.schemas.types import MediaType, SystemConfigKey, MessageChannel, NotificationType, EventType, ChainEventType, \
-    ContentType
+from app.schemas.types import BestVersionMode, MediaType, SystemConfigKey, MessageChannel, NotificationType, EventType, \
+    ChainEventType, ContentType
 
 
 subscribe_interaction_manager = SlashInteractionManager()
@@ -292,6 +292,126 @@ class SubscribeChain(ChainBase):
                 interested.append(episode_num)
         return sorted(set(interested))
 
+    @classmethod
+    def __get_best_version_mode(cls, subscribe: Subscribe) -> str:
+        """
+        获取 TV 洗版模式，旧订阅或非法值统一回落到分集洗版。
+        """
+        mode = subscribe.best_version_mode
+        if not mode:
+            mode = cls.__get_default_subscribe_config(MediaType.TV, "best_version_mode")
+        return BestVersionMode.normalize(mode) or BestVersionMode.EPISODE.value
+
+    @classmethod
+    def __is_best_version_whole_context(cls, subscribe: Subscribe, context: Context) -> bool:
+        """
+        判断候选是否可作为全集洗版资源，避免仅凭单集命中就进入全集优先分支。
+        """
+        if subscribe.type != MediaType.TV.value:
+            return False
+
+        meta = context.meta_info if context else None
+        episodes = meta.episode_list if meta else []
+        if not episodes:
+            # 无明确集数时沿用现有约定，按合集或整季包处理。
+            return True
+
+        target_episodes = cls.__get_best_version_target_episodes(subscribe)
+        if not target_episodes:
+            return False
+        return set(target_episodes).issubset(set(episodes))
+
+    @classmethod
+    def __is_best_version_context_allowed(cls, subscribe: Subscribe, context: Context) -> bool:
+        """
+        按洗版模式判断 TV 候选是否允许进入后续优先级过滤。
+        """
+        if subscribe.type != MediaType.TV.value:
+            return True
+
+        mode = cls.__get_best_version_mode(subscribe)
+        if mode == BestVersionMode.WHOLE_ONLY.value:
+            return cls.__is_best_version_whole_context(subscribe, context)
+        return cls._is_episode_range_covered(meta=context.meta_info, subscribe=subscribe)
+
+    @classmethod
+    def __build_whole_best_version_no_exists(
+            cls,
+            subscribe: Subscribe,
+            mediakey: Union[int, str],
+    ) -> Dict[Union[int, str], Dict[int, schemas.NotExistMediaInfo]]:
+        """
+        构造全集洗版下载使用的缺失信息，强制 DownloadChain 先按整季资源处理。
+        """
+        return {
+            mediakey: {
+                subscribe.season: schemas.NotExistMediaInfo(
+                    season=subscribe.season,
+                    episodes=[],
+                    total_episode=subscribe.total_episode,
+                    start_episode=subscribe.start_episode or 1,
+                )
+            }
+        }
+
+    @classmethod
+    def __batch_download_best_version(
+            cls,
+            subscribe: Subscribe,
+            contexts: List[Context],
+            no_exists: Dict[Union[int, str], Dict[int, schemas.NotExistMediaInfo]],
+            username: Optional[str] = None,
+            save_path: Optional[str] = None,
+            downloader: Optional[str] = None,
+            source: Optional[str] = None,
+    ) -> Tuple[List[Context], Dict[Union[int, str], Dict[int, schemas.NotExistMediaInfo]]]:
+        """
+        对 TV 洗版应用分集洗版/仅全集策略，分集模式下优先尝试全集资源。
+        """
+        if not subscribe.best_version or subscribe.type != MediaType.TV.value:
+            return DownloadChain().batch_download(
+                contexts=contexts,
+                no_exists=no_exists,
+                username=username,
+                save_path=save_path,
+                downloader=downloader,
+                source=source,
+            )
+
+        mode = cls.__get_best_version_mode(subscribe)
+        whole_contexts = [
+            context for context in contexts
+            if cls.__is_best_version_whole_context(subscribe, context)
+        ]
+        if whole_contexts:
+            mediakey = subscribe.tmdbid or subscribe.doubanid
+            whole_no_exists = cls.__build_whole_best_version_no_exists(
+                subscribe=subscribe,
+                mediakey=mediakey,
+            )
+            downloads, lefts = DownloadChain().batch_download(
+                contexts=whole_contexts,
+                no_exists=whole_no_exists,
+                username=username,
+                save_path=save_path,
+                downloader=downloader,
+                source=source,
+            )
+            if downloads or mode == BestVersionMode.WHOLE_ONLY.value:
+                return downloads, lefts
+
+        if mode == BestVersionMode.WHOLE_ONLY.value:
+            return [], no_exists
+
+        return DownloadChain().batch_download(
+            contexts=contexts,
+            no_exists=no_exists,
+            username=username,
+            save_path=save_path,
+            downloader=downloader,
+            source=source,
+        )
+
     @staticmethod
     def __get_event_media(_mediaid: str, _meta: MetaBase) -> Optional[MediaInfo]:
         """
@@ -356,6 +476,8 @@ class SubscribeChain(ChainBase):
                 "exclude") else kwargs.get("exclude"),
             'best_version': self.__get_default_subscribe_config(mtype, "best_version") if not kwargs.get(
                 "best_version") else kwargs.get("best_version"),
+            'best_version_mode': self.__get_default_subscribe_config(mtype, "best_version_mode") if not kwargs.get(
+                "best_version_mode") else kwargs.get("best_version_mode"),
             'search_imdbid': self.__get_default_subscribe_config(mtype, "search_imdbid") if not kwargs.get(
                 "search_imdbid") else kwargs.get("search_imdbid"),
             'sites': self.__get_default_subscribe_config(mtype, "sites") or None if not kwargs.get(
@@ -855,8 +977,8 @@ class SubscribeChain(ChainBase):
                                     # 洗版时，不符合订阅集数的不要
                                     if (
                                         torrent_mediainfo.type == MediaType.TV
-                                        and not self._is_episode_range_covered(
-                                            meta=torrent_meta, subscribe=subscribe
+                                        and not self.__is_best_version_context_allowed(
+                                            subscribe=subscribe, context=context
                                         )
                                     ):
                                         logger.info(
@@ -900,7 +1022,8 @@ class SubscribeChain(ChainBase):
                             continue
 
                         # 自动下载
-                        downloads, lefts = DownloadChain().batch_download(
+                        downloads, lefts = self.__batch_download_best_version(
+                            subscribe=subscribe,
                             contexts=matched_contexts,
                             no_exists=no_exists,
                             username=subscribe.username,
@@ -1345,9 +1468,9 @@ class SubscribeChain(ChainBase):
                                     # 洗版时，不符合订阅集数的不要
                                     if (
                                         meta.type == MediaType.TV
-                                        and not self._is_episode_range_covered(
-                                            meta=torrent_meta,
+                                        and not self.__is_best_version_context_allowed(
                                             subscribe=subscribe,
+                                            context=_context,
                                         )
                                     ):
                                         logger.debug(
@@ -1416,14 +1539,15 @@ class SubscribeChain(ChainBase):
 
                     # 开始批量择优下载
                     logger.info(f'{mediainfo.title_year} 匹配完成，共匹配到{len(_match_context)}个资源')
-                    downloads, lefts = DownloadChain().batch_download(contexts=_match_context,
-                                                                      no_exists=no_exists,
-                                                                      username=subscribe.username,
-                                                                      save_path=subscribe.save_path,
-                                                                      downloader=subscribe.downloader,
-                                                                      source=self.get_subscribe_source_keyword(
-                                                                          subscribe)
-                                                                      )
+                    downloads, lefts = self.__batch_download_best_version(
+                        subscribe=subscribe,
+                        contexts=_match_context,
+                        no_exists=no_exists,
+                        username=subscribe.username,
+                        save_path=subscribe.save_path,
+                        downloader=subscribe.downloader,
+                        source=self.get_subscribe_source_keyword(subscribe),
+                    )
 
                     # 同步外部修改，更新订阅信息
                     subscribe = SubscribeOper().get(subscribe.id)

--- a/app/db/models/subscribe.py
+++ b/app/db/models/subscribe.py
@@ -71,6 +71,8 @@ class Subscribe(Base):
     downloader = Column(String)
     # 是否洗版
     best_version = Column(Integer, default=0)
+    # 洗版模式：episode 分集（优先全集），whole_only 仅全集
+    best_version_mode = Column(String)
     # 当前优先级
     current_priority = Column(Integer)
     # 洗版时已下载剧集的优先级状态，格式：{"1": 90, "2": 100}

--- a/app/db/models/subscribehistory.py
+++ b/app/db/models/subscribehistory.py
@@ -60,6 +60,8 @@ class SubscribeHistory(Base):
     sites = Column(JSON)
     # 是否洗版
     best_version = Column(Integer, default=0)
+    # 洗版模式：episode 分集（优先全集），whole_only 仅全集
+    best_version_mode = Column(String)
     # 洗版时已下载剧集的优先级状态，格式：{"1": 90, "2": 100}
     episode_priority = Column(JSON)
     # 保存路径

--- a/app/schemas/subscribe.py
+++ b/app/schemas/subscribe.py
@@ -2,6 +2,8 @@ from typing import Optional, List, Dict, Any
 
 from pydantic import BaseModel, Field, ConfigDict
 
+from app.schemas.types import BestVersionMode
+
 
 class Subscribe(BaseModel):
     id: Optional[int] = None
@@ -59,6 +61,8 @@ class Subscribe(BaseModel):
     downloader: Optional[str] = None
     # 是否洗版
     best_version: Optional[int] = 0
+    # 洗版模式：episode 分集（优先全集），whole_only 仅全集
+    best_version_mode: Optional[BestVersionMode] = None
     # 当前优先级
     current_priority: Optional[int] = None
     # 洗版时已下载剧集的优先级状态
@@ -78,7 +82,7 @@ class Subscribe(BaseModel):
     # 剧集组
     episode_group: Optional[str] = None
 
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, use_enum_values=True)
 
 
 class SubscribeShare(BaseModel):

--- a/app/schemas/types.py
+++ b/app/schemas/types.py
@@ -30,6 +30,26 @@ def media_type_to_agent(value) -> Optional[str]:
     return None
 
 
+# 订阅洗版模式，控制电视剧洗版时分集推进与全集收口的取舍。
+class BestVersionMode(str, Enum):
+    EPISODE = "episode"  # 分集洗版，遇到覆盖目标范围的全集时优先下载全集
+    WHOLE_ONLY = "whole_only"  # 仅接受全集或完整覆盖目标范围的资源
+
+    @classmethod
+    def values(cls) -> set[str]:
+        """返回可写入订阅配置和数据库字段的洗版模式值集合。"""
+        return {mode.value for mode in cls}
+
+    @classmethod
+    def normalize(cls, value: Optional[str]) -> Optional[str]:
+        """归一化洗版模式，仅接受当前对外暴露的模式值。"""
+        if isinstance(value, cls):
+            return value.value
+        if value in cls.values():
+            return value
+        return None
+
+
 # 排序类型枚举
 class SortType(Enum):
     TIME = "time"  # 按时间排序

--- a/database/versions/09c91570f4a2_2_2_7.py
+++ b/database/versions/09c91570f4a2_2_2_7.py
@@ -1,0 +1,45 @@
+"""2.2.7
+为订阅洗版增加分集和仅全集模式
+
+Revision ID: 09c91570f4a2
+Revises: 9caa49cb3e10
+Create Date: 2026-05-13
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "09c91570f4a2"
+down_revision = "9caa49cb3e10"
+branch_labels = None
+depends_on = None
+
+
+def _has_column(inspector: sa.Inspector, table_name: str, column_name: str) -> bool:
+    """判断指定表是否已经存在目标列，支持重复执行迁移时安全跳过。"""
+    if table_name not in inspector.get_table_names():
+        return False
+    return any(column["name"] == column_name for column in inspector.get_columns(table_name))
+
+
+def upgrade() -> None:
+    """新增订阅洗版模式字段，历史订阅保持空值并按系统默认解释。"""
+    inspector = sa.inspect(op.get_bind())
+    if _has_column(inspector, "subscribe", "best_version_mode") is False:
+        op.add_column("subscribe", sa.Column("best_version_mode", sa.String(), nullable=True))
+
+    inspector = sa.inspect(op.get_bind())
+    if _has_column(inspector, "subscribehistory", "best_version_mode") is False:
+        op.add_column("subscribehistory", sa.Column("best_version_mode", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """回滚订阅洗版模式字段。"""
+    inspector = sa.inspect(op.get_bind())
+    if _has_column(inspector, "subscribehistory", "best_version_mode"):
+        op.drop_column("subscribehistory", "best_version_mode")
+
+    inspector = sa.inspect(op.get_bind())
+    if _has_column(inspector, "subscribe", "best_version_mode"):
+        op.drop_column("subscribe", "best_version_mode")

--- a/tests/test_subscribe_chain.py
+++ b/tests/test_subscribe_chain.py
@@ -279,6 +279,7 @@ class SubscribeChainTest(TestCase):
             "name": "Test Show",
             "season": 1,
             "best_version": 1,
+            "best_version_mode": None,
             "type": MediaType.TV.value,
             "start_episode": 1,
             "total_episode": 3,
@@ -310,6 +311,14 @@ class SubscribeChainTest(TestCase):
             torrent_info=SimpleNamespace(pri_order=priority),
             selected_episodes=selected_episodes,
             meta_info=SimpleNamespace(episode_list=meta_episodes or []),
+        )
+
+    @staticmethod
+    def _build_context(episodes=None, priority=100):
+        return SimpleNamespace(
+            meta_info=SimpleNamespace(episode_list=episodes or []),
+            torrent_info=SimpleNamespace(pri_order=priority),
+            media_info=SimpleNamespace(type=MediaType.TV),
         )
 
     def test_get_episode_priority_falls_back_to_current_priority(self):
@@ -380,6 +389,75 @@ class SubscribeChainTest(TestCase):
                 subscribe=subscribe,
             )
         )
+
+    def test_whole_context_requires_full_target_range(self):
+        subscribe = self._build_subscribe(total_episode=3)
+
+        self.assertTrue(
+            SubscribeChain._SubscribeChain__is_best_version_whole_context(
+                subscribe,
+                self._build_context(episodes=[]),
+            )
+        )
+        self.assertTrue(
+            SubscribeChain._SubscribeChain__is_best_version_whole_context(
+                subscribe,
+                self._build_context(episodes=[1, 2, 3]),
+            )
+        )
+        self.assertFalse(
+            SubscribeChain._SubscribeChain__is_best_version_whole_context(
+                subscribe,
+                self._build_context(episodes=[1, 2]),
+            )
+        )
+
+    def test_whole_only_rejects_partial_episode_context(self):
+        subscribe = self._build_subscribe(best_version_mode="whole_only", total_episode=3)
+
+        self.assertFalse(
+            SubscribeChain._SubscribeChain__is_best_version_context_allowed(
+                subscribe,
+                self._build_context(episodes=[2]),
+            )
+        )
+        self.assertTrue(
+            SubscribeChain._SubscribeChain__is_best_version_context_allowed(
+                subscribe,
+                self._build_context(episodes=[1, 2, 3]),
+            )
+        )
+
+    def test_episode_mode_downloads_whole_context_before_episode_fallback(self):
+        subscribe = self._build_subscribe(best_version_mode="episode", total_episode=3)
+        whole_context = self._build_context(episodes=[1, 2, 3])
+        episode_context = self._build_context(episodes=[1])
+        no_exists = {
+            1: {
+                1: SimpleNamespace(
+                    season=1,
+                    episodes=[1, 2, 3],
+                    total_episode=3,
+                    start_episode=1,
+                )
+            }
+        }
+
+        with patch.object(SUBSCRIBE_CHAIN_MODULE, "DownloadChain") as download_chain_cls:
+            download_chain = download_chain_cls.return_value
+            download_chain.batch_download.return_value = ([whole_context], {})
+
+            downloads, _ = SubscribeChain._SubscribeChain__batch_download_best_version(
+                subscribe=subscribe,
+                contexts=[episode_context, whole_context],
+                no_exists=no_exists,
+            )
+
+        self.assertEqual(downloads, [whole_context])
+        call_contexts = download_chain.batch_download.call_args.kwargs["contexts"]
+        call_no_exists = download_chain.batch_download.call_args.kwargs["no_exists"]
+        self.assertEqual(call_contexts, [whole_context])
+        self.assertEqual(call_no_exists[1][1].episodes, [])
 
     def test_update_subscribe_priority_uses_selected_episodes(self):
         subscribe = self._build_subscribe(


### PR DESCRIPTION
## 变更说明

- 为订阅洗版增加 `best_version_mode` 字段，支持 `episode` 分集（优先全集）和 `whole_only` 仅全集两种模式。
- TV 洗版下载时优先尝试覆盖目标范围的全集资源，未命中时按模式决定是否回退分集。
- 同步订阅历史、Agent 查询/更新工具和迁移脚本，并补充订阅链路单测。

## 影响路径

- 后端订阅模型、schema、订阅处理链、Agent 工具
- 数据库迁移 `09c91570f4a2_2_2_7.py`

## 验证步骤

- `/Users/chengyu/GitHub/MoviePilot/.venv/bin/python -m py_compile app/chain/subscribe.py app/schemas/types.py app/schemas/subscribe.py app/agent/tools/impl/update_subscribe.py app/agent/tools/impl/query_subscribes.py database/versions/09c91570f4a2_2_2_7.py`
- `/Users/chengyu/GitHub/MoviePilot/.venv/bin/python -m unittest tests.test_subscribe_chain`
- `git diff --check`

本 PR 为 codex 协作提交
