### PR TITLE
fix: respect explicit subscribe best version settings

### DIFF
--- a/app/api/endpoints/subscribe.py
+++ b/app/api/endpoints/subscribe.py
@@ -41,6 +41,14 @@ def start_subscribe_add(
     )
 
 
+def build_subscribe_event_payload(subscribe: Subscribe) -> dict:
+    """
+    从 ORM 已加载字段构造订阅事件快照，避免异步接口里属性懒加载触发隐式 IO。
+    """
+    values = subscribe.__dict__
+    return {column.name: values.get(column.name) for column in subscribe.__table__.columns}
+
+
 @router.get("/", summary="查询所有订阅", response_model=List[schemas.Subscribe])
 async def read_subscribes(
     db: AsyncSession = Depends(get_async_db),
@@ -349,12 +357,20 @@ async def delete_subscribe_by_mediaid(
         subscribe = await Subscribe.async_get_by_mediaid(db, mediaid)
         if subscribe:
             delete_subscribes.append(subscribe)
+    delete_events = []
     for subscribe in delete_subscribes:
-        # 在删除之前获取订阅信息
-        subscribe_info = subscribe.to_dict()
-        subscribe_id = subscribe.id
-        await Subscribe.async_delete(db, subscribe_id)
-        # 发送事件
+        subscribe_info = build_subscribe_event_payload(subscribe)
+        subscribe_id = subscribe_info.get("id")
+        if not subscribe_id:
+            continue
+        delete_events.append((subscribe_id, subscribe_info))
+        await db.delete(subscribe)
+    try:
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    for subscribe_id, subscribe_info in delete_events:
         await eventmanager.async_send_event(
             EventType.SubscribeDeleted,
             {"subscribe_id": subscribe_id, "subscribe_info": subscribe_info},
@@ -726,8 +742,13 @@ async def delete_subscribe(
     subscribe = await Subscribe.async_get(db, subscribe_id)
     if subscribe:
         # 在删除之前获取订阅信息
-        subscribe_info = subscribe.to_dict()
-        await Subscribe.async_delete(db, subscribe_id)
+        subscribe_info = build_subscribe_event_payload(subscribe)
+        await db.delete(subscribe)
+        try:
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
         # 发送事件
         await eventmanager.async_send_event(
             EventType.SubscribeDeleted,
@@ -735,6 +756,6 @@ async def delete_subscribe(
         )
         # 统计订阅
         MoviePilotServerHelper.sub_done_async(
-            {"tmdbid": subscribe.tmdbid, "doubanid": subscribe.doubanid}
+            {"tmdbid": subscribe_info.get("tmdbid"), "doubanid": subscribe_info.get("doubanid")}
         )
     return schemas.Response(success=True)

--- a/app/api/endpoints/subscribe.py
+++ b/app/api/endpoints/subscribe.py
@@ -19,6 +19,7 @@ from app.db.models.user import User
 from app.db.systemconfig_oper import SystemConfigOper
 from app.db.user_oper import get_current_active_user_async
 from app.helper.server import MoviePilotServerHelper
+from app.log import logger
 from app.scheduler import Scheduler
 from app.schemas.types import MediaType, EventType, SystemConfigKey
 
@@ -371,10 +372,13 @@ async def delete_subscribe_by_mediaid(
         await db.rollback()
         raise
     for subscribe_id, subscribe_info in delete_events:
-        await eventmanager.async_send_event(
-            EventType.SubscribeDeleted,
-            {"subscribe_id": subscribe_id, "subscribe_info": subscribe_info},
-        )
+        try:
+            await eventmanager.async_send_event(
+                EventType.SubscribeDeleted,
+                {"subscribe_id": subscribe_id, "subscribe_info": subscribe_info},
+            )
+        except Exception as err:
+            logger.error(f"发送订阅删除事件失败：{subscribe_id} - {err}", exc_info=True)
     return schemas.Response(success=True)
 
 

--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -582,8 +582,8 @@ class SubscribeChain(ChainBase):
                 "include") else kwargs.get("include"),
             'exclude': self.__get_default_subscribe_config(mtype, "exclude") if not kwargs.get(
                 "exclude") else kwargs.get("exclude"),
-            'best_version': self.__get_default_subscribe_config(mtype, "best_version") if not kwargs.get(
-                "best_version") else kwargs.get("best_version"),
+            'best_version': self.__get_default_subscribe_config(mtype, "best_version")
+            if kwargs.get("best_version") is None else kwargs.get("best_version"),
             'best_version_full': self.__get_default_subscribe_config(mtype, "best_version_full")
             if kwargs.get("best_version_full") is None else kwargs.get("best_version_full"),
             'search_imdbid': self.__get_default_subscribe_config(mtype, "search_imdbid") if not kwargs.get(

--- a/app/schemas/subscribe.py
+++ b/app/schemas/subscribe.py
@@ -62,9 +62,9 @@ class Subscribe(BaseModel):
     # 下载器
     downloader: Optional[str] = None
     # 是否洗版
-    best_version: Optional[int] = 0
+    best_version: Optional[int] = None
     # 是否只洗全集整包
-    best_version_full: Optional[int] = 0
+    best_version_full: Optional[int] = None
     # 当前优先级
     current_priority: Optional[int] = None
     # 洗版时已下载剧集的优先级状态

--- a/tests/test_subscribe_chain.py
+++ b/tests/test_subscribe_chain.py
@@ -372,6 +372,25 @@ class SubscribeChainTest(TestCase):
             media_info=SimpleNamespace(type=MediaType.TV, tmdb_id=1, douban_id=None),
         )
 
+    def test_default_kwargs_respects_explicit_zero_best_version(self):
+        """显式关闭洗版时必须保留 0，仅未传值才应用默认订阅规则。"""
+
+        def _default_config(_mtype, key):
+            return 1 if key in {"best_version", "best_version_full"} else None
+
+        with patch.object(SubscribeChain, "_SubscribeChain__get_default_subscribe_config", side_effect=_default_config):
+            explicit = SubscribeChain()._SubscribeChain__get_default_kwargs(
+                MediaType.TV,
+                best_version=0,
+                best_version_full=0,
+            )
+            omitted = SubscribeChain()._SubscribeChain__get_default_kwargs(MediaType.TV)
+
+        self.assertEqual(explicit["best_version"], 0)
+        self.assertEqual(explicit["best_version_full"], 0)
+        self.assertEqual(omitted["best_version"], 1)
+        self.assertEqual(omitted["best_version_full"], 1)
+
     def test_format_subscribe_progress_preserves_special_season_zero(self):
         """订阅列表展示必须把 S0 当作合法季号，而不是回退到第 1 季。"""
         subscribe = self._build_subscribe(season=0, total_episode=5, lack_episode=2)


### PR DESCRIPTION
### **User description**
## 变更说明

修复订阅洗版参数的默认值和媒体级批量取消订阅的删除流程：

- `best_version` / `best_version_full` 未传时才走后端默认规则，显式传 `0` 时保持普通订阅语义。
- 媒体级删除多个订阅时，先构造删除事件 payload，再执行批量删除，避免删除后访问异步 ORM 对象触发 `MissingGreenlet`。
- 为显式 `best_version=0` 增加回归测试。

## 影响路径

- `app/chain/subscribe.py`
- `app/schemas/subscribe.py`
- `app/api/endpoints/subscribe.py`
- `tests/test_subscribe_chain.py`

## 验证

- `../.venv-test/bin/python -m pytest tests/test_subscribe_oper.py tests/test_subscribe_chain.py -q`：48 passed
- `env -u CONFIG_DIR ../.venv-test/bin/python -m pylint app`：10.00/10
- `git diff --check`：通过

## 联动 PR

- 前端配套 PR：https://github.com/jxxghp/MoviePilot-Frontend/pull/501

前端 PR 调整订阅入口在完整入库时才显式选择洗版方式，其余场景不传 `best_version`，由后端默认规则处理。

本 PR 为 Codex 协作提交


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- 保留显式洗版零值

- 删除前快照订阅信息

- 统一提交删除事务

- 增加回归测试


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>subscribe.py</strong><dd><code>修复订阅删除事件快照流程</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/api/endpoints/subscribe.py

<ul><li>新增 <code>build_subscribe_event_payload</code> 生成订阅快照。<br> <li> 删除前收集事件数据，避免异步懒加载。<br> <li> 批量与单条删除改用事务提交。<br> <li> 删除统计改用快照中的媒体标识。</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6001/files#diff-5850184ddaa52b77ccd3b80349213cd9b3302fb29526840d0d11218f69bb5d9c">+29/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>subscribe.py</strong><dd><code>保留洗版显式零值配置</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/chain/subscribe.py

- `best_version` 仅在未传值时使用默认配置。
- 显式传入 `0` 时保留关闭洗版语义。


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6001/files#diff-cad6359993258638e5dfa201eb0e98e5e79a162161b40ecb593410aabfc336b7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>subscribe.py</strong><dd><code>调整洗版字段默认值</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/schemas/subscribe.py

<ul><li><code>best_version</code> 默认值改为 <code>None</code>。<br> <li> <code>best_version_full</code> 默认值改为 <code>None</code>。<br> <li> 区分未传值与显式关闭洗版。</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6001/files#diff-4c076a3305f65fd993e037bcc098b52b538e7bcf47db9d34ac9a9b31aa8e0f78">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_subscribe_chain.py</strong><dd><code>增加洗版零值回归测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_subscribe_chain.py

<ul><li>新增显式 <code>best_version=0</code> 回归测试。<br> <li> 验证未传洗版参数时应用默认规则。<br> <li> 同时覆盖 <code>best_version_full</code> 零值行为。</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6001/files#diff-05f686d8f473e2a3e44a85570209c156b7deffb4e7d452e42931b75eb612b45a">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

