### PR TITLE
fix(security): release SSRF DNS inflight lock outside async with block

### DIFF
--- a/app/utils/security.py
+++ b/app/utils/security.py
@@ -210,7 +210,11 @@ class SecurityUtils:
     def _release_inflight_lock(hostname: str, lock: asyncio.Lock) -> None:
         """
         请求结束后清理 in-flight 锁，避免长期持有大量已闲置的 `asyncio.Lock`。
-        只有当前 lock 仍是字典里登记的那把、且没有其它协程在等待时才删除。
+
+        仅当字典中登记的仍是当前 lock，且 `lock.locked()` 为 False 时才删除。
+        `asyncio.Lock` 公平 FIFO：持有者释放后若仍有等待者，锁会立刻被下一个
+        等待者接走、`locked()` 重新变为 True，因此该守卫可同时排除"仍有持有者"
+        与"刚被等待者接走"两种情况，避免误删后续协程仍在使用的字典条目。
         """
         with _dns_inflight_meta_lock:
             current = _dns_inflight_locks.get(hostname)
@@ -258,7 +262,7 @@ class SecurityUtils:
                 return addresses
         finally:
             # 必须在 `async with` 释放锁之后再清理字典：`_release_inflight_lock`
-            # 通过 `lock.locked()` 判断是否仍有持锁/等待者，锁未释放时清理会被跳过。
+            # 以 `not lock.locked()` 为清理守卫，持锁状态下调用会跳过 pop。
             SecurityUtils._release_inflight_lock(hostname, lock)
 
     @staticmethod

--- a/app/utils/security.py
+++ b/app/utils/security.py
@@ -238,26 +238,28 @@ class SecurityUtils:
             return value
 
         lock = SecurityUtils._get_inflight_lock(hostname)
-        async with lock:
-            # 等到锁后再查一次缓存，前一个持锁者可能已经回填结果
-            hit, value = SecurityUtils._cache_lookup(hostname)
-            if hit:
-                SecurityUtils._release_inflight_lock(hostname, lock)
-                return value
+        try:
+            async with lock:
+                # 等到锁后再查一次缓存，前一个持锁者可能已经回填结果
+                hit, value = SecurityUtils._cache_lookup(hostname)
+                if hit:
+                    return value
 
-            loop = asyncio.get_running_loop()
-            try:
-                address_infos = await loop.getaddrinfo(
-                    hostname, None, type=socket.SOCK_STREAM
-                )
-            except socket.gaierror:
-                SecurityUtils._cache_store(hostname, None)
-                SecurityUtils._release_inflight_lock(hostname, lock)
-                return None
-            addresses = _resolve_addrinfo_to_ips(address_infos)
-            SecurityUtils._cache_store(hostname, addresses)
-        SecurityUtils._release_inflight_lock(hostname, lock)
-        return addresses
+                loop = asyncio.get_running_loop()
+                try:
+                    address_infos = await loop.getaddrinfo(
+                        hostname, None, type=socket.SOCK_STREAM
+                    )
+                except socket.gaierror:
+                    SecurityUtils._cache_store(hostname, None)
+                    return None
+                addresses = _resolve_addrinfo_to_ips(address_infos)
+                SecurityUtils._cache_store(hostname, addresses)
+                return addresses
+        finally:
+            # 必须在 `async with` 释放锁之后再清理字典：`_release_inflight_lock`
+            # 通过 `lock.locked()` 判断是否仍有持锁/等待者，锁未释放时清理会被跳过。
+            SecurityUtils._release_inflight_lock(hostname, lock)
 
     @staticmethod
     def _addresses_all_global(

--- a/tests/test_security_utils.py
+++ b/tests/test_security_utils.py
@@ -550,3 +550,102 @@ class SecurityUtilsTest(TestCase):
         self.assertEqual(errors, [])
         self.assertTrue(all(results))
         self.assertEqual(len(results), 8 * 50)
+
+    def test_async_dns_resolution_failure_releases_inflight_lock(self):
+        """
+        DNS 解析失败后 in-flight 锁字典中必须被清理，避免每个解析失败的 hostname
+        都在 `_dns_inflight_locks` 里残留一把 `asyncio.Lock`。
+        """
+        import asyncio
+
+        async def fail_getaddrinfo(*_args, **_kwargs):
+            raise socket.gaierror()
+
+        async def run() -> None:
+            loop = asyncio.get_running_loop()
+            with patch.object(loop, "getaddrinfo", side_effect=fail_getaddrinfo):
+                result = await SecurityUtils._hostname_addresses_async(
+                    "bad-host.example"
+                )
+            self.assertIsNone(result)
+
+        asyncio.run(run())
+        self.assertNotIn(
+            "bad-host.example",
+            _dns_inflight_locks,
+            "解析失败路径必须释放 in-flight 锁字典条目",
+        )
+
+    def test_async_dns_resolution_success_releases_inflight_lock(self):
+        """
+        正常解析完成后 in-flight 锁字典也必须被清理，避免 hostname 累积。
+        """
+        import asyncio
+
+        async def fake_getaddrinfo(*_args, **_kwargs):
+            return [
+                (
+                    socket.AF_INET,
+                    socket.SOCK_STREAM,
+                    0,
+                    "",
+                    ("93.184.216.34", 0),
+                )
+            ]
+
+        async def run() -> None:
+            loop = asyncio.get_running_loop()
+            with patch.object(loop, "getaddrinfo", side_effect=fake_getaddrinfo):
+                result = await SecurityUtils._hostname_addresses_async(
+                    "ok-host.example"
+                )
+            self.assertIsNotNone(result)
+
+        asyncio.run(run())
+        self.assertNotIn(
+            "ok-host.example",
+            _dns_inflight_locks,
+            "正常解析路径必须释放 in-flight 锁字典条目",
+        )
+
+    def test_async_dns_concurrent_waiters_release_inflight_lock(self):
+        """
+        并发未命中场景下，所有等待者完成后 in-flight 锁字典也必须被清理，
+        覆盖"等到锁但缓存已被前一个协程回填"的二次返回路径。
+        """
+        import asyncio
+
+        async def run() -> None:
+            loop = asyncio.get_running_loop()
+            release = asyncio.Event()
+
+            async def slow_getaddrinfo(*_args, **_kwargs):
+                await release.wait()
+                return [
+                    (
+                        socket.AF_INET,
+                        socket.SOCK_STREAM,
+                        0,
+                        "",
+                        ("93.184.216.34", 0),
+                    )
+                ]
+
+            with patch.object(loop, "getaddrinfo", side_effect=slow_getaddrinfo):
+                tasks = [
+                    asyncio.create_task(
+                        SecurityUtils._hostname_addresses_async("multi-host.example")
+                    )
+                    for _ in range(5)
+                ]
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+                release.set()
+                await asyncio.gather(*tasks)
+
+        asyncio.run(run())
+        self.assertNotIn(
+            "multi-host.example",
+            _dns_inflight_locks,
+            "并发等待者全部退出后必须释放 in-flight 锁字典条目",
+        )


### PR DESCRIPTION
## 背景

PR #5832 在 `app/utils/security.py` 引入了 `_dns_inflight_locks` 用于异步 DNS 解析去重。code review（gemini-code-assist）指出 `_hostname_addresses_async` 的清理逻辑存在两处问题，本 PR 一并修复。

## 问题定位

### Bug 1：`async with` 块内调用 `_release_inflight_lock` 是死代码

`_release_inflight_lock` 的清理守卫依赖 `not lock.locked()`：

```python
if current is lock and not lock.locked():
    _dns_inflight_locks.pop(hostname, None)
```

但原实现中两处调用都发生在 `async with lock:` 块内部（cache hit 提前返回 / `gaierror` 异常路径），此时 `lock.locked() == True`，`pop` 永远不会触发——这两行什么都没做。

### Bug 2：`gaierror` 路径跳过末尾清理 → 内存泄漏

`async with` 结束之后的 `_release_inflight_lock` 是 happy path 唯一有效的清理点。`socket.gaierror` 异常分支在块内 `return None`，**根本到不了末尾**，每个解析失败的 hostname 都会在 `_dns_inflight_locks` 里永久残留一把 `asyncio.Lock`。

量化：单个泄漏对象 ~100B + dict 条目，攻击 / 探测场景下能稳定堆积；正常生产环境每次媒体服务器配置错误也会贡献一条永不清理的条目。

## 修复

把整段去重逻辑包进 `try/finally`，把 `_release_inflight_lock` 唯一调用点放到 `finally` 里，**在 `async with` 释放锁之后**执行：

```python
lock = SecurityUtils._get_inflight_lock(hostname)
try:
    async with lock:
        ...
        return addresses
finally:
    SecurityUtils._release_inflight_lock(hostname, lock)
```

这样：
- 无论 happy path、cache hit、`gaierror`、甚至 `CancelledError` / 其它异常，`finally` 都会跑；
- `finally` 跑时 `async with` 已经退出，锁已释放，`lock.locked() == False` 让清理生效。

## 测试

新增 3 条针对性回归用例：

- `test_async_dns_resolution_failure_releases_inflight_lock`：`gaierror` 路径必须清字典（**buggy 版本下 FAIL**，fix 后通过）。
- `test_async_dns_resolution_success_releases_inflight_lock`：正常解析路径必须清字典（防回退）。
- `test_async_dns_concurrent_waiters_release_inflight_lock`：并发等待者全部退出后必须清字典（覆盖"等到锁但缓存已回填"的二次返回路径）。

## 验证

- `python -m unittest tests.test_security_utils` → 24/24 通过（在 buggy 版本上手动验证 gaierror 用例会失败，证明用例有效）。
- `pylint app/utils/security.py` → 10.00/10。
- 行为语义对 happy path 无变化；仅修复异常/边界路径的清理。

## 影响范围

- 仅影响 `_hostname_addresses_async` 的清理路径，不改变 DNS 解析、缓存、SSRF 防护语义。
- `_get_inflight_lock` / `_release_inflight_lock` / `_dns_inflight_locks` 数据结构不变。

本 PR 为 Claude Code 协作提交。