### PR TITLE
chore: ignore config/plugins/ in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ config/user.db*
 config/sites/**
 config/agent/
 config/logs/
+config/plugins/
 config/temp/
 config/cache/
 .runtime/


### PR DESCRIPTION
避免插件运行时数据目录被误提交到仓库。
