### PR TITLE
fix(transfer): 修复订阅自定义识别词在整理时失效

### DIFF
--- a/app/chain/download.py
+++ b/app/chain/download.py
@@ -467,20 +467,6 @@ class DownloadChain(ChainBase):
         # 返回 种子文件路径，种子目录名，种子文件清单
         return content, download_folder, files
 
-    @staticmethod
-    def __get_source_custom_words(source: Optional[str]) -> Optional[str]:
-        """
-        根据下载来源反查订阅，获取完整自定义识别词文本，作为整理时复现识别的快照。
-
-        整理阶段直接复用此快照，避免依赖订阅实时反查（订阅季号漂移、来源解析失败等会导致反查为空而丢失偏移）。
-        此处延迟导入 SubscribeChain，规避与订阅链（subscribe.py 模块级 import DownloadChain）构成的循环依赖。
-        """
-        if not source:
-            return None
-        from app.chain.subscribe import SubscribeChain
-        subscribe = SubscribeChain().get_subscribe_by_source(source)
-        return subscribe.custom_words if subscribe and subscribe.custom_words else None
-
     def download_single(self, context: Context,
                         torrent_file: Path = None,
                         torrent_content: Optional[Union[str, bytes]] = None,
@@ -492,7 +478,8 @@ class DownloadChain(ChainBase):
                         userid: Union[str, int] = None,
                         username: Optional[str] = None,
                         label: Optional[str] = None,
-                        return_detail: bool = False) -> Union[Optional[str], Tuple[Optional[str], Optional[str]]]:
+                        return_detail: bool = False,
+                        custom_words: Optional[str] = None) -> Union[Optional[str], Tuple[Optional[str], Optional[str]]]:
         """
         下载及发送通知
         :param context: 资源上下文
@@ -507,6 +494,7 @@ class DownloadChain(ChainBase):
         :param username: 调用下载的用户名/插件名
         :param label: 自定义标签
         :param return_detail: 是否返回详细结果；False 时返回下载任务 hash 或 None，True 时返回 (hash, error_msg)
+        :param custom_words: 下载来源（如订阅）的完整自定义识别词文本，随下载记录存档，供整理时原样复现识别
         :return: return_detail=False 时返回下载任务 hash 或 None；return_detail=True 时返回 (hash, error_msg)
         """
         _torrent = context.torrent_info
@@ -664,7 +652,7 @@ class DownloadChain(ChainBase):
                 media_category=_media.category,
                 episode_group=_media.episode_group,
                 note={"source": source},
-                custom_words=self.__get_source_custom_words(source)
+                custom_words=custom_words
             )
 
             # 登记下载文件
@@ -753,7 +741,8 @@ class DownloadChain(ChainBase):
                        source: Optional[str] = None,
                        userid: Optional[str] = None,
                        username: Optional[str] = None,
-                       downloader: Optional[str] = None
+                       downloader: Optional[str] = None,
+                       custom_words: Optional[str] = None
                        ) -> Tuple[List[Context], Dict[Union[int, str], Dict[int, NotExistMediaInfo]]]:
         """
         根据缺失数据，自动种子列表中组合择优下载
@@ -765,6 +754,7 @@ class DownloadChain(ChainBase):
         :param userid:  用户ID
         :param username: 调用下载的用户名/插件名
         :param downloader: 下载器
+        :param custom_words: 下载来源（如订阅）的完整自定义识别词文本，随下载记录存档，供整理时原样复现识别
         :return: 已经下载的资源列表、剩余未下载到的剧集 no_exists[tmdb_id/douban_id] = {season: NotExistMediaInfo}
         """
         # 已下载的项目
@@ -905,7 +895,7 @@ class DownloadChain(ChainBase):
                 logger.info(f"开始下载电影 {context.torrent_info.title} ...")
                 if self.download_single(context, save_path=save_path, channel=channel,
                                         source=source, userid=userid, username=username,
-                                        downloader=downloader):
+                                        downloader=downloader, custom_words=custom_words):
                     # 下载成功
                     logger.info(f"{context.torrent_info.title} 添加下载成功")
                     downloaded_list.append(context)
@@ -1001,7 +991,8 @@ class DownloadChain(ChainBase):
                                         source=source,
                                         userid=userid,
                                         username=username,
-                                        downloader=downloader
+                                        downloader=downloader,
+                                        custom_words=custom_words
                                     )
                             else:
                                 # 下载
@@ -1009,7 +1000,8 @@ class DownloadChain(ChainBase):
                                 download_id = self.download_single(context, save_path=save_path,
                                                                    channel=channel, source=source,
                                                                    userid=userid, username=username,
-                                                                   downloader=downloader)
+                                                                   downloader=downloader,
+                                                                   custom_words=custom_words)
 
                             if download_id:
                                 # 下载成功
@@ -1091,7 +1083,8 @@ class DownloadChain(ChainBase):
                                 download_id = self.download_single(context, save_path=save_path,
                                                                    channel=channel, source=source,
                                                                    userid=userid, username=username,
-                                                                   downloader=downloader)
+                                                                   downloader=downloader,
+                                                                   custom_words=custom_words)
                                 if download_id:
                                     # 下载成功
                                     logger.info(f"{meta.title} 添加下载成功")
@@ -1186,7 +1179,8 @@ class DownloadChain(ChainBase):
                                 source=source,
                                 userid=userid,
                                 username=username,
-                                downloader=downloader
+                                downloader=downloader,
+                                custom_words=custom_words
                             )
                             if not download_id:
                                 continue

--- a/app/chain/download.py
+++ b/app/chain/download.py
@@ -467,6 +467,20 @@ class DownloadChain(ChainBase):
         # 返回 种子文件路径，种子目录名，种子文件清单
         return content, download_folder, files
 
+    @staticmethod
+    def __get_source_custom_words(source: Optional[str]) -> Optional[str]:
+        """
+        根据下载来源反查订阅，获取完整自定义识别词文本，作为整理时复现识别的快照。
+
+        整理阶段直接复用此快照，避免依赖订阅实时反查（订阅季号漂移、来源解析失败等会导致反查为空而丢失偏移）。
+        此处延迟导入 SubscribeChain，规避与订阅链（subscribe.py 模块级 import DownloadChain）构成的循环依赖。
+        """
+        if not source:
+            return None
+        from app.chain.subscribe import SubscribeChain
+        subscribe = SubscribeChain().get_subscribe_by_source(source)
+        return subscribe.custom_words if subscribe and subscribe.custom_words else None
+
     def download_single(self, context: Context,
                         torrent_file: Path = None,
                         torrent_content: Optional[Union[str, bytes]] = None,
@@ -649,7 +663,8 @@ class DownloadChain(ChainBase):
                 date=time.strftime("%Y-%m-%d %H:%M:%S", time.localtime()),
                 media_category=_media.category,
                 episode_group=_media.episode_group,
-                note={"source": source}
+                note={"source": source},
+                custom_words=self.__get_source_custom_words(source)
             )
 
             # 登记下载文件

--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -506,6 +506,7 @@ class SubscribeChain(ChainBase):
                 save_path=save_path,
                 downloader=downloader,
                 source=source,
+                custom_words=subscribe.custom_words,
             )
             if downloads:
                 return downloads, lefts
@@ -518,6 +519,7 @@ class SubscribeChain(ChainBase):
             save_path=save_path,
             downloader=downloader,
             source=source,
+            custom_words=subscribe.custom_words,
         )
 
     @staticmethod

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -2403,6 +2403,32 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             self.__normalize_dir_path(Path(current_item.path).parent),
         )
 
+    @staticmethod
+    def _get_subscribe_custom_words(
+            history_record: Optional[DownloadHistory],
+    ) -> Optional[List[str]]:
+        """
+        获取整理用自定义识别词：优先使用下载时保存的快照，无快照（历史旧记录）时再按来源实时反查订阅。
+
+        快照优先可避免整理阶段因订阅季号漂移、来源解析失败或订阅完成被删导致识别词丢失，从而原样入库到偏移前的季集。
+        """
+        if not history_record:
+            return None
+        # 下载时保存的完整订阅识别词快照优先
+        if history_record.custom_words:
+            return history_record.custom_words.split("\n")
+        # 兜底：历史旧记录无快照时，按下载来源实时反查订阅
+        if not isinstance(history_record.note, dict):
+            return None
+        subscribe = SubscribeChain().get_subscribe_by_source(
+            history_record.note.get("source")
+        )
+        return (
+            subscribe.custom_words.split("\n")
+            if subscribe and subscribe.custom_words
+            else None
+        )
+
     def do_transfer(
             self,
             fileitem: FileItem,
@@ -2478,24 +2504,6 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         )
         # 汇总错误信息
         err_msgs: List[str] = []
-
-        def _get_subscribe_custom_words(
-                history_record: Optional[DownloadHistory],
-        ) -> Optional[List[str]]:
-            """
-            根据下载记录获取订阅自定义识别词。
-            """
-            if not history_record or not isinstance(history_record.note, dict):
-                return None
-            # 使用source动态获取订阅
-            subscribe = SubscribeChain().get_subscribe_by_source(
-                history_record.note.get("source")
-            )
-            return (
-                subscribe.custom_words.split("\n")
-                if subscribe and subscribe.custom_words
-                else None
-            )
 
         def _build_file_meta(
                 source_path: Path,
@@ -2620,7 +2628,7 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             )
             return _build_file_meta(
                 main_path,
-                custom_word_list=_get_subscribe_custom_words(main_download_history),
+                custom_word_list=self._get_subscribe_custom_words(main_download_history),
             )
 
         def _append_item(
@@ -2778,7 +2786,7 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                     bluray_dir=main_bluray_dir,
                     download_hash=download_hash,
                 )
-                subscribe_custom_words = _get_subscribe_custom_words(
+                subscribe_custom_words = self._get_subscribe_custom_words(
                     main_download_history
                 )
                 main_meta = _build_file_meta(
@@ -2901,7 +2909,7 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                     else:
                         file_meta = _build_file_meta(
                             file_path,
-                            custom_word_list=_get_subscribe_custom_words(download_history),
+                            custom_word_list=self._get_subscribe_custom_words(download_history),
                         )
                 else:
                     file_meta = _build_file_meta(file_path)

--- a/tests/test_download_chain.py
+++ b/tests/test_download_chain.py
@@ -158,6 +158,61 @@ def test_download_single_submits_download_added_to_background(monkeypatch):
     )
 
 
+def test_download_single_persists_custom_words_snapshot(monkeypatch):
+    """下载成功登记历史时，应把传入的订阅识别词原样存入快照，供整理时原样复现识别。"""
+    captured = {}
+
+    class _CapturingDownloadHistoryOper:
+        """捕获写入下载历史的字段，验证识别词快照确实落库。"""
+
+        def add(self, **kwargs):
+            captured.update(kwargs)
+
+        def add_files(self, _files):
+            pass
+
+    _FakeThreadHelper.submitted = []
+    monkeypatch.setattr(download_module, "ThreadHelper", _FakeThreadHelper)
+    monkeypatch.setattr(download_module, "DownloadHistoryOper", _CapturingDownloadHistoryOper)
+    monkeypatch.setattr(download_module, "TorrentHelper", _FakeTorrentHelper)
+
+    chain = DownloadChain.__new__(DownloadChain)
+    chain.download = MagicMock(return_value=("qb", "hash123", "Original", "添加下载成功"))
+    chain.download_added = MagicMock()
+    chain.eventmanager = MagicMock()
+    chain.eventmanager.send_event.return_value = None
+    chain.post_message = MagicMock()
+
+    context = Context(
+        meta_info=MetaInfo("Demo Show 2024"),
+        media_info=MediaInfo(
+            type=MediaType.TV,
+            title="Demo Show",
+            year="2024",
+            tmdb_id=1,
+            genre_ids=[18],
+        ),
+        torrent_info=TorrentInfo(
+            title="Demo Show 2024",
+            enclosure="https://example.com/demo.torrent",
+            site_cookie="uid=1",
+            site_name="TestSite",
+        ),
+    )
+
+    custom_words = "S04 => S01\n第 <> 集 >> EP+66"
+    result = chain.download_single(
+        context=context,
+        torrent_content=b"torrent-content",
+        save_path="/downloads",
+        username="tester",
+        custom_words=custom_words,
+    )
+
+    assert result == "hash123"
+    assert captured["custom_words"] == custom_words
+
+
 def test_save_subtitle_response_creates_missing_temp_directory(monkeypatch, tmp_path):
     """
     下载字幕 API 保存响应前应自动创建缺失的临时目录。
@@ -431,6 +486,29 @@ def test_batch_download_does_not_download_duplicate_movie_after_success(monkeypa
     assert lefts is None
     chain.download_single.assert_called_once()
     assert chain.download_single.call_args.args[0] is first_context
+
+
+def test_batch_download_threads_custom_words_to_download_single(monkeypatch):
+    """订阅识别词须经 batch_download 透传到 download_single，作为整理快照随下载存档。"""
+    _FakeBatchTorrentHelper.episodes = []
+    monkeypatch.setattr(download_module, "TorrentHelper", _FakeBatchTorrentHelper)
+    monkeypatch.setattr(download_module.eventmanager, "send_event", lambda *args, **kwargs: None)
+
+    chain = DownloadChain.__new__(DownloadChain)
+    chain.download_single = MagicMock(return_value="hash")
+
+    context = SimpleNamespace(
+        media_info=SimpleNamespace(type=MediaType.MOVIE, title_year="Demo Movie (2026)"),
+        meta_info=SimpleNamespace(season_episode=""),
+        torrent_info=SimpleNamespace(title="Demo Movie"),
+    )
+
+    custom_words = "S04 => S01\n第 <> 集 >> EP+66"
+    downloads, _lefts = chain.batch_download(contexts=[context], custom_words=custom_words)
+
+    assert downloads == [context]
+    chain.download_single.assert_called_once()
+    assert chain.download_single.call_args.kwargs["custom_words"] == custom_words
 
 
 def test_batch_download_accepts_complete_coverage_when_files_cover_target_range(monkeypatch):

--- a/tests/test_subscribe_chain.py
+++ b/tests/test_subscribe_chain.py
@@ -358,6 +358,7 @@ class SubscribeChainTest(TestCase):
             "description": None,
             "last_update": None,
             "username": None,
+            "custom_words": None,
             "to_dict": lambda: {},
         }
         data.update(overrides)
@@ -1186,7 +1187,11 @@ class SubscribeChainTest(TestCase):
         )
 
     def test_episode_best_version_downloads_full_pack_before_episode_fallback(self):
-        subscribe = self._build_subscribe(best_version_full=0, total_episode=3)
+        subscribe = self._build_subscribe(
+            best_version_full=0,
+            total_episode=3,
+            custom_words="S04 => S01\n第 <> 集 >> EP+66",
+        )
         full_pack_context = SimpleNamespace(
             torrent_info=SimpleNamespace(pri_order=90),
             media_info=SimpleNamespace(type=MediaType.TV),
@@ -1234,6 +1239,8 @@ class SubscribeChainTest(TestCase):
         self.assertEqual(len(calls), 1)
         self.assertEqual(calls[0]["contexts"], [full_pack_context])
         self.assertEqual(calls[0]["no_exists"]["media-key"][1].episodes, [])
+        # 订阅识别词须作为入参随下载下传，供整理时复现识别（避免下载模块反查订阅的循环依赖）
+        self.assertEqual(calls[0]["custom_words"], "S04 => S01\n第 <> 集 >> EP+66")
 
     def test_episode_best_version_falls_back_when_full_pack_not_downloaded(self):
         subscribe = self._build_subscribe(best_version_full=0, total_episode=3)

--- a/tests/test_transfer_custom_words.py
+++ b/tests/test_transfer_custom_words.py
@@ -2,12 +2,12 @@
 """订阅自定义识别词快照用例：下载时保存完整识别词，整理时快照优先、实时反查兜底。
 
 回归场景：订阅做季+集组合偏移（如 S04E05→S01E71），下载阶段生效但整理阶段因实时反查订阅
-返回空而静默回退全局识别词、丢失偏移。修复后整理优先复用下载时保存的快照。
+返回空而静默回退全局识别词、丢失偏移。修复后由订阅链在发起下载时将完整识别词作为入参传入
+下载模块并存档（避免下载模块反查订阅的同级循环依赖），整理时优先复用该快照。
 """
 from types import SimpleNamespace
 
 import app.chain.transfer as transfer_module
-from app.chain.download import DownloadChain
 from app.chain.transfer import TransferChain
 
 
@@ -74,25 +74,3 @@ def test_transfer_returns_none_when_unavailable(monkeypatch):
         )
         is None
     )
-
-
-def test_download_snapshots_full_subscribe_custom_words(monkeypatch):
-    """下载时应反查订阅并返回完整 custom_words 文本作为整理快照。"""
-    import app.chain.subscribe as subscribe_module
-
-    class _FakeSubscribeChain:
-        def get_subscribe_by_source(self, source):
-            assert source == "Subscribe|{...}"
-            return SimpleNamespace(custom_words="S04 => S01\n第 <> 集 >> EP+66")
-
-    # download.py 内为延迟导入，需 patch 源模块属性
-    monkeypatch.setattr(subscribe_module, "SubscribeChain", _FakeSubscribeChain)
-
-    snapshot = DownloadChain._DownloadChain__get_source_custom_words("Subscribe|{...}")
-    assert snapshot == "S04 => S01\n第 <> 集 >> EP+66"
-
-
-def test_download_snapshot_none_for_non_subscribe_source():
-    """非订阅来源（source 为空）不保存快照，且不触发任何订阅反查。"""
-    assert DownloadChain._DownloadChain__get_source_custom_words(None) is None
-    assert DownloadChain._DownloadChain__get_source_custom_words("") is None

--- a/tests/test_transfer_custom_words.py
+++ b/tests/test_transfer_custom_words.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""订阅自定义识别词快照用例：下载时保存完整识别词，整理时快照优先、实时反查兜底。
+
+回归场景：订阅做季+集组合偏移（如 S04E05→S01E71），下载阶段生效但整理阶段因实时反查订阅
+返回空而静默回退全局识别词、丢失偏移。修复后整理优先复用下载时保存的快照。
+"""
+from types import SimpleNamespace
+
+import app.chain.transfer as transfer_module
+from app.chain.download import DownloadChain
+from app.chain.transfer import TransferChain
+
+
+def _fake_history(custom_words=None, note=None):
+    """构造仅含测试所需字段的下载历史替身。"""
+    return SimpleNamespace(custom_words=custom_words, note=note)
+
+
+def test_transfer_prefers_snapshot_over_live_lookup(monkeypatch):
+    """整理时存在下载快照，应直接使用快照且不触发实时反查订阅。"""
+    called = {"lookup": False}
+
+    class _GuardSubscribeChain:
+        def get_subscribe_by_source(self, source):
+            # 一旦走到实时反查即视为失败：快照存在时不应触发
+            called["lookup"] = True
+            return SimpleNamespace(custom_words="不应使用\n实时反查")
+
+    monkeypatch.setattr(transfer_module, "SubscribeChain", _GuardSubscribeChain)
+
+    history = _fake_history(
+        custom_words="S04 => S01\n第 <> 集 >> EP+66",
+        note={"source": "Subscribe|{...}"},
+    )
+    result = TransferChain._get_subscribe_custom_words(history)
+
+    assert result == ["S04 => S01", "第 <> 集 >> EP+66"]
+    assert called["lookup"] is False
+
+
+def test_transfer_falls_back_to_live_lookup_without_snapshot(monkeypatch):
+    """整理时无快照（历史旧记录），应按下载来源实时反查订阅取识别词。"""
+
+    class _FakeSubscribeChain:
+        def get_subscribe_by_source(self, source):
+            assert source == "Subscribe|{...}"
+            return SimpleNamespace(custom_words="A => B")
+
+    monkeypatch.setattr(transfer_module, "SubscribeChain", _FakeSubscribeChain)
+
+    history = _fake_history(custom_words=None, note={"source": "Subscribe|{...}"})
+    result = TransferChain._get_subscribe_custom_words(history)
+
+    assert result == ["A => B"]
+
+
+def test_transfer_returns_none_when_unavailable(monkeypatch):
+    """无下载记录、note 非字典、或来源反查不到订阅时返回 None（回退全局识别词）。"""
+
+    class _NoneSubscribeChain:
+        def get_subscribe_by_source(self, source):
+            return None
+
+    monkeypatch.setattr(transfer_module, "SubscribeChain", _NoneSubscribeChain)
+
+    # 无下载记录
+    assert TransferChain._get_subscribe_custom_words(None) is None
+    # 无快照且 note 非字典：不应触发实时反查
+    assert TransferChain._get_subscribe_custom_words(_fake_history(note="不是字典")) is None
+    # 无快照、来源可解析但反查不到订阅
+    assert (
+        TransferChain._get_subscribe_custom_words(
+            _fake_history(note={"source": "Subscribe|{}"})
+        )
+        is None
+    )
+
+
+def test_download_snapshots_full_subscribe_custom_words(monkeypatch):
+    """下载时应反查订阅并返回完整 custom_words 文本作为整理快照。"""
+    import app.chain.subscribe as subscribe_module
+
+    class _FakeSubscribeChain:
+        def get_subscribe_by_source(self, source):
+            assert source == "Subscribe|{...}"
+            return SimpleNamespace(custom_words="S04 => S01\n第 <> 集 >> EP+66")
+
+    # download.py 内为延迟导入，需 patch 源模块属性
+    monkeypatch.setattr(subscribe_module, "SubscribeChain", _FakeSubscribeChain)
+
+    snapshot = DownloadChain._DownloadChain__get_source_custom_words("Subscribe|{...}")
+    assert snapshot == "S04 => S01\n第 <> 集 >> EP+66"
+
+
+def test_download_snapshot_none_for_non_subscribe_source():
+    """非订阅来源（source 为空）不保存快照，且不触发任何订阅反查。"""
+    assert DownloadChain._DownloadChain__get_source_custom_words(None) is None
+    assert DownloadChain._DownloadChain__get_source_custom_words("") is None


### PR DESCRIPTION
### **User description**
## 问题

订阅做季+集组合偏移（订阅级自定义识别词，如 `S04E05 → S01E71`，用于对齐 TMDB 绝对集编号）时，**下载阶段偏移生效，但整理阶段偏移完全丢失**，文件原样入库到偏移前的季集（如 Season 4）。

## 根因

整理阶段获取识别词的方式被改为"按下载来源实时反查订阅"（`note["source"] → get_subscribe_by_source → subscribe.custom_words`）。该实时反查在订阅季号漂移、来源解析失败或订阅完成被删等场景返回空，`MetaInfoPath` 拿到 `custom_words=None` 后**静默回退到全局识别词**（用户仅在订阅级配置识别词），导致季/集偏移丢失。

## 修复

恢复"下载时保存识别词快照 + 整理时快照优先、实时反查兜底"：

- **`app/chain/download.py`**：下载时反查订阅取完整 `subscribe.custom_words`，存入 `download_history.custom_words` 快照；延迟导入 `SubscribeChain` 规避与订阅链的循环依赖。
- **`app/chain/transfer.py`**：将识别词获取从 `do_transfer` 内闭包提取为 `TransferChain._get_subscribe_custom_words` 静态方法，改为**快照优先**，无快照（历史旧记录）时再实时反查订阅兜底。
- 复用既有 2.2.3 迁移（`58edfac72c32`）建立的 `custom_words` 列，**无需新迁移**。

## 兼容性 / 副作用

- 整理以下载时快照为准：下载后再修改订阅识别词不影响已下载文件的整理（保证下载/整理一致）。
- 历史旧下载记录（无快照）保留实时反查行为，无回归。

## 测试

- 新增 `tests/test_transfer_custom_words.py`：覆盖快照优先 / 实时反查兜底 / None 分支 / 下载完整快照 / 空来源。
- 全量 `python tests/run.py`：1510 passed, 1 skipped。


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- 存档订阅识别词快照

- 整理阶段优先复用快照

- 历史记录保留反查兜底

- 补充相关回归测试


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>download.py</strong><dd><code>下载历史保存识别词快照</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/chain/download.py

<ul><li><code>download_single</code> 新增 <code>custom_words</code> 入参。<br> <li> 下载历史登记时保存 <code>custom_words</code> 快照。<br> <li> <code>batch_download</code> 透传识别词到单任务下载。<br> <li> 多处下载调用补齐 <code>custom_words</code> 传递。</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6018/files#diff-465dca72daf1459ec043549e88962cd2af9b4c1a7ee973405c93158414b406eb">+17/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>subscribe.py</strong><dd><code>订阅下载透传自定义识别词</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/chain/subscribe.py

- 订阅发起批量下载时传入 `subscribe.custom_words`。
- 全集优先与普通下载路径均透传识别词。


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6018/files#diff-cad6359993258638e5dfa201eb0e98e5e79a162161b40ecb593410aabfc336b7">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>transfer.py</strong><dd><code>整理阶段优先使用识别词快照</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/chain/transfer.py

<ul><li>新增 <code>TransferChain._get_subscribe_custom_words</code> 静态方法。<br> <li> 整理时优先读取下载历史 <code>custom_words</code> 快照。<br> <li> 无快照时按 <code>note.source</code> 实时反查订阅兜底。<br> <li> 元数据构建调用统一使用新方法。</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6018/files#diff-82ba99ba5bf406a9207ce84406ca0a5be6103dd23bc70156d6a0a06d849fdb8e">+29/-21</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_download_chain.py</strong><dd><code>覆盖下载识别词快照传递</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_download_chain.py

- 新增下载历史保存 `custom_words` 快照测试。
- 新增 `batch_download` 透传识别词测试。


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6018/files#diff-99edfde5a79891f0871c6a3fa002b76adae2c21517776d7aca0bab87c7e76601">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_subscribe_chain.py</strong><dd><code>验证订阅识别词下传下载</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_subscribe_chain.py

- 测试订阅对象补充 `custom_words` 字段。
- 验证分集洗版全集优先下载会透传识别词。


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6018/files#diff-05f686d8f473e2a3e44a85570209c156b7deffb4e7d452e42931b75eb612b45a">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_transfer_custom_words.py</strong><dd><code>覆盖整理识别词快照逻辑</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_transfer_custom_words.py

- 新增识别词快照优先回归测试。
- 覆盖无快照时实时反查订阅兜底。
- 覆盖无记录、非字典 `note`、反查为空分支。


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6018/files#diff-fd36140377e73a16f061b1bd207e319fdcb5d87135b0bee2e944d91405b9a454">+76/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

