### PR TITLE
ci: harden pull request unit test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,13 @@ on:
   # 允许手动触发
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: unit-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pytest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 变更说明

- 为 Unit Tests workflow 显式设置 `permissions: contents: read`，避免 PR 测试任务获得不必要的仓库写权限。
- 增加 `concurrency` 配置，同一 PR 或同一分支只保留最新一次单测运行，减少连续推送造成的重复 runner 消耗。

## 背景

当前 Unit Tests 会在指向 `v2` 的 `pull_request` 上触发。该 workflow 不使用 secrets、不发布、不部署，适合作为 fork PR 自动运行的低权限测试任务。显式收紧 `GITHUB_TOKEN` 权限并取消同组旧运行后，可以在考虑将 fork PR 审批策略调整为 first-time contributors 时降低权限与资源滥用风险。

## 验证

- YAML 解析通过
- `git diff --check`

本 PR 为 Codex 协作提交
