### PR TITLE
fix: 修复极影视媒体库同步不完整

### DIFF
--- a/app/modules/zspace/zspace.py
+++ b/app/modules/zspace/zspace.py
@@ -15,6 +15,9 @@ from app.utils.http import RequestUtils
 from app.utils.url import UrlUtils
 
 
+DEFAULT_ITEMS_PAGE_SIZE = 100
+
+
 class ZSpace:
     _host: Optional[str] = None
     _playhost: Optional[str] = None
@@ -826,30 +829,53 @@ class ZSpace:
         if not parent or not self._host or not self._apikey or not self.user:
             return None
         url = f"{self._host}emby/Users/{self.user}/Items"
-        params = {
-            "ParentId": parent,
-            "Fields": "ProviderIds,OriginalTitle,ProductionYear,Path,UserDataPlayCount,UserDataLastPlayedDate,ParentId"
-        }
-        if limit is not None and limit != -1:
-            params.update({
-                "StartIndex": start_index,
-                "Limit": limit
-            })
-        try:
-            res = self.__request_utils().get_res(url, params=params)
-            if not res or res.status_code != 200:
-                return None
-            items = res.json().get("Items") or []
-            for item in items:
-                if not item:
-                    continue
-                if "Folder" in item.get("Type"):
-                    for sub_item in self.get_items(parent=item.get('Id')) or []:
-                        yield sub_item
-                elif item.get("Type") in ["Movie", "Series"]:
+        fetch_all = limit is None or limit == -1
+        page_size = DEFAULT_ITEMS_PAGE_SIZE if fetch_all else limit
+        current_start_index = max(start_index or 0, 0)
+        while True:
+            params = {
+                "ParentId": parent,
+                "Recursive": "true",
+                "StartIndex": current_start_index,
+                "Limit": page_size,
+                "Fields": "ProviderIds,OriginalTitle,ProductionYear,Path,"
+                          "UserDataPlayCount,UserDataLastPlayedDate,ParentId"
+            }
+            try:
+                res = self.__request_utils().get_res(url, params=params)
+                if not res or res.status_code != 200:
+                    return None
+                result = res.json() or {}
+                items = result.get("Items") or []
+                for item in items:
+                    if not item or item.get("Type") not in ["Movie", "Series"]:
+                        continue
+                    provider_ids = item.get("ProviderIds") or {}
+                    needs_detail = (
+                        not provider_ids.get("Tmdb")
+                        or not item.get("ProductionYear")
+                        or not item.get("Path")
+                    )
+                    if needs_detail and item.get("Id"):
+                        detail_item = self.get_iteminfo(item.get("Id"))
+                        if detail_item:
+                            yield detail_item
+                            continue
                     yield self.__format_item_info(item)
-        except Exception as e:
-            logger.error(f"连接Users/Items出错：{e}")
+            except Exception as e:
+                logger.error(f"连接Users/Items出错：{e}")
+                return None
+
+            if not fetch_all:
+                break
+            current_start_index += len(items)
+            total_count = result.get("TotalRecordCount")
+            if not items or (
+                    total_count is not None and current_start_index >= total_count
+            ) or (
+                    total_count is None and len(items) < page_size
+            ):
+                break
         return None
 
     def get_webhook_message(self, form: Any, args: dict) -> Optional[schemas.WebhookEventInfo]:

--- a/tests/test_zspace_sync_items.py
+++ b/tests/test_zspace_sync_items.py
@@ -1,0 +1,167 @@
+from unittest.mock import patch
+
+from app.modules.zspace.zspace import ZSpace
+
+
+class _FakeResponse:
+    """模拟极影视 HTTP 响应。"""
+
+    def __init__(self, payload: dict, status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict:
+        """返回模拟的 JSON 数据。"""
+        return self._payload
+
+
+def _build_client() -> ZSpace:
+    """构造不触发登录流程的极影视客户端。"""
+    client = ZSpace.__new__(ZSpace)
+    client._host = "http://zspace.local/"
+    client._apikey = "zspace-token"
+    client.user = "user-id"
+    return client
+
+
+def test_get_items_fetches_all_recursive_pages() -> None:
+    """全量同步应递归查询并持续翻页，且忽略合集外壳。"""
+    client = _build_client()
+    responses = [
+        _FakeResponse({
+            "Items": [
+                {
+                    "Id": "movie-1",
+                    "Type": "Movie",
+                    "Name": "电影一",
+                    "ProductionYear": 2025,
+                    "ProviderIds": {"Tmdb": "101"},
+                    "Path": "/media/movie-1.mkv",
+                },
+                {
+                    "Id": "collection-1",
+                    "Type": "BoxSet",
+                    "Name": "电影合集",
+                },
+            ],
+            "TotalRecordCount": 3,
+        }),
+        _FakeResponse({
+            "Items": [
+                {
+                    "Id": "series-1",
+                    "Type": "Series",
+                    "Name": "剧集一",
+                    "ProductionYear": 2024,
+                    "ProviderIds": {"Tmdb": "202"},
+                    "Path": "/media/series-1",
+                },
+            ],
+            "TotalRecordCount": 3,
+        }),
+    ]
+
+    with patch("app.modules.zspace.zspace.DEFAULT_ITEMS_PAGE_SIZE", 2), patch(
+        "app.modules.zspace.zspace.RequestUtils"
+    ) as request_utils_cls:
+        request_utils_cls.return_value.get_res.side_effect = responses
+        items = list(client.get_items(parent="library-id"))
+
+    assert [item.item_id for item in items] == ["movie-1", "series-1"]
+    calls = request_utils_cls.return_value.get_res.call_args_list
+    assert calls[0].kwargs["params"]["Recursive"] == "true"
+    assert calls[0].kwargs["params"]["StartIndex"] == 0
+    assert calls[0].kwargs["params"]["Limit"] == 2
+    assert calls[1].kwargs["params"]["StartIndex"] == 2
+    assert calls[1].kwargs["params"]["Limit"] == 2
+
+
+def test_get_items_loads_detail_when_list_metadata_is_incomplete() -> None:
+    """列表项缺少关键元数据时应使用详情接口补全。"""
+    client = _build_client()
+    responses = [
+        _FakeResponse({
+            "Items": [
+                {
+                    "Id": "movie-1",
+                    "Type": "Movie",
+                    "Name": "疯狂动物城",
+                    "ProductionYear": None,
+                    "ProviderIds": {},
+                    "Path": "",
+                }
+            ],
+            "TotalRecordCount": 1,
+        }),
+        _FakeResponse({
+            "Id": "movie-1",
+            "ParentId": "library-id",
+            "Type": "Movie",
+            "Name": "疯狂动物城",
+            "OriginalTitle": "Zootopia",
+            "ProductionYear": 2016,
+            "ProviderIds": {
+                "Tmdb": "269149",
+                "Imdb": "tt2948356",
+            },
+            "Path": "/media/疯狂动物城 (2016)/疯狂动物城.mkv",
+        }),
+    ]
+
+    with patch("app.modules.zspace.zspace.RequestUtils") as request_utils_cls:
+        request_utils_cls.return_value.get_res.side_effect = responses
+        items = list(client.get_items(parent="library-id"))
+
+    assert len(items) == 1
+    assert items[0].item_id == "movie-1"
+    assert items[0].tmdbid == 269149
+    assert items[0].imdbid == "tt2948356"
+    assert items[0].year == 2016
+    assert items[0].path.endswith("疯狂动物城.mkv")
+    assert request_utils_cls.return_value.get_res.call_args_list[1].args[0] == (
+        "http://zspace.local/emby/Users/user-id/Items/movie-1"
+    )
+
+
+def test_get_items_uses_total_count_when_server_returns_short_pages() -> None:
+    """服务端单页少于请求数量时应以总记录数决定是否继续翻页。"""
+    client = _build_client()
+    responses = [
+        _FakeResponse({
+            "Items": [
+                {
+                    "Id": "movie-1",
+                    "Type": "Movie",
+                    "Name": "电影一",
+                    "ProductionYear": 2025,
+                    "ProviderIds": {"Tmdb": "101"},
+                    "Path": "/media/movie-1.mkv",
+                }
+            ],
+            "TotalRecordCount": 2,
+        }),
+        _FakeResponse({
+            "Items": [
+                {
+                    "Id": "movie-2",
+                    "Type": "Movie",
+                    "Name": "电影二",
+                    "ProductionYear": 2024,
+                    "ProviderIds": {"Tmdb": "102"},
+                    "Path": "/media/movie-2.mkv",
+                }
+            ],
+            "TotalRecordCount": 2,
+        }),
+    ]
+
+    with patch("app.modules.zspace.zspace.DEFAULT_ITEMS_PAGE_SIZE", 100), patch(
+        "app.modules.zspace.zspace.RequestUtils"
+    ) as request_utils_cls:
+        request_utils_cls.return_value.get_res.side_effect = responses
+        items = list(client.get_items(parent="library-id"))
+
+    assert [item.item_id for item in items] == ["movie-1", "movie-2"]
+    calls = request_utils_cls.return_value.get_res.call_args_list
+    assert calls[0].kwargs["params"]["StartIndex"] == 0
+    assert calls[1].kwargs["params"]["StartIndex"] == 1


### PR DESCRIPTION
## 问题说明

  极影视媒体库同步完成后，MoviePilot 本地记录的入库状态与极影视网页展示不一致。

  主要包含两个原因：

  ### 1. 媒体库列表没有完整分页

  原实现调用极影视 Emby 兼容接口时，`limit=-1` 会省略以下参数：

  - `Recursive`
  - `StartIndex`
  - `Limit`

  MoviePilot 将“不传 Limit”理解为获取全部数据，但极影视接口实际只返回默认第一页。

  例如电影库共有 42 条记录，默认第一页返回 20 条，其中包含 4 个 `BoxSet` 合集。MoviePilot 只同步 `Movie` 和 `Series`，所以最终只写入了 16 部电影。

  这导致 `mediaserveritem` 表数据不完整，推荐页根据该表判断入库状态时，部分已存在于极影视的影片没有显示入库标记。

  ### 2. 列表接口返回的元数据不完整

  合集内容下的`Movie` 或 `Series` 在列表接口中缺少关键字段，例如：

  - `ProviderIds.Tmdb`
  - `ProductionYear`
  - `Path`

  以《疯狂动物城》为例，列表接口返回：

  ```text
  ProviderIds = {}
  ProductionYear = None
  Path = ""
  ```
  但通过条目详情接口查询同一个 item_id 时，可以获得完整的 TMDB ID、IMDb ID、年份和文件路径。

  原实现直接使用列表结果写入本地数据库，导致这些条目无法通过 TMDB ID 或标题、年份正确匹配，网页仍然无法显示入库状态。

  ## 修改内容

  ### 完整分页查询

  极影视全量同步现在：

  - 显式传递 Recursive=true
  - 显式传递 StartIndex
  - 使用每页 100 条的分页大小
  - 根据服务端返回的 TotalRecordCount 持续翻页
  - 服务端不返回总数时，使用短页作为结束条件

  当服务端实际返回数量小于请求数量、但 TotalRecordCount 表明仍有剩余数据时，也会继续请求下一页。

  ### 条目类型过滤

  递归接口已经覆盖媒体库子目录，因此不再对 Folder 重复递归请求。

  同步仍只处理：

  - Movie
  - Series

  以下类型不会作为独立媒体写入：

  - Folder
  - BoxSet
  - Season
  - Episode

  BoxSet 是合集外壳，不代表具体影片，继续保持跳过行为。

  ### 详情接口补全

  列表中的 Movie 或 Series 缺少以下任意关键字段时：

  - TMDB ID
  - 制作年份
  - 媒体路径

  会根据 item_id 请求：

  GET /emby/Users/{user_id}/Items/{item_id}

  使用详情接口返回的数据构造本地媒体记录。详情请求失败时仍回退到原列表数据，不会中断整个媒体库同步。

  ## 测试覆盖

  新增极影视同步测试，覆盖：

  - Recursive=true 参数
  - StartIndex 和 Limit 分页参数
  - 多页数据完整获取
  - 以 TotalRecordCount 判断是否继续翻页
  - 服务端返回短页但仍有剩余数据的场景
  - BoxSet 合集过滤
  - 列表元数据不完整时查询详情
  - 详情数据中的 TMDB ID、IMDb ID、年份及路径写入

  ## 验证结果

  相关测试：

  18 passed

  全量测试：

  1174 passed, 1 skipped

  全量静态检查：

  pylint app/
  10.00/10
  0 warnings
  0 errors

  ## 兼容性与风险

  - 不涉及数据库结构变更，无需迁移。
  - 不涉及配置项、REST API、CLI 或前端变更。
  - 未修改项目依赖。
  - 对元数据完整的条目不会增加额外详情请求。
  - 只有缺少 TMDB ID、年份或路径的条目会增加一次详情请求。