### PR TITLE
fix(agent): require_admin 权限门禁失效，非管理员可调用 admin 工具

### DIFF
--- a/app/agent/tools/base.py
+++ b/app/agent/tools/base.py
@@ -132,7 +132,10 @@ class MoviePilotTool(BaseTool, metaclass=ABCMeta):
         super().__init__(**kwargs)
         self._session_id = session_id
         self._user_id = user_id
-        self._require_admin = getattr(self.__class__, "require_admin", False)
+        # require_admin 在各工具子类以 pydantic 字段声明，pydantic v2 不在类对象上暴露字段值
+        # （getattr(cls, ...) 取不到），必须经实例读取——super().__init__() 已按字段默认填充实例；
+        # getattr 兜底兼容未声明该字段的工具，缺省按非管理员（False）处理。
+        self._require_admin = getattr(self, "require_admin", False)
         self.tags = self._build_tool_tags()
 
     @staticmethod


### PR DESCRIPTION
## 问题

agent 工具的“仅管理员”权限门禁全部失效，非管理员可调用所有标记 `require_admin` 的危险工具（如 `delete_download`、`install_plugin`、`update_site` 等）。

各工具子类以 pydantic 字段声明 `require_admin: bool = True`，但 `ToolBase.__init__` 用 `getattr(self.__class__, "require_admin", False)` 取值。pydantic v2 不在**类对象**上暴露字段值，`getattr(类, 字段名)` 取不到 → `_require_admin` 恒为 `False`，`MoviePilotToolsManager` 据此判定门禁 → 永远放行。

## 修复

`app/agent/tools/base.py` 改为经**实例**读取：`getattr(self, "require_admin", False)`。`super().__init__()` 已按字段默认填充实例字段，此处即可取到子类声明的值；`getattr` 兜底兼容以 `ClassVar` 声明或未声明该字段的工具（缺省按非管理员处理）。

## 影响

非管理员上下文下，`require_admin` 工具现在会被正确拦截（修复前该门禁完全失效）。属安全相关行为修正。

## 验证

现有测试 `tests/test_agent_system_settings_tools.py::TestAgentSystemSettingsTools::test_tool_manager_blocks_admin_tools_for_non_admin_context`（此前因该缺陷失败）现通过。

---
本 PR 为 Claude Code 协作提交
