### PR TITLE
fix: 插件配置表单在存储配置缺少新键时显示为空

### DIFF
--- a/app/api/endpoints/plugin.py
+++ b/app/api/endpoints/plugin.py
@@ -325,10 +325,13 @@ def plugin_form(
     render_mode, _ = plugin_instance.get_render_mode()
     try:
         conf, model = plugin_instance.get_form()
+        stored_config = plugin_manager.get_plugin_config(plugin_id)
+        # Merge stored config with defaults so all keys exist for v-show evaluation
+        merged_model = {**model, **(stored_config or {})}
         return {
             "render_mode": render_mode,
             "conf": conf,
-            "model": plugin_manager.get_plugin_config(plugin_id) or model,
+            "model": merged_model,
         }
     except Exception as e:
         logger.error(f"插件 {plugin_id} 调用方法 get_form 出错: {str(e)}")


### PR DESCRIPTION
  ## 问题

  插件更新版本后修改了配置项的键名，
  打开插件配置页面时表单完全空白，右上角关闭按钮也无响应。

  ## 原因
  
  `FormRender.vue` 通过 `with(model) { return key }` 求值 `v-show` 表达式。
  当数据库中存储的旧配置缺少新键时，JavaScript 抛出 `ReferenceError`，
  导致整个表单渲染崩溃。

  API 端点原有的逻辑 `stored_config or defaults` 不做合并——
  只要存储配置存在（即使缺少键），就直接返回，不补全 defaults。

  ## 修复
  
  在返回 model 前，将 defaults 与存储配置合并，确保所有 defaults 中的键始终存在：
  
  ```python
  merged_model = {**model, **(stored_config or {})}
```
  - defaults 保证所有键存在
  - 存储配置的值覆盖 defaults（保留用户已保存的配置）
  - 缺失的键自动填充默认值

  影响范围

  - 修复所有因改键名导致配置页面空白的插件
  - 无破坏性变更，现有插件不受影响
  - 仅修改 app/api/endpoints/plugin.py 一处逻辑
