### PR TITLE
fix: 修复前端代理服务器设置清空保存后，httpx 持续报 `Unknown scheme for proxy URL

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -691,9 +691,11 @@ class Settings(BaseSettings, ConfigModel, LogConfigModel):
             value = value.strip()
 
         # 处理 Optional 类型：当值为空字符串且类型允许 None 时，转为 None
+        # 兼容 typing.Union (Python 3.9) 与 types.UnionType (Python 3.10+ PEP 604)
         origin = get_origin(expected_type)
+        is_union = origin is Union or getattr(origin, "__name__", None) == "UnionType"
         if (
-            origin is Union
+            is_union
             and type(None) in get_args(expected_type)
             and isinstance(value, str)
             and not value
@@ -827,7 +829,6 @@ class Settings(BaseSettings, ConfigModel, LogConfigModel):
                 unset_key(
                     dotenv_path=SystemUtils.get_env_path(),
                     key_to_unset=field_name,
-                    quote_mode="always",
                 )
                 logger.info(f"配置项 '{field_name}' 已清空，从 'app.env' 中移除")
                 return True, message

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -9,10 +9,10 @@ import sys
 import threading
 from asyncio import AbstractEventLoop
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Optional, Tuple, Type, Union, get_origin, get_args
 from urllib.parse import quote, urlencode, urlparse
 
-from dotenv import set_key
+from dotenv import set_key, unset_key
 from pydantic import BaseModel, Field, ConfigDict, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -690,6 +690,16 @@ class Settings(BaseSettings, ConfigModel, LogConfigModel):
         if isinstance(value, str):
             value = value.strip()
 
+        # 处理 Optional 类型：当值为空字符串且类型允许 None 时，转为 None
+        origin = get_origin(expected_type)
+        if (
+            origin is Union
+            and type(None) in get_args(expected_type)
+            and isinstance(value, str)
+            and not value
+        ):
+            return default, str(default) != str(original_value)
+
         try:
             if expected_type is bool:
                 if isinstance(value, bool):
@@ -812,13 +822,20 @@ class Settings(BaseSettings, ConfigModel, LogConfigModel):
             logger.warning(message)
             return False, message
         else:
+            # 当值为 None 时，从 env 文件中删除该键，恢复为默认值
+            if converted_value is None:
+                unset_key(
+                    dotenv_path=SystemUtils.get_env_path(),
+                    key_to_unset=field_name,
+                    quote_mode="always",
+                )
+                logger.info(f"配置项 '{field_name}' 已清空，从 'app.env' 中移除")
+                return True, message
             # 如果是列表、字典或集合类型，将其转换为JSON字符串
             if isinstance(converted_value, (list, dict, set)):
                 value_to_write = json.dumps(converted_value)
             else:
-                value_to_write = (
-                    str(converted_value) if converted_value is not None else ""
-                )
+                value_to_write = str(converted_value)
 
             set_key(
                 dotenv_path=SystemUtils.get_env_path(),
@@ -967,7 +984,7 @@ class Settings(BaseSettings, ConfigModel, LogConfigModel):
 
     @property
     def PROXY(self):
-        if self.PROXY_HOST:
+        if self.PROXY_HOST and self.PROXY_HOST.strip():
             return {
                 "http": self.PROXY_HOST,
                 "https": self.PROXY_HOST,
@@ -1009,7 +1026,7 @@ class Settings(BaseSettings, ConfigModel, LogConfigModel):
 
     @property
     def PROXY_SERVER(self):
-        if self.PROXY_HOST:
+        if self.PROXY_HOST and self.PROXY_HOST.strip():
             try:
                 parsed = urlparse(self.PROXY_HOST)
                 if not parsed.scheme:

--- a/app/utils/http.py
+++ b/app/utils/http.py
@@ -92,6 +92,9 @@ def _get_shared_async_transport(
     会话级状态由调用方在外层 AsyncClient(transport=...) 实例化时单独配置，
     每次调用用完即销毁，因此天然无 jar 累积串扰。
     """
+    # 规范化代理：拒绝空字符串等非法值，防止 httpx 抛出 Unknown scheme for proxy URL
+    if proxy is not None and (not proxy or not proxy.strip()):
+        proxy = None
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
@@ -899,14 +902,14 @@ class AsyncRequestUtils:
 
         # 如果已经是字符串格式，直接返回
         if isinstance(proxies, str):
-            return proxies
+            return proxies.strip() or None
 
         # 如果是字典格式，提取http或https代理
         if isinstance(proxies, dict):
             # 优先使用https代理，如果没有则使用http代理
             proxy_url = proxies.get("https") or proxies.get("http")
-            if proxy_url:
-                return proxy_url
+            if proxy_url and proxy_url.strip():
+                return proxy_url.strip()
 
         return None
 

--- a/app/utils/http.py
+++ b/app/utils/http.py
@@ -907,9 +907,14 @@ class AsyncRequestUtils:
         # 如果是字典格式，提取http或https代理
         if isinstance(proxies, dict):
             # 优先使用https代理，如果没有则使用http代理
-            proxy_url = proxies.get("https") or proxies.get("http")
-            if proxy_url and proxy_url.strip():
-                return proxy_url.strip()
+            # 先各自 strip，避免空白字符串阻断裂合取或回退到 http 代理
+            https_proxy = proxies.get("https")
+            http_proxy = proxies.get("http")
+            https_proxy = https_proxy.strip() if isinstance(https_proxy, str) else None
+            http_proxy = http_proxy.strip() if isinstance(http_proxy, str) else None
+            proxy_url = https_proxy or http_proxy
+            if proxy_url:
+                return proxy_url
 
         return None
 


### PR DESCRIPTION
## 描述

### 发现背景

在测试 **OIDC Auth 插件**的「测试连接」功能时，测试接口直接返回了错误：

Unknown scheme for proxy URL URL('')

排查后发现与 OIDC 插件本身无关，而是系统代理配置残留导致的框架级 bug。

### 根因

前端/API 清空代理设置后，系统会将空字符串 '' 写入 app.env（PROXY_HOST=''），
该空值经框架 HTTP 层透传至 httpx，触发异常。

完整问题链路：

前端清空代理 → API 收到 PROXY_HOST=""
  → generic_type_converter: Optional[str] 未被识别 → 保持空字符串 ""
  → update_env_config: set_key 写入 PROXY_HOST=''
  → 下次启动 / 热重载: app.env 读到 ""
  → Settings.PROXY 返回 {"http": "", "https": ""}
  → 框架 HTTP 层透传空字符串 → httpx 抛异常

### 修复方案（三层防御）

| 层次 | 文件 | 变更 |
|---|---|---|
| 类型转换层 | config.py → generic_type_converter | 新增 Optional 类型识别：Optional[X] + 空字符串 → 直接返回 None |
| 持久化层 | config.py → update_env_config | 值为 None 时用 unset_key 删除整行，而非写入 '' |
| HTTP 代理层 | http.py → Transport / Converter | 空/空白 proxy 归一化为 None；PROXY/PROXY_SERVER 属性增加 .strip() 校验 |

### 变更文件

- app/core/config.py — +30 / -10
- app/utils/http.py — +9 / -3

### 注意事项

config.py 和 http.py 属于核心模块，PluginReload 无法热重载，
需重启 MoviePilot 服务生效。