### PR TITLE
feat: include episode group in subscribe source

### DIFF
--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -3157,6 +3157,7 @@ class SubscribeChain(ChainBase):
             'year': subscribe.year,
             'type': subscribe.type,
             'season': subscribe.season,
+            'episode_group': subscribe.episode_group,
             'tmdbid': subscribe.tmdbid,
             'imdbid': subscribe.imdbid,
             'tvdbid': subscribe.tvdbid,

--- a/tests/test_subscribe_source_keyword.py
+++ b/tests/test_subscribe_source_keyword.py
@@ -1,0 +1,27 @@
+import json
+from types import SimpleNamespace
+
+from app.chain.subscribe import SubscribeChain
+from app.schemas.types import MediaType
+
+
+def test_subscribe_source_keyword_includes_episode_group():
+    subscribe = SimpleNamespace(
+        id=1,
+        name="Test Show",
+        year="2026",
+        type=MediaType.TV.value,
+        season=1,
+        episode_group="group-season-03",
+        tmdbid=12345,
+        imdbid=None,
+        tvdbid=None,
+        doubanid=None,
+        bangumiid=None,
+    )
+
+    source = SubscribeChain.get_subscribe_source_keyword(subscribe)
+    payload = json.loads(source.split("|", 1)[1])
+
+    assert payload["episode_group"] == "group-season-03"
+    assert SubscribeChain.parse_subscribe_source_keyword(source)["episode_group"] == "group-season-03"


### PR DESCRIPTION
## Summary

- 在订阅 source 关键字中补充 episode_group，使订阅触发下载后的历史记录可回溯剧集组上下文。
- 新增回归测试，确保 source 生成和解析保留 episode_group。
- 配套插件 PR：https://github.com/InfinityPacer/MoviePilot-Plugins/pull/182

## Validation

- python -m pytest tests/test_subscribe_source_keyword.py
- python -m py_compile app/chain/subscribe.py
- git diff --check

本 PR 为 codex 协作提交