### PR TITLE
fix(subscribe): persist best-version downloads to note and read it back

### DIFF
--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -1189,11 +1189,14 @@ class SubscribeChain(ChainBase):
         mediakey = subscribe.tmdbid or subscribe.doubanid
         # 是否有剩余集
         no_lefts = not lefts or not lefts.get(mediakey)
+        # 不论是否洗版，只要本轮有下载产生就要把集数追加进 subscribe.note，
+        # 保证"已下载过哪些集"这条事实在所有订阅模式下都有可靠落点；洗版分支
+        # 之前只写 episode_priority，导致用户切回普通订阅时丢失下载历史，并让
+        # __get_downloaded 在洗版下无法从 note 拿到 priority 未达 100 但实际下过的集。
+        if downloads:
+            self.__update_subscribe_note(subscribe=subscribe, downloads=downloads)
         # 是否完成订阅
         if not subscribe.best_version:
-            # 订阅存在待定策略，不管是否已完成，均需更新订阅信息
-            # 更新订阅已下载信息
-            self.__update_subscribe_note(subscribe=subscribe, downloads=downloads)
             # 更新订阅剩余集数和时间
             self.__update_lack_episodes(lefts=lefts, subscribe=subscribe, mediainfo=mediainfo,
                                         update_date=bool(downloads))
@@ -1856,14 +1859,31 @@ class SubscribeChain(ChainBase):
     @staticmethod
     def __get_downloaded(subscribe: Subscribe) -> List[int]:
         """
-        获取已下载过的集数或电影
+        获取已下载过的集数或电影。
+
+        洗版分支以"洗到顶（priority==100）"为完成判据，但实际下载过、还没洗到顶的
+        集（如 priority=99 的 HDR 档）也应当算作"曾经下载过"，否则订阅刷新时它们
+        会留在 no_exists 中被反复匹配。这里把 episode_priority 完成集与 subscribe.note
+        合并返回，保证：
+        - 洗版迁移后再切回普通订阅时，note 里记录的旧下载集仍能从这里读出来；
+        - 洗版进行中，priority<100 但已经在下载器里的集不会被订阅链路当成"还没下"。
         """
         if subscribe.best_version:
             if subscribe.type == MediaType.TV.value:
                 completed = SubscribeChain.__get_best_version_completed_episodes(subscribe)
-                if completed:
-                    logger.info(f'订阅 {subscribe.name} 第{subscribe.season}季 已完成洗版剧集：{completed}')
-                return completed
+                # 合并历史下载记录：episode_priority==100 的完成集 ∪ subscribe.note 中持久化的下载集。
+                downloaded_episodes = set(completed)
+                for episode in subscribe.note or []:
+                    try:
+                        downloaded_episodes.add(int(episode))
+                    except (TypeError, ValueError):
+                        continue
+                downloaded = sorted(downloaded_episodes)
+                if downloaded:
+                    logger.info(
+                        f'订阅 {subscribe.name} 第{subscribe.season}季 已下载剧集（洗版完成 + note 历史）：{downloaded}'
+                    )
+                return downloaded
             return []
         note = subscribe.note or []
         if not note:

--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -1861,14 +1861,9 @@ class SubscribeChain(ChainBase):
         """
         获取已下载过的集数或电影。
 
-        重要：洗版分支返回的是"无需在本轮搜索/匹配中再处理"的集合，下游会用它
-        从 pending no_exists 中减去；只有"已洗到顶（priority==100）"才满足这个语义。
-        洗版进行中处于 priority<100 的集（例如 HDR 档 99）虽然已经下载过，但仍要
-        继续被搜索以寻找更高优先级版本——绝对不能把 note 合并进来减 pending，否则
-        check_and_handle_existing_media 会以 exist_flag=True 跳过整轮搜索，订阅卡死。
-
-        note 在洗版下的价值是"将来用户切回普通订阅时的下载历史事实源"，由非 best_version
-        分支自然消费；本分支只读 episode_priority。
+        洗版分支只返回 priority==100 的完成集；priority<100 的集仍要继续搜索更高
+        优先级版本，不能并入返回值（会让下游把 pending 减空、订阅卡死）。
+        note 由非洗版分支消费，用于洗版关闭后的迁移读取。
         """
         if subscribe.best_version:
             if subscribe.type == MediaType.TV.value:

--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -1861,29 +1861,21 @@ class SubscribeChain(ChainBase):
         """
         获取已下载过的集数或电影。
 
-        洗版分支以"洗到顶（priority==100）"为完成判据，但实际下载过、还没洗到顶的
-        集（如 priority=99 的 HDR 档）也应当算作"曾经下载过"，否则订阅刷新时它们
-        会留在 no_exists 中被反复匹配。这里把 episode_priority 完成集与 subscribe.note
-        合并返回，保证：
-        - 洗版迁移后再切回普通订阅时，note 里记录的旧下载集仍能从这里读出来；
-        - 洗版进行中，priority<100 但已经在下载器里的集不会被订阅链路当成"还没下"。
+        重要：洗版分支返回的是"无需在本轮搜索/匹配中再处理"的集合，下游会用它
+        从 pending no_exists 中减去；只有"已洗到顶（priority==100）"才满足这个语义。
+        洗版进行中处于 priority<100 的集（例如 HDR 档 99）虽然已经下载过，但仍要
+        继续被搜索以寻找更高优先级版本——绝对不能把 note 合并进来减 pending，否则
+        check_and_handle_existing_media 会以 exist_flag=True 跳过整轮搜索，订阅卡死。
+
+        note 在洗版下的价值是"将来用户切回普通订阅时的下载历史事实源"，由非 best_version
+        分支自然消费；本分支只读 episode_priority。
         """
         if subscribe.best_version:
             if subscribe.type == MediaType.TV.value:
                 completed = SubscribeChain.__get_best_version_completed_episodes(subscribe)
-                # 合并历史下载记录：episode_priority==100 的完成集 ∪ subscribe.note 中持久化的下载集。
-                downloaded_episodes = set(completed)
-                for episode in subscribe.note or []:
-                    try:
-                        downloaded_episodes.add(int(episode))
-                    except (TypeError, ValueError):
-                        continue
-                downloaded = sorted(downloaded_episodes)
-                if downloaded:
-                    logger.info(
-                        f'订阅 {subscribe.name} 第{subscribe.season}季 已下载剧集（洗版完成 + note 历史）：{downloaded}'
-                    )
-                return downloaded
+                if completed:
+                    logger.info(f'订阅 {subscribe.name} 第{subscribe.season}季 已完成洗版剧集：{completed}')
+                return completed
             return []
         note = subscribe.note or []
         if not note:

--- a/tests/test_subscribe_chain.py
+++ b/tests/test_subscribe_chain.py
@@ -1036,50 +1036,40 @@ class SubscribeNoteTrackingTest(TestCase):
             "note must not be touched when downloads is empty",
         )
 
-    def test_get_downloaded_unions_note_with_completed_episodes(self):
-        """__get_downloaded 在洗版分支应当返回 priority==100 完成集 ∪ note。
+    def test_get_downloaded_best_version_returns_only_completed_episodes(self):
+        """关键回归：洗版分支不得把 note 合并进 __get_downloaded 返回值。
 
-        现实场景：E83 已经被下到 priority=99（HDR），note 也已经记录了 E83；
-        episode_priority 仅含 E1..E82=100；__get_downloaded 应该把这些都返回，
-        让订阅下次刷新构造 no_exists 时把 E83 从缺失列表里减掉。
+        否则 check_and_handle_existing_media → __get_subscribe_no_exits 会把
+        priority<100 但已下载的集从 pending no_exists 中减掉，配合 force=True 但
+        __is_best_version_complete=False 的 finish_subscribe_or_not，会让订阅每轮
+        都跳过搜索却又永远不完成。__get_downloaded 在洗版下的语义是"无需再处理的
+        集"，只有 priority==100 才满足该语义。
         """
         subscribe = self._build_subscribe(
             best_version=1,
-            total_episode=92,
-            episode_priority={str(ep): 100 for ep in range(1, 83)},
-            note=[83],
+            total_episode=3,
+            episode_priority={"1": 100, "2": 100, "3": 99},
+            note=[1, 2, 3],
         )
 
         downloaded = SubscribeChain._SubscribeChain__get_downloaded(subscribe)
 
-        self.assertEqual(downloaded, list(range(1, 84)))
+        # E3 priority=99 仍是 pending，绝对不能合并到 downloaded 里
+        self.assertEqual(downloaded, [1, 2])
+        self.assertNotIn(3, downloaded)
 
-    def test_get_downloaded_falls_back_to_note_only_when_priority_empty(self):
-        """迁移场景：用户把洗版关闭再开启、或全新洗版尚未写出 priority 时，note 仍是事实源。
-
-        覆盖 episode_priority 为空但 note 非空的情况，确保 __get_downloaded 不返回空集。
+    def test_get_downloaded_non_best_version_reads_note_after_wash_migration(self):
+        """迁移场景：洗版期间 finish_subscribe_or_not 把下载集写入 note；
+        用户随后把 best_version 关掉，订阅切回普通模式时 __get_downloaded
+        从非洗版分支读取 note，旧洗版集仍能作为"已下载"被识别，避免重新匹配。
         """
         subscribe = self._build_subscribe(
-            best_version=1,
-            total_episode=12,
-            episode_priority=None,
-            current_priority=None,
+            best_version=0,
+            total_episode=5,
+            episode_priority={"1": 100, "2": 99},  # 旧洗版残留，普通分支不读
             note=[1, 2, 3],
         )
 
         downloaded = SubscribeChain._SubscribeChain__get_downloaded(subscribe)
 
         self.assertEqual(downloaded, [1, 2, 3])
-
-    def test_get_downloaded_ignores_non_numeric_note_entries(self):
-        """note 历史上可能混入非数字条目（旧版本写入或电影项），洗版分支必须健壮跳过。"""
-        subscribe = self._build_subscribe(
-            best_version=1,
-            total_episode=5,
-            episode_priority={"1": 100},
-            note=[1, "invalid", None, 2],
-        )
-
-        downloaded = SubscribeChain._SubscribeChain__get_downloaded(subscribe)
-
-        self.assertEqual(downloaded, [1, 2])

--- a/tests/test_subscribe_chain.py
+++ b/tests/test_subscribe_chain.py
@@ -925,3 +925,161 @@ class SubscribeFilterAllowedEpisodesTest(TestCase):
         self.assertEqual(_context.allowed_episodes, set(range(84, 93)))
         # 浅拷贝 + 新字段写入不应反向污染源 context（match() 中 contexts 缓存可能跨多次匹配复用）。
         self.assertIsNone(original_context.allowed_episodes)
+
+
+class SubscribeNoteTrackingTest(TestCase):
+    """覆盖洗版与非洗版下 subscribe.note 的下载历史追踪。
+
+    回归目标：finish_subscribe_or_not 必须在所有订阅模式下都把本轮下载的集数追加进
+    subscribe.note；__get_downloaded 在洗版分支必须把 note 与 episode_priority==100
+    的完成集合并返回，避免迁移或低优先级下载场景下已下集被误判为"未下载"。
+    """
+
+    def _build_subscribe(self, **overrides):
+        return SubscribeChainTest()._build_subscribe(**overrides)
+
+    @staticmethod
+    def _build_download_context(episodes):
+        """构造一个最小化下载 context：只携带 finish_subscribe_or_not / __update_subscribe_note 路径会读到的字段。"""
+        return SimpleNamespace(
+            meta_info=SimpleNamespace(season_list=[1], episode_list=list(episodes)),
+            media_info=SimpleNamespace(
+                type=MediaType.TV,
+                tmdb_id=1,
+                douban_id=None,
+            ),
+            torrent_info=SimpleNamespace(pri_order=99, title="fake-torrent"),
+            selected_episodes=list(episodes),
+        )
+
+    def test_finish_subscribe_writes_note_for_best_version_downloads(self):
+        """洗版分支若产生 downloads，subscribe.note 必须被追加，不再被 best_version 标志拦截。
+
+        旧逻辑只在非洗版分支调用 __update_subscribe_note，导致 best_version=1 时
+        下载历史只落在 episode_priority；用户切回普通订阅或排障对账时缺失"下过哪些集"
+        的事实源。这条用例验证修复后两个分支都会写 note。
+        """
+        subscribe = self._build_subscribe(
+            best_version=1,
+            total_episode=92,
+            episode_priority={"1": 100},
+            note=[1],
+        )
+        chain = SubscribeChain()
+        downloads = [self._build_download_context([83])]
+
+        captured_updates = []
+
+        class _SubscribeOper:
+            def update(self, subscribe_id, payload):
+                captured_updates.append((subscribe_id, payload))
+
+            def get(self, *args, **kwargs):
+                return subscribe
+
+        with patch.object(SUBSCRIBE_CHAIN_MODULE, "SubscribeOper", _SubscribeOper), patch.object(
+            SubscribeChain,
+            "update_subscribe_priority",
+        ), patch.object(
+            SubscribeChain,
+            "_SubscribeChain__finish_subscribe",
+        ):
+            chain.finish_subscribe_or_not(
+                subscribe=subscribe,
+                meta=SimpleNamespace(type=MediaType.TV),
+                mediainfo=SimpleNamespace(title_year="Test Show (2026)", type=MediaType.TV,
+                                          tmdb_id=1, douban_id=None),
+                downloads=downloads,
+                lefts=None,
+            )
+
+        # note 更新必然发生在 SubscribeOper.update 上，定位"note" 键的最近一次写入。
+        note_writes = [payload["note"] for _, payload in captured_updates if "note" in payload]
+        self.assertTrue(note_writes, "best_version downloads should still trigger note update")
+        self.assertIn(83, note_writes[-1])
+        self.assertIn(1, note_writes[-1])  # 既有 note 保留
+
+    def test_finish_subscribe_skips_note_when_no_downloads(self):
+        """没有 downloads 时不应触碰 note，避免空写入或误清除。"""
+        subscribe = self._build_subscribe(best_version=1, total_episode=92, note=[1, 2])
+        chain = SubscribeChain()
+
+        captured_updates = []
+
+        class _SubscribeOper:
+            def update(self, subscribe_id, payload):
+                captured_updates.append((subscribe_id, payload))
+
+            def get(self, *args, **kwargs):
+                return subscribe
+
+        with patch.object(SUBSCRIBE_CHAIN_MODULE, "SubscribeOper", _SubscribeOper), patch.object(
+            SubscribeChain,
+            "_SubscribeChain__is_best_version_complete",
+            return_value=False,
+        ), patch.object(
+            SubscribeChain,
+            "_SubscribeChain__finish_subscribe",
+        ):
+            chain.finish_subscribe_or_not(
+                subscribe=subscribe,
+                meta=SimpleNamespace(type=MediaType.TV),
+                mediainfo=SimpleNamespace(title_year="Test Show (2026)", type=MediaType.TV,
+                                          tmdb_id=1, douban_id=None),
+                downloads=None,
+                lefts=None,
+            )
+
+        # 无下载时不应该有 note 写入。
+        self.assertFalse(
+            [payload for _, payload in captured_updates if "note" in payload],
+            "note must not be touched when downloads is empty",
+        )
+
+    def test_get_downloaded_unions_note_with_completed_episodes(self):
+        """__get_downloaded 在洗版分支应当返回 priority==100 完成集 ∪ note。
+
+        现实场景：E83 已经被下到 priority=99（HDR），note 也已经记录了 E83；
+        episode_priority 仅含 E1..E82=100；__get_downloaded 应该把这些都返回，
+        让订阅下次刷新构造 no_exists 时把 E83 从缺失列表里减掉。
+        """
+        subscribe = self._build_subscribe(
+            best_version=1,
+            total_episode=92,
+            episode_priority={str(ep): 100 for ep in range(1, 83)},
+            note=[83],
+        )
+
+        downloaded = SubscribeChain._SubscribeChain__get_downloaded(subscribe)
+
+        self.assertEqual(downloaded, list(range(1, 84)))
+
+    def test_get_downloaded_falls_back_to_note_only_when_priority_empty(self):
+        """迁移场景：用户把洗版关闭再开启、或全新洗版尚未写出 priority 时，note 仍是事实源。
+
+        覆盖 episode_priority 为空但 note 非空的情况，确保 __get_downloaded 不返回空集。
+        """
+        subscribe = self._build_subscribe(
+            best_version=1,
+            total_episode=12,
+            episode_priority=None,
+            current_priority=None,
+            note=[1, 2, 3],
+        )
+
+        downloaded = SubscribeChain._SubscribeChain__get_downloaded(subscribe)
+
+        self.assertEqual(downloaded, [1, 2, 3])
+
+    def test_get_downloaded_ignores_non_numeric_note_entries(self):
+        """note 历史上可能混入非数字条目（旧版本写入或电影项），洗版分支必须健壮跳过。"""
+        subscribe = self._build_subscribe(
+            best_version=1,
+            total_episode=5,
+            episode_priority={"1": 100},
+            note=[1, "invalid", None, 2],
+        )
+
+        downloaded = SubscribeChain._SubscribeChain__get_downloaded(subscribe)
+
+        self.assertEqual(downloaded, [1, 2])


### PR DESCRIPTION
## 背景

订阅按"洗版（`best_version=1`）"模式下载时，`subscribe.note` 字段从不被更新——下载历史只落在 `episode_priority` 上，又把"已下到的优先级"与"是否完成洗版（==100）"两件事编码在同一个数字里。导致用户把洗版关闭切回普通订阅时，洗版期间下过的集在 `subscribe.note` 里完全没有记录，会被普通订阅链路视作"从没下过"重新匹配。

## 修复

把 `MoviePilot/app/chain/subscribe.py:finish_subscribe_or_not` 中 `__update_subscribe_note` 调用从 `if not subscribe.best_version:` 分支抽出来：**只要本轮 `downloads` 非空就调用**，让两种订阅模式共享统一的下载历史落点。`__update_subscribe_note` 自身不改动；它读取的 `context.meta_info.episode_list` 在 `DownloadChain.batch_download` pass #2/#4 出口的 `meta.set_episodes` 已经校正成真实文件集，写入语义正确。

### `__get_downloaded` 在洗版分支保持原语义

**重要约束**：`__get_downloaded` 在洗版分支的返回值会被下游 `check_and_handle_existing_media → __get_subscribe_no_exits` 当成"无需再处理的集"使用，从 pending `no_exists` 中减去。只有"已洗到顶（`priority==100`）"才满足这个语义；`priority<100` 的集虽然下载过，但洗版的本意是要继续找更高优先级版本，**绝对不能并入返回值**——否则 `check_and_handle_existing_media` 以 `exist_flag=True` 跳过整轮搜索，配合 `__is_best_version_complete=False` 不完成订阅，订阅就会卡死在 priority<100 永远不再升级。

中间版本（commit `9cd9da52`）曾让 `__get_downloaded` 在洗版分支返回 `completed_episodes ∪ note`，引入了上述死锁；commit `4469ac02` 已撤销该合并、`d475e30d` 精简注释。

### note 在迁移场景下的消费

洗版期间 note 被写入；用户切回普通订阅（`best_version=0`）后，`__get_downloaded` 走非洗版分支**直接读 note**——旧洗版集仍然作为"已下载"被识别，避免重新匹配。无需在洗版分支动手。

## 与已合 #5781 的关系

#5781 修候选过滤层的"同优先级重复下载"；本 PR 修订阅表数据完整性（洗版下 note 没有落点）。两条修复正交，合在一起让"洗版订阅的已下载状态"在订阅表里可完整还原。

## 测试

新增 4 条用例，全部 26 条通过：

- `test_finish_subscribe_writes_note_for_best_version_downloads` —— 洗版有下载时 `SubscribeOper.update` 必然写入 `note`，并保留既有 note 条目
- `test_finish_subscribe_skips_note_when_no_downloads` —— 无下载时不触碰 note
- `test_get_downloaded_best_version_returns_only_completed_episodes` —— **关键回归**：洗版分支不得把 note 合并进 `__get_downloaded` 返回值
- `test_get_downloaded_non_best_version_reads_note_after_wash_migration` —— 迁移场景：`best_version=0` 时从 note 拿回洗版期间下载集

执行：

```
cd MoviePilot
../.venv/bin/python -m unittest tests.test_subscribe_chain
```

结果 `Ran 26 tests in 0.003s OK`。

## 验证路径

- 复现：洗版订阅一集下载完成后，检查订阅表 `subscribe.note`（或 WebUI 订阅详情"已下载集数"），修复前为空，修复后含本次下载的集
- 迁移：把洗版订阅关闭，订阅刷新走非洗版分支时 `__get_downloaded` 仍能从 note 拿到旧下载集
- 回归边界：洗版进行中（`best_version=1`），`__get_downloaded` 仍只返回 `priority==100` 的完成集，搜索/匹配链路行为与既有完全一致

## 能力边界

- 不动 `__update_subscribe_note` 自身的集数来源（仍读 `meta.episode_list`）：实测 `meta.set_episodes` 已把 meta 校正成真实文件集，没必要再绕到 `context.selected_episodes`
- 洗版分支 `__get_downloaded` 不读 note 是有意为之，把"曾经下载过"与"无需再搜索"两件事拆开，避免污染 pending 计算

本 PR 为 Claude Code 协作提交。
