### PR TITLE
fix: recognize HDR Vivid resources

### DIFF
--- a/app/core/meta/metavideo.py
+++ b/app/core/meta/metavideo.py
@@ -49,7 +49,7 @@ class MetaVideo(MetaBase):
     _part_re = r"(^PART[0-9ABI]{0,2}$|^CD[0-9]{0,2}$|^DVD[0-9]{0,2}$|^DISK[0-9]{0,2}$|^DISC[0-9]{0,2}$)"
     _roman_numerals = r"^(?=[MDCLXVI])M*(C[MD]|D?C{0,3})(X[CL]|L?X{0,3})(I[XV]|V?I{0,3})$"
     _source_re = r"^BLURAY$|^HDTV$|^UHDTV$|^HDDVD$|^WEBRIP$|^DVDRIP$|^BDRIP$|^BLU$|^WEB$|^BD$|^HDRip$|^REMUX$|^UHD$"
-    _effect_re = r"^SDR$|^HDR\d*$|^DOLBY$|^DOVI$|^DV$|^3D$|^REPACK$|^HLG$|^HDR10(\+|Plus)$|^HDR10P$|^VIVID$|^EDR$|^HQ$"
+    _effect_re = r"^SDR$|^HDR\d*$|^HDRVIVID$|^DOLBY$|^DOVI$|^DV$|^3D$|^REPACK$|^HLG$|^HDR10(\+|Plus)$|^HDR10P$|^VIVID$|^EDR$|^HQ$"
     _resources_type_re = r"%s|%s" % (_source_re, _effect_re)
     _name_no_begin_re = r"^[\[【].+?[\]】]"
     _name_no_chinese_re = r".*版|.*字幕"

--- a/app/modules/filter/builtin_rules.py
+++ b/app/modules/filter/builtin_rules.py
@@ -83,7 +83,7 @@ BUILTIN_RULE_SET: Dict[str, dict] = {
     },
     # HDR
     "HDR": {
-        "include": [r"[\s.]+HDR[\s.]+|HDR10|HDR10\+"],
+        "include": [r"[\s.]+HDR[\s.]+|HDR10|HDR10\+|HDRVivid"],
         "exclude": [],
     },
     # SDR

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-moviepilot-rust~=0.1.12
+moviepilot-rust~=0.1.13
 pydantic>=2.13.4,<3.0.0
 pydantic-settings>=2.14.1,<3.0.0
 SQLAlchemy~=2.0.50

--- a/tests/test_metainfo.py
+++ b/tests/test_metainfo.py
@@ -211,6 +211,19 @@ def test_video_bit_extracted_for_video_title():
     assert meta.video_bit == "10bit"
 
 
+def test_hdr_vivid_effect_extracted_for_video_title():
+    """测试合并写法 HDRVivid 可识别为资源效果。"""
+    with patch("app.core.metainfo.rust_accel.parse_metainfo", return_value=None):
+        meta = MetaInfo(
+            title="Never-Ending Summer 2026 S01E18-S01E19 2160p WEB-DL 50Fps "
+                  "HDRVivid H265 10bit AAC-XXWEB"
+        )
+
+    assert meta.resource_type == "WEB-DL"
+    assert meta.resource_effect == "HDRVivid"
+    assert meta.fps == 50
+
+
 def test_video_bit_extracted_for_anime_title():
     """测试动漫标题中的视频位深可单独识别。"""
     meta = MetaInfo(

--- a/tests/test_torrent_filter.py
+++ b/tests/test_torrent_filter.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from app.core.context import MediaInfo, TorrentInfo
 from app.helper.torrent import TorrentHelper
 from app.modules.filter import FilterModule
+from app.modules.filter.builtin_rules import BUILTIN_RULE_SET
 from app.utils import rust_accel
 
 
@@ -63,6 +64,22 @@ def test_filter_torrents_keeps_priority_and_boolean_rule_semantics():
     assert torrents[:2] == filtered
     assert filtered[0].pri_order == 100
     assert filtered[1].pri_order == 99
+
+
+def test_builtin_hdr_rule_matches_hdr_vivid_release():
+    """
+    内置 HDR 规则应覆盖 HDR Vivid 合并写法，保证订阅优先级规则可命中。
+    """
+    module = _build_filter_module(
+        rule_string="HDR",
+        rule_set=BUILTIN_RULE_SET,
+    )
+    torrent = TorrentInfo(title="Movie 2026 2160p WEB-DL HDRVivid H265", description="")
+
+    filtered = module.filter_torrents(rule_groups=["test"], torrent_list=[torrent])
+
+    assert [torrent] == filtered
+    assert torrent.pri_order == 100
 
 
 def test_filter_torrents_keeps_lazy_priority_level_parsing():


### PR DESCRIPTION
### **User description**
## 变更说明

- 将 `HDRVivid` 纳入视频资源效果识别，避免被漏识别为 HDR 相关效果。
- 内置 `HDR` 过滤规则加入 `HDRVivid`，使订阅优先级规则可命中该类资源。
- 将 `requirements.in` 中的 `moviepilot-rust` 提升到 `0.1.13`。
- 补充 Python fallback 解析和内置 HDR 规则的回归测试。

## 影响路径

- `app/core/meta/metavideo.py`
- `app/modules/filter/builtin_rules.py`
- `requirements.in`
- `tests/test_metainfo.py`
- `tests/test_torrent_filter.py`

## 关联

Fixes #6006

依赖 Rust 解析侧 PR：jxxghp/MoviePilot-Rust#6

## 验证

- `env -u CONFIG_DIR ../.venv-test/bin/python -m pytest tests/test_metainfo.py tests/test_torrent_filter.py -q`：34 passed
- `env -u CONFIG_DIR ../.venv-test/bin/python tests/run.py`：1487 passed, 1 skipped
- `env -u CONFIG_DIR ../.venv-test/bin/python -m pylint app`：10.00/10
- `git diff --check`

本 PR 为 Codex 协作提交


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- 识别 `HDRVivid` 资源效果

- HDR 规则覆盖 `HDRVivid`

- 升级 Rust 解析依赖

- 补充相关回归测试


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>metavideo.py</strong><dd><code>新增 `HDRVivid` 效果正则匹配</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/core/meta/metavideo.py

- 在 `_effect_re` 中加入 `^HDRVIVID$`
- 支持 `HDRVivid` 合并写法效果识别


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6007/files#diff-2df0762e26af43a7ba33ab2d02e4423737003cfb1a4ddad7c863e7ad8c2f5076">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>builtin_rules.py</strong><dd><code>扩展 HDR 内置过滤匹配</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/modules/filter/builtin_rules.py

- 扩展内置 `HDR` 过滤规则
- 允许 `HDRVivid` 命中 HDR 订阅规则


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6007/files#diff-2cbacb10f17a0a5ec8529efdbbb82c8aaa26784bd6b2dc7a6e2fd77f91646fd8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_metainfo.py</strong><dd><code>增加 `HDRVivid` 元信息解析测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_metainfo.py

<ul><li>新增 <code>HDRVivid</code> 标题解析回归测试<br> <li> 校验 <code>WEB-DL</code>、效果和帧率识别<br> <li> 使用 mock 覆盖 Python fallback 解析路径</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6007/files#diff-124bbb4fba047ac4722c4fc79aa86aa89d762e18c6efda7675a29a86f6ac7f99">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_torrent_filter.py</strong><dd><code>增加 HDR 过滤回归测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_torrent_filter.py

<ul><li>引入 <code>BUILTIN_RULE_SET</code> 测试内置规则<br> <li> 新增 <code>HDRVivid</code> 种子 HDR 匹配测试<br> <li> 验证命中后优先级为 <code>100</code></ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6007/files#diff-e005822a8587bdf2d36024e98dc52e4bc4eebbc9f016d7eb8fa06d6249c87377">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>requirements.in</strong><dd><code>升级 Rust 解析依赖版本</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

requirements.in

- 将 `moviepilot-rust` 升级到 `~0.1.13`
- 同步依赖 Rust 侧解析能力更新


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6007/files#diff-de469cc9cf8992ffaec661b4e087cfded3ec6da722072ec1fdf11f61690fd1b8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

