### PR TITLE
fix(jellyfin): 修复播放通知封面缺失问题

### DIFF
--- a/app/modules/jellyfin/jellyfin.py
+++ b/app/modules/jellyfin/jellyfin.py
@@ -502,18 +502,17 @@ class Jellyfin:
         try:
             res = RequestUtils(timeout=10).get_res(url, params)
             if res:
-                images = res.json().get("Images")
+                images = res.json().get("Images") or []
                 for image in images:
                     if image.get("ProviderName") == "TheMovieDb" and image.get("Type") == image_type:
                         return image.get("Url")
-                # return images[0].get("Url") # 首选无则返回第一张
+                # TMDB 无匹配时回退本地图片
+                logger.info(f"未找到 TMDB {image_type}，回退本地图片")
             else:
                 logger.info(f"Items/RemoteImages 未获取到返回数据，采用本地图片")
-                return self.generate_image_link(item_id, image_type, True)
         except Exception as e:
             logger.error(f"连接Items/Id/RemoteImages出错：" + str(e))
-            return None
-        return None
+        return self.generate_image_link(item_id, image_type, True)
 
     def get_item_path_by_id(self, item_id: str) -> Optional[str]:
         """


### PR DESCRIPTION
## 问题描述

Jellyfin 播放通知封面缺失。当 TMDB RemoteImages 返回数据但无匹配图片时，`get_remote_image_by_id` 方法直接 `return None`，导致播放通知没有封面图片。

原始代码仅在 API 请求失败（`else` 分支）时回退到本地图片，但忽略了 TMDB 无匹配的情况。

## 修复方案

在 TMDB 无匹配时也回退到本地图片，与 API 请求失败时的处理保持一致。

### 修改内容

`app/modules/jellyfin/jellyfin.py` 中的 `get_remote_image_by_id` 方法：

1. `images` 变量增加默认值 `[]` 防止 `None` 遍历异常
2. TMDB 无匹配后增加本地图片回退日志和调用
3. 统一所有失败路径都回退到 `generate_image_link`

### 修改前
```python
for image in images:
    if image.get("ProviderName") == "TheMovieDb" and image.get("Type") == image_type:
        return image.get("Url")
# 无匹配时直接 return None
...
return None
```

### 修改后
```python
for image in images:
    if image.get("ProviderName") == "TheMovieDb" and image.get("Type") == image_type:
        return image.get("Url")
# TMDB 无匹配时回退本地图片
logger.info(f"未找到 TMDB {image_type}，回退本地图片")
...
return self.generate_image_link(item_id, image_type, True)
```

## 测试情况

- [x] 语法检查通过
- [x] 本地功能验证正常