### PR TITLE
test: 拆分 agent token-event 用例，找回被过度跳过的 3 个用例

### DIFF
--- a/tests/test_agent_tokens_events.py
+++ b/tests/test_agent_tokens_events.py
@@ -2,14 +2,10 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
-import pytest
 from langchain_core.messages import AIMessage
 
 from app.agent import MoviePilotAgent
 from app.agent.memory import memory_manager
-# agenttokens 为动态安装插件（app/plugins/** 被 gitignore，CI / 全新环境无此插件），
-# 缺失时跳过本模块，避免 collection 阶段 ImportError。
-AgentTokens = pytest.importorskip("app.plugins.agenttokens").AgentTokens
 from app.schemas.types import ChainEventType, EventType
 
 
@@ -44,31 +40,6 @@ class _FakeFailingAgent(_FakeAgent):
 
 
 class AgentTokensEventsTest(unittest.IsolatedAsyncioTestCase):
-    async def test_plugin_sidebar_nav_respects_config(self):
-        """插件侧边栏入口应受 show_sidebar_nav 配置控制。"""
-        plugin = AgentTokens()
-
-        with patch.object(plugin, "update_config"):
-            plugin.init_plugin(
-                {
-                    "enabled": True,
-                    "show_sidebar_nav": False,
-                    "providers": [],
-                }
-            )
-            self.assertEqual([], plugin.get_sidebar_nav())
-
-            plugin.init_plugin(
-                {
-                    "enabled": True,
-                    "show_sidebar_nav": True,
-                    "providers": [],
-                }
-            )
-            nav = plugin.get_sidebar_nav()
-
-        self.assertEqual("Agent Tokens 管理", nav[0]["title"])
-
     async def test_initialize_llm_uses_chain_event_selection(self):
         """Agent 初始化 LLM 时应优先使用链式事件返回的供应商配置。"""
         agent = MoviePilotAgent(session_id="agent-tokens-test", user_id="user-1")


### PR DESCRIPTION
## 背景

`tests/test_agent_tokens_events.py` 此前整模块被 `pytest.importorskip("app.plugins.agenttokens")` 跳过。但该文件混了两类用例：只有「插件侧栏入口」用例真依赖 AgentTokens 插件；另外 3 个测的是主程序 `MoviePilotAgent` 的事件契约（按 `AgentLLMProvider` 链式事件选择 LLM 供应商、执行成功/失败后广播 `AgentTokensUsage` 用量），它们以 mock 注入事件、**并不依赖插件**，却被一并跳过。

## 改动

- 移除「插件侧栏入口」用例（该用例属插件侧逻辑，迁至官方插件仓的单测）。
- 移除 `app.plugins.agenttokens` 的 `importorskip` 与相关 import。

于是 3 个主程序 Agent 事件契约用例不再被无谓跳过、恢复正常运行。仅改测试，未动业务代码。

## 验证

全新环境（仅 `requirements.in`）：`python tests/run.py` = **945 passed / 0 skipped**（此前 942 passed / 1 skipped，找回 3 个被过度跳过的用例）；socket 探针全量零真实出站。

---
本 PR 为 Claude Code 协作提交
