### PR TITLE
test: 修复单测 warnings 并精确忽略上游弃用告警

### DIFF
--- a/app/modules/indexer/parser/nexus_php.py
+++ b/app/modules/indexer/parser/nexus_php.py
@@ -116,7 +116,7 @@ class NexusPhpSiteUserInfo(SiteParserBase):
             has_ucoin, self.bonus = self._parse_ucoin(html)
             if has_ucoin:
                 return
-            tmps = html.xpath('//a[contains(@href,"mybonus")]/text()') if html else None
+            tmps = html.xpath('//a[contains(@href,"mybonus")]/text()') if html is not None else None
             if tmps:
                 bonus_text = str(tmps[0]).strip()
                 bonus_match = re.search(r"([\d,.]+)", bonus_text)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,11 @@
+[pytest]
+# 仅对「无法在本仓修复根因」的已知上游/三方弃用告警做精确忽略，保持测试输出干净、
+# 让本仓自身的新告警更醒目。本仓代码引发的告警一律不在此忽略，应在源码/用例处修复。
+filterwarnings =
+    ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning
+    ignore:websockets.legacy is deprecated:DeprecationWarning
+    ignore:websockets.InvalidStatusCode is deprecated:DeprecationWarning
+    ignore:pkg_resources is deprecated as an API:DeprecationWarning
+    ignore:Deprecated call to .pkg_resources.declare_namespace:DeprecationWarning
+    ignore:'crypt' is deprecated:DeprecationWarning
+    ignore:'audioop' is deprecated:DeprecationWarning

--- a/tests/test_agent_image_support.py
+++ b/tests/test_agent_image_support.py
@@ -453,7 +453,8 @@ class AgentImageSupportTest(unittest.TestCase):
         ) as prepare_files, patch(
             "app.chain.message.agent_manager.process_message", new_callable=AsyncMock
         ) as process_message, patch(
-            "app.chain.message.asyncio.run_coroutine_threadsafe"
+            "app.chain.message.asyncio.run_coroutine_threadsafe",
+            side_effect=lambda coro, _loop: (coro.close(), Mock())[1],
         ) as run_coroutine_threadsafe:
             chain._handle_ai_message(
                 text="/ai 帮我看看这张图",

--- a/tests/test_agent_image_support.py
+++ b/tests/test_agent_image_support.py
@@ -454,7 +454,7 @@ class AgentImageSupportTest(unittest.TestCase):
             "app.chain.message.agent_manager.process_message", new_callable=AsyncMock
         ) as process_message, patch(
             "app.chain.message.asyncio.run_coroutine_threadsafe",
-            side_effect=lambda coro, _loop: (coro.close(), Mock())[1],
+            side_effect=lambda coro, _loop: coro.close(),
         ) as run_coroutine_threadsafe:
             chain._handle_ai_message(
                 text="/ai 帮我看看这张图",
@@ -487,7 +487,7 @@ class AgentImageSupportTest(unittest.TestCase):
             "app.chain.message.agent_manager.process_message", new_callable=AsyncMock
         ) as process_message, patch(
             "app.chain.message.asyncio.run_coroutine_threadsafe",
-            side_effect=lambda coro, _loop: (coro.close(), Mock())[1],
+            side_effect=lambda coro, _loop: coro.close(),
         ):
             chain._handle_ai_message(
                 text="帮我推荐一部电影",

--- a/tests/test_transfer_failed_retry_buttons.py
+++ b/tests/test_transfer_failed_retry_buttons.py
@@ -95,11 +95,16 @@ class TestTransferFailedRetryButtons(unittest.TestCase):
             errmsg="未识别到媒体信息",
         )
 
+        def _close_pending_coro(coro, *args, **kwargs):
+            """关闭被调度的协程：测试中事件循环未运行，不关闭会残留 never-awaited 警告。"""
+            coro.close()
+
         with patch.object(settings, "AI_AGENT_ENABLE", True):
             with patch(
                 "app.chain.message.TransferHistoryOper"
             ) as history_oper_cls, patch(
-                "app.chain.message.asyncio.run_coroutine_threadsafe"
+                "app.chain.message.asyncio.run_coroutine_threadsafe",
+                side_effect=_close_pending_coro,
             ) as run_task:
                 history_oper_cls.return_value.get.return_value = history
                 with patch.object(chain, "post_message") as post_message:


### PR DESCRIPTION
## 背景与目标

全量单测此前伴随多个 warning。本 PR 修复属于本仓的告警，并对无法在本仓修复根因的上游弃用告警做精确忽略，使输出干净、本仓自身新告警更醒目。

## 改动

- `app/modules/indexer/parser/nexus_php.py`：lxml 元素真值判断 `if html` 改为 `if html is not None`，消除 FutureWarning，并规避未来 lxml「元素真值恒为真」的行为变化。
- 修复两处 coroutine never-awaited：`test_transfer_failed_retry_buttons`、`test_agent_image_support` 中被 mock 的 `run_coroutine_threadsafe` 增加关闭传入协程的 `side_effect`——测试中事件循环未运行，否则被调度的协程在 GC 时残留告警。
- 新增 `pytest.ini`：对 `dateutil`/`lark_oapi` 的 `utcfromtimestamp`、`websockets`、`pkg_resources`、`crypt`/`audioop` 等已知上游弃用告警做精确 `filterwarnings` 忽略；本仓自身告警不在忽略之列。

## 验证

仅装 `requirements.in` + `pytest` 的隔离环境下全量 `pytest tests`：949 passed，0 warning。

本 PR 为 Claude Code 协作提交。
