### PR TITLE
fix(docker): prevent stale service worker caching

### DIFF
--- a/docker/nginx.common.conf
+++ b/docker/nginx.common.conf
@@ -85,6 +85,7 @@ location = /service-worker.js {
 
 location = /manifest.webmanifest {
     expires off;
+    default_type application/manifest+json;
     add_header Cache-Control "no-cache, must-revalidate";
     try_files $uri =404;
 }
@@ -99,7 +100,6 @@ location ~* ^/(?!api/v1).*\.(js|css)$ {
 
 # assets目录
 location /assets {
-    expires 1y;
     add_header Cache-Control "public, max-age=31536000, immutable";
 }
 

--- a/docker/nginx.common.conf
+++ b/docker/nginx.common.conf
@@ -76,6 +76,19 @@ location ~* \.(png|jpg|jpeg|gif|ico|svg)$ {
     add_header Cache-Control "public, immutable";
 }
 
+# Service Worker 和 Web App Manifest 需要稳定 URL 但不能长缓存，否则前端更新时浏览器可能继续注册旧版本。
+location = /service-worker.js {
+    expires off;
+    add_header Cache-Control "no-cache, must-revalidate";
+    try_files $uri =404;
+}
+
+location = /manifest.webmanifest {
+    expires off;
+    add_header Cache-Control "no-cache, must-revalidate";
+    try_files $uri =404;
+}
+
 # JS 和 CSS 静态资源缓存（排除 /api/v1 路径）
 location ~* ^/(?!api/v1).*\.(js|css)$ {
     try_files $uri =404;
@@ -87,7 +100,7 @@ location ~* ^/(?!api/v1).*\.(js|css)$ {
 # assets目录
 location /assets {
     expires 1y;
-    add_header Cache-Control "public, immutable";
+    add_header Cache-Control "public, max-age=31536000, immutable";
 }
 
 # 站点图标


### PR DESCRIPTION
## 变更说明

- 为 Docker nginx 增加 `/service-worker.js` 精确缓存规则，避免前端升级后浏览器继续注册旧 Service Worker。
- 为 `/manifest.webmanifest` 增加同样的重新验证规则，并显式设置 `application/manifest+json` 类型，避免 PWA 元数据被普通静态资源策略长缓存。
- 将 `/assets` 的长缓存策略显式补充 `max-age=31536000`，保持带 hash 静态资源长期缓存语义，同时避免与 `expires` 生成重复缓存头。

## 影响路径

- `docker/nginx.common.conf`

## 验证

- `git diff --check`
- 渲染 Docker nginx 模板后通过 `nginx -t` 语法校验
- 未进行 Docker 容器启动验证

## 联动 PR

- 前端示例 nginx 配置同步修复：https://github.com/jxxghp/MoviePilot-Frontend/pull/498

本 PR 为 Codex 协作提交
