### PR TITLE
test: 测试启动隔离 CONFIG_DIR，避免连接/写入真实数据库

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,20 @@
+"""MoviePilot 后端测试包。
+
+在导入任何用例之前隔离 CONFIG_DIR。测试普遍直接 ``import app.*``，而 app 在导入链路中
+按 ``settings.CONFIG_PATH`` 连接 ``user.db``：本地非容器布局下默认落到
+``MoviePilot/config/user.db``（线上真实库），``import app.chain.*`` 等在导入时即会建立/连接。
+本文件在 ``unittest discover``（会先导入 tests 包）与 ``pytest``（导入 tests.* 用例前先导入本包）
+两种入口下都最先执行，故在此把 CONFIG_DIR 指向进程私有临时目录，避免测试连到或写入真实库与配置。
+已显式设置 CONFIG_DIR 时（如 CI 指定隔离目录）尊重之、不覆盖。
+"""
+import atexit
+import os
+import shutil
+import tempfile
+
+# 必须早于首个 import app.*：app.db 在导入时即按 CONFIG_PATH 建立/连接 user.db
+if not os.environ.get("CONFIG_DIR"):
+    _isolated_config_dir = tempfile.mkdtemp(prefix="mp-test-config-")
+    os.environ["CONFIG_DIR"] = _isolated_config_dir
+    # 进程退出时清理临时库与目录，避免 /tmp 堆积
+    atexit.register(shutil.rmtree, _isolated_config_dir, ignore_errors=True)


### PR DESCRIPTION
## 背景与根因

`tests/` 下的用例普遍直接 `import app.*`。而 `app.db` 在**导入阶段**即按 `settings.CONFIG_PATH` 连接 `user.db`：当未设置 `CONFIG_DIR`、且处于非容器 / 非冻结的本地布局时，`CONFIG_PATH` 会回退到仓库内的 `config/` 目录，也就是开发者的真实数据库。

后果是：直接运行任一会 `import app.chain.*` 的测试（无论通过 `unittest discover` 还是 `pytest`），都会在导入期连接、甚至写入本地真实的 `config/user.db` 与 `config/` 目录，破坏测试隔离，并存在污染真实数据的风险。

## 改动

在 `tests/__init__.py` 中，于导入任何用例之前，把 `CONFIG_DIR` 指向进程私有的临时目录：

- 该包的 `__init__` 在两种入口下都会最先执行——`unittest discover` 会先导入 `tests` 包；`pytest` 在导入 `tests.*` 用例前同样先导入本包。因此一处即可覆盖两个 runner。
- 已显式设置 `CONFIG_DIR`（例如 CI 指定的隔离目录）时尊重之、不覆盖。
- 进程退出时清理临时目录，避免堆积。

## 验证

- 两种入口下 `settings.CONFIG_PATH` 均指向临时目录，不再指向仓库内 `config/`。
- 运行会 `import app.chain` 的用例后，真实 `config/user.db` 的修改时间未发生变化，`config/` 目录下无临时残留。

## 能力边界

- 仅隔离测试期的配置目录，不改动任何测试逻辑或运行时行为。
- 不引入测试框架依赖、不改动 CI；pytest 依赖声明与 CI 跑测试等改进将另行推进。

---

本 PR 为 Claude Code 协作提交
