### PR TITLE
fix(chain): 手动 AI 重新整理提示词上下文 key 错误（his_id→history_id）

### DIFF
--- a/app/chain/message.py
+++ b/app/chain/message.py
@@ -839,8 +839,9 @@ class MessageChain(ChainBase):
             source_path = src_fileitem.get("path") if isinstance(src_fileitem, dict) else ""
             source_path = source_path or his.src or ""
             season_episode = f"{his.seasons or ''}{his.episodes or ''}".strip()
+            # 键名必须与 System Tasks.yaml 中 manual_transfer_redo 模板的占位符一致
             template_context = {
-                "his_id": his.id,
+                "history_id": his.id,
                 "current_status": "success" if his.status else "failed",
                 "recognized_title": his.title or "unknown",
                 "media_type": his.type or "unknown",


### PR DESCRIPTION
## 问题

从整理历史页触发的「AI 重新整理」（Telegram/消息端 `transfer_ai_retry` 回调）会失败：`MessageChain._take_over_transfer_history_by_ai` 在构建 `manual_transfer_redo` 提示词时，`template_context` 用了键名 `his_id`，而 `app/agent/prompt/System Tasks.yaml` 中该模板的占位符是 `{history_id}`，渲染时抛 `PromptConfigError`。

## 修复

`app/chain/message.py` 中该键名改为 `history_id`，与模板占位符一致（也与另一调用方 `app/api/endpoints/history.py` 复用的上下文构造保持一致）。

## 验证

现有测试 `tests/test_transfer_failed_retry_buttons.py::TestTransferFailedRetryButtons::test_transfer_ai_retry_callback_schedules_agent_takeover`（此前因该缺陷失败）现通过。

---
本 PR 为 Claude Code 协作提交
