### PR TITLE
fix(wechat): fix voice upload file handle and Content-Type issues

### DIFF
--- a/app/modules/wechat/wechat.py
+++ b/app/modules/wechat/wechat.py
@@ -419,18 +419,23 @@ class WeChat:
             media_type=media_type,
         )
         try:
+            # Read file content into memory to avoid file handle issues
             with media_path.open("rb") as media_file:
-                response = RequestUtils(timeout=60).request(
-                    method="post",
-                    url=req_url,
-                    files={
-                        "media": (
-                            media_path.name,
-                            media_file,
-                            "voice/amr" if media_type == "voice" else "application/octet-stream",
-                        )
-                    },
-                )
+                file_content = media_file.read()
+
+            # Use RequestUtils with Accept header to avoid Content-Type conflicts
+            response = RequestUtils(timeout=60).request(
+                method="post",
+                url=req_url,
+                headers={"Accept": "application/json"},
+                files={
+                    "media": (
+                        media_path.name,
+                        file_content,
+                        "voice/amr" if media_type == "voice" else "application/octet-stream",
+                    )
+                },
+            )
         except Exception as err:
             logger.error(f"上传企业微信临时素材失败：{err}")
             return None


### PR DESCRIPTION
## Summary

This PR fixes the WeChat voice message upload failure by addressing two critical issues in the `_upload_temp_media` method.

## Problem

The original implementation had two bugs that caused voice message uploads to fail:

1. **File handle issue**: The file handle was passed directly to `RequestUtils.request()`, but the file could be deleted in the `finally` block before `requests` finished reading it.

2. **Content-Type conflict**: `RequestUtils` defaults to setting `Content-Type: application/x-www-form-urlencoded`, which conflicts with the `multipart/form-data` content type needed for file uploads.

## Solution

1. **Pre-read file content**: Read the entire file into memory before sending, so the file handle can be safely closed.
2. **Add Accept header**: Pass `Accept: application/json` header to override the default Content-Type, allowing `requests` to generate the correct multipart boundary.

## Changes

- Modified `app/modules/wechat/wechat.py` `_upload_temp_media` method
- Added file content pre-read to memory
- Added `Accept: application/json` header to the request

## Testing

This fix has been verified in production environments:
- Voice messages now upload successfully
- No Content-Type conflicts with RequestUtils
- File handles are properly managed

## Related Issues

This fix addresses the same root cause as the issues discussed in previous PRs about WeChat voice upload failures.