### PR TITLE
fix: 修复工作流 RSS 种子上下文类型

### DIFF
--- a/app/schemas/context.py
+++ b/app/schemas/context.py
@@ -232,6 +232,8 @@ class TorrentInfo(BaseModel):
     labels: Optional[list] = Field(default_factory=list)
     # 种子优先级
     pri_order: Optional[int] = 0
+    # 种子分类 电影/电视剧
+    category: Optional[str] = None
     # 促销
     volume_factor: Optional[str] = None
     # 剩余免费时间

--- a/app/workflow/actions/fetch_rss.py
+++ b/app/workflow/actions/fetch_rss.py
@@ -5,11 +5,11 @@ from pydantic import Field
 from app.workflow.actions import BaseAction
 from app.chain.media import MediaChain
 from app.core.config import settings, global_vars
-from app.core.context import Context
+from app.core.context import Context, TorrentInfo
 from app.core.metainfo import MetaInfo
 from app.helper.rss import RssHelper
 from app.log import logger
-from app.schemas import ActionParams, ActionContext, TorrentInfo
+from app.schemas import ActionParams, ActionContext
 
 
 class FetchRssParams(ActionParams):

--- a/tests/test_workflow_fetch_rss.py
+++ b/tests/test_workflow_fetch_rss.py
@@ -1,0 +1,47 @@
+import unittest
+from datetime import datetime
+from unittest.mock import patch
+
+from app.core.context import TorrentInfo
+from app.schemas import ActionContext
+from app.workflow.actions.fetch_rss import FetchRssAction
+
+
+class FetchRssActionTest(unittest.TestCase):
+    """
+    RSS 工作流动作测试。
+    """
+
+    def test_execute_builds_core_torrent_info_for_downstream_workflow(self):
+        """
+        工作流产出的种子信息应使用 core TorrentInfo，避免下载事件下游收到缺少运行时接口的 schema 对象。
+        """
+        rss_items = [
+            {
+                "title": "Example RSS Torrent",
+                "enclosure": "https://example.com/example.torrent",
+                "link": "https://example.com/details",
+                "size": 1024,
+                "pubdate": datetime(2026, 5, 19, 8, 30, 0),
+            }
+        ]
+
+        with patch("app.workflow.actions.fetch_rss.RssHelper") as rss_helper, \
+                patch("app.workflow.actions.fetch_rss.global_vars.is_workflow_stopped", return_value=False):
+            rss_helper.return_value.parse.return_value = rss_items
+
+            context = FetchRssAction("fetch-rss").execute(
+                workflow_id=1,
+                params={"url": "https://example.com/rss.xml"},
+                context=ActionContext(),
+            )
+
+        torrent_info = context.torrents[0].torrent_info
+        self.assertIsInstance(torrent_info, TorrentInfo)
+        self.assertIsNone(torrent_info.category)
+        self.assertTrue(callable(getattr(torrent_info, "to_dict", None)))
+        self.assertEqual("2026-05-19 08:30:00", torrent_info.pubdate)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更说明

- 修复工作流 `FetchRssAction` 构造种子上下文时混用 `app.schemas.TorrentInfo` 与 `app.core.context.Context` 的问题，统一改为 core `TorrentInfo`。
- 在 `app.schemas.context.TorrentInfo` 中补齐 `category` 字段，保持 API / 事件序列化模型与 core 上下文模型的关键字段一致。
- 新增 `tests/test_workflow_fetch_rss.py`，覆盖 RSS 工作流产出的 `torrent_info` 必须具备 core 运行时接口。

## 根因

工作流 RSS 动作此前从 `app.schemas` 导入 Pydantic 版 `TorrentInfo`，但同文件使用的是 core 版 `Context`。该对象进入下载事件链路后，下游按 core `TorrentInfo` 读取字段和方法，遇到 schemas 版缺少的字段或运行时接口时会触发异常。

## 验证

- `/Users/chengyu/GitHub/MoviePilot/.venv/bin/python -m pytest tests/test_workflow_fetch_rss.py`
- `/Users/chengyu/GitHub/MoviePilot/.venv/bin/python -m py_compile app/workflow/actions/fetch_rss.py app/schemas/context.py tests/test_workflow_fetch_rss.py`
- `git diff --check`

`pylint app/` 未能执行：当前推荐虚拟环境缺少 `pylint` 模块。

本 PR 为 Codex 协作提交
