### PR TITLE
fix(alembic): 修复PG密码含特殊字符时数据库迁移静默失败的问题

### DIFF
--- a/app/db/init.py
+++ b/app/db/init.py
@@ -1,3 +1,5 @@
+from configparser import ConfigParser as _ConfigParser
+
 from alembic.command import upgrade
 from alembic.config import Config
 
@@ -24,6 +26,7 @@ def update_db():
     script_location = settings.ROOT_PATH / 'database'
     try:
         alembic_cfg = Config()
+        alembic_cfg.file_config = _ConfigParser(interpolation=None)
         alembic_cfg.set_main_option('script_location', str(script_location))
         
         # 根据数据库类型设置不同的URL


### PR DESCRIPTION
 ## 问题描述

   当 PostgreSQL 密码包含可 URL 编码的特殊字符（如
   `!`、`#`、`%`）时，数据库迁移会静默失败，导致升级后新列缺失，相关功能运行时报错。

   **错误日志：**
   ```
   数据库更新失败：invalid interpolation syntax in 'postgresql://postgres:...%21@...' at position 31
   ```

   **影响范围：** 所有使用含特殊字符密码的 PostgreSQL 用户。

   ## 根因分析

   1. 用户密码中的 `!` 被 `DB_POSTGRESQL_URL()` 正确 URL 编码为 `%21`（SQLAlchemy 连接所必需）
   2. `update_db()` 将此 URL 通过 `alembic_cfg.set_main_option('sqlalchemy.url', url)` 存入 Alembic 的 Config 对象
   3. Alembic Config 内部使用 Python `ConfigParser`，它将 `%` 解释为变量插值语法（`%(name)s`）
   4. `%21` 无法被解析为合法的插值变量 → 抛出异常 → 迁移被 `except` 捕获并仅记录日志 → 应用继续启动但数据库未更新

   **引入时间：** commit `c2c9950b`（2026-05-07），将 `update_db()` 中的直接字符串拼接改为调用
   `DB_POSTGRESQL_URL()`，后者对密码进行了 URL 编码，意外触发了 ConfigParser 插值问题。

   ## 修复方案

   在创建 Alembic Config 对象时禁用 ConfigParser 的插值功能，使 URL 作为字面值存储，不进行 `%(var)s` 解析。

   ## 验证

   已验证含 `!`、`#`、`%`、`@`、`&` 等特殊字符的密码均可正常工作。