### PR TITLE
fix(transfer): expose file meta in intercept event

### DIFF
--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -976,7 +976,7 @@ class TransHandler:
         """
         整理一个文件，同时处理其他相关文件
         :param fileitem: 原文件
-        :param meta: 文件级整理识别元数据
+        :param meta: 元数据
         :param mediainfo: 媒体信息
         :param source_oper: 源存储操作对象
         :param target_oper: 目标存储操作对象

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -536,6 +536,7 @@ class TransHandler:
                 # 整理文件
                 new_item, err_msg = self.__transfer_file(
                     fileitem=fileitem,
+                    meta=in_meta,
                     mediainfo=mediainfo,
                     target_storage=target_storage,
                     target_file=new_file,
@@ -962,6 +963,7 @@ class TransHandler:
     def __transfer_file(
         self,
         fileitem: FileItem,
+        meta: Optional[MetaBase],
         mediainfo: MediaInfo,
         source_oper: StorageBase,
         target_oper: StorageBase,
@@ -974,6 +976,7 @@ class TransHandler:
         """
         整理一个文件，同时处理其他相关文件
         :param fileitem: 原文件
+        :param meta: 文件级整理识别元数据
         :param mediainfo: 媒体信息
         :param source_oper: 源存储操作对象
         :param target_oper: 目标存储操作对象
@@ -990,6 +993,7 @@ class TransHandler:
         )
         event_data = TransferInterceptEventData(
             fileitem=fileitem,
+            meta=meta,
             mediainfo=mediainfo,
             target_storage=target_storage,
             target_path=target_file,

--- a/app/schemas/event.py
+++ b/app/schemas/event.py
@@ -388,7 +388,7 @@ class TransferInterceptEventData(ChainEventData):
     Attributes:
         # 输入参数
         fileitem (FileItem): 源文件
-        meta (Any): 文件级整理识别元数据
+        meta (Any): 元数据
         target_storage (str): 目标存储
         target_path (Path): 目标路径
         transfer_type (str): 整理方式（copy、move、link、softlink等）
@@ -402,7 +402,7 @@ class TransferInterceptEventData(ChainEventData):
 
     # 输入参数
     fileitem: FileItem = Field(..., description="源文件")
-    meta: Optional[Any] = Field(default=None, description="文件级整理识别元数据")
+    meta: Optional[Any] = Field(default=None, description="元数据")
     mediainfo: Any = Field(..., description="媒体信息")
     target_storage: str = Field(..., description="目标存储")
     target_path: Path = Field(..., description="目标路径")

--- a/app/schemas/event.py
+++ b/app/schemas/event.py
@@ -388,6 +388,7 @@ class TransferInterceptEventData(ChainEventData):
     Attributes:
         # 输入参数
         fileitem (FileItem): 源文件
+        meta (Any): 文件级整理识别元数据
         target_storage (str): 目标存储
         target_path (Path): 目标路径
         transfer_type (str): 整理方式（copy、move、link、softlink等）
@@ -401,6 +402,7 @@ class TransferInterceptEventData(ChainEventData):
 
     # 输入参数
     fileitem: FileItem = Field(..., description="源文件")
+    meta: Optional[Any] = Field(default=None, description="文件级整理识别元数据")
     mediainfo: Any = Field(..., description="媒体信息")
     target_storage: str = Field(..., description="目标存储")
     target_path: Path = Field(..., description="目标路径")

--- a/tests/test_transfer_job_manager.py
+++ b/tests/test_transfer_job_manager.py
@@ -265,6 +265,81 @@ class TransferJobManagerTest(unittest.TestCase):
         self.assertEqual(target_item, transferinfo.target_item)
         self.assertEqual(target_folder, transferinfo.target_diritem)
 
+    def test_single_file_transfer_intercept_event_carries_file_meta(self):
+        """
+        单文件整理拦截事件应携带文件级识别元数据，便于事件处理器按季集匹配。
+        """
+        handler = TransHandler()
+        source_item = FileItem(
+            storage="alist",
+            path="/downloads/Test.Show.S02E03.mkv",
+            type="file",
+            name="Test.Show.S02E03.mkv",
+            basename="Test.Show.S02E03",
+            extension="mkv",
+            size=1024,
+            modify_time=1715939275.0,
+        )
+        target_path = Path("/library")
+        target_file = Path("/library/Test.Show.S02E03.mkv")
+        target_folder = FileItem(
+            storage="alist",
+            type="dir",
+            path="/library/",
+            name="library",
+            basename="library",
+        )
+        target_item = FileItem(
+            storage="alist",
+            path=target_file.as_posix(),
+            type="file",
+            name=target_file.name,
+            basename=target_file.stem,
+            extension="mkv",
+            size=1024,
+        )
+        source_oper = SimpleNamespace(
+            is_support_transtype=lambda transfer_type: True,
+            move=lambda fileitem, path, name: True,
+        )
+        target_oper = SimpleNamespace(
+            get_folder=lambda path: target_folder,
+            get_item=lambda path: None,
+        )
+        in_meta = MetaVideo("Test.Show.S02E03")
+
+        with patch.object(
+                TransHandler, "get_rename_path", return_value=target_file
+        ), patch(
+                "app.modules.filemanager.transhandler.DirectoryHelper.get_media_root_path",
+                return_value=Path("/library"),
+        ), patch.object(
+                TransHandler,
+                "_TransHandler__transfer_command",
+                return_value=(target_item, ""),
+        ), patch(
+                "app.modules.filemanager.transhandler.eventmanager.send_event",
+                return_value=None,
+        ) as send_event:
+            transferinfo = handler.transfer_media(
+                fileitem=source_item,
+                in_meta=in_meta,
+                mediainfo=make_media_info(),
+                target_storage="alist",
+                target_path=target_path,
+                transfer_type="move",
+                source_oper=source_oper,
+                target_oper=target_oper,
+                need_scrape=True,
+                need_notify=True,
+            )
+
+        self.assertTrue(transferinfo.success)
+        event_data = send_event.call_args.args[1]
+        self.assertIs(in_meta, event_data.meta)
+        self.assertEqual(2, event_data.meta.begin_season)
+        self.assertEqual(3, event_data.meta.begin_episode)
+
     def test_success_callback_uses_transfer_result_target_diritem(self):
         """
         回调发送刮削事件时应直接使用整理结果里的目标目录项。

--- a/tests/test_transfer_job_manager.py
+++ b/tests/test_transfer_job_manager.py
@@ -267,7 +267,7 @@ class TransferJobManagerTest(unittest.TestCase):
 
     def test_single_file_transfer_intercept_event_carries_file_meta(self):
         """
-        单文件整理拦截事件应携带文件级识别元数据，便于事件处理器按季集匹配。
+        单文件整理拦截事件应携带元数据，便于事件处理器按季集匹配。
         """
         handler = TransHandler()
         source_item = FileItem(


### PR DESCRIPTION
### **User description**
## 变更说明

- `TransferInterceptEventData` 增加可选 `meta` 字段，用于传递单文件整理时的文件级识别元数据。
- 单文件整理发送 `TransferIntercept` 事件时透传 `in_meta`，事件处理器可直接读取季集信息。
- 增加单测覆盖单文件整理事件携带 `S02E03` 文件级 meta 的行为。

## 影响路径

- `app/schemas/event.py`
- `app/modules/filemanager/transhandler.py`
- `tests/test_transfer_job_manager.py`

## 验证

- `env -u CONFIG_DIR .venv-test/bin/python -m pytest tests/test_transfer_job_manager.py -q`：24 passed
- `git diff --check`：通过

## 说明

- 本改动保持字段可选，目录整理事件仍不传递文件级 meta。
- 联动插件 PR 会提升插件 `system_version`，避免旧主程序安装依赖该事件字段的插件版本。

本 PR 为 Codex 协作提交


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- 单文件拦截事件透传元数据

- 事件模型新增可选 `meta`

- 增加季集元数据回归测试


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transhandler.py</strong><dd><code>单文件整理事件传递元数据</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/modules/filemanager/transhandler.py

<ul><li>将 <code>in_meta</code> 传入单文件整理流程<br> <li> <code>__transfer_file</code> 新增 <code>meta</code> 参数<br> <li> 构造 <code>TransferInterceptEventData</code> 时填充 <code>meta</code></ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6019/files#diff-d93f3dd52f728e3c8ce028394e334986b9803bd9a08f258349daa68f7e693962">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>event.py</strong><dd><code>拦截事件模型新增元数据字段</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/schemas/event.py

<ul><li>为 <code>TransferInterceptEventData</code> 新增可选 <code>meta</code><br> <li> 更新事件模型注释说明元数据字段<br> <li> 默认值保持为 <code>None</code> 以兼容旧用法</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6019/files#diff-fa9319abe1e10bed0e75c211eec40aac3f967b7e285c332e428ae45badbcd957">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_transfer_job_manager.py</strong><dd><code>覆盖单文件事件元数据传递</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_transfer_job_manager.py

- 新增单文件整理拦截事件测试
- 构造 `S02E03` 场景验证季集元数据
- 断言事件中的 `meta` 保持同一对象


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6019/files#diff-e57c5dccdc8a490d8ba3c6e13de2f507656e6d343c9c56e012a011defca4b2dd">+75/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

