### PR TITLE
fix: sanitize LLM model endpoint errors

### DIFF
--- a/app/api/endpoints/llm.py
+++ b/app/api/endpoints/llm.py
@@ -48,7 +48,7 @@ class LlmProviderAuthStartRequest(BaseModel):
     method: str
 
 
-def _sanitize_llm_test_error(message: str, api_key: Optional[str] = None) -> str:
+def _sanitize_llm_error(message: str, api_key: Optional[str] = None) -> str:
     """
     清理错误信息中的敏感字段，避免回显密钥。
     """
@@ -70,11 +70,14 @@ def _sanitize_llm_test_error(message: str, api_key: Optional[str] = None) -> str
     )
 
     normalized_message = sanitized.lower().replace("_", "").replace(" ", "")
-    if "str" in normalized_message and "modeldump" in normalized_message:
+    if "str" in normalized_message and (
+        "modeldump" in normalized_message
+        or "setprivateattributes" in normalized_message
+    ):
         return (
-            "服务返回内容不是兼容的模型响应，"
-            "请检查基础地址是否填写为 API Base URL，不要填写网页地址或完整的 "
-            "chat/completions 路径"
+            "服务返回内容不是兼容的模型响应，请检查基础地址是否填写为 "
+            "API Base URL，如果服务要求 /v1 等版本路径，请包含在基础地址中，"
+            "不要填写网页地址或完整的 chat/completions 路径"
         )
     return sanitized
 
@@ -113,7 +116,10 @@ async def get_llm_models(
             },
         )
     except Exception as err:
-        return schemas.Response(success=False, message=str(err))
+        return schemas.Response(
+            success=False,
+            message=_sanitize_llm_error(str(err), api_key),
+        )
 
 
 @router.get("/providers", summary="获取LLM提供商目录", response_model=schemas.Response)
@@ -312,5 +318,5 @@ async def llm_test(
     except Exception as err:
         return schemas.Response(
             success=False,
-            message=_sanitize_llm_test_error(str(err), payload.api_key),
+            message=_sanitize_llm_error(str(err), payload.api_key),
         )

--- a/tests/test_llm_endpoint_error_messages.py
+++ b/tests/test_llm_endpoint_error_messages.py
@@ -24,3 +24,54 @@ def test_llm_test_maps_internal_model_dump_error_to_base_url_hint():
     assert "基础地址" in resp.message
     assert "API Base URL" in resp.message
     assert "model_dump" not in resp.message
+
+
+def test_llm_test_maps_internal_private_attribute_error_to_base_url_hint():
+    """LLM 测试遇到 SDK 内部属性错误时应提示检查基础地址。"""
+    with patch.object(llm_endpoint.settings, "AI_AGENT_ENABLE", True), patch.object(
+        llm_endpoint.settings, "LLM_PROVIDER", "openai"
+    ), patch.object(llm_endpoint.settings, "LLM_MODEL", "gpt-4o-mini"), patch.object(
+        llm_endpoint.settings, "LLM_API_KEY", "sk-test"
+    ), patch.object(
+        llm_endpoint.LLMHelper,
+        "test_current_settings",
+        AsyncMock(
+            side_effect=AttributeError(
+                "'str' object has no attribute '_set_private_attributes'"
+            )
+        ),
+        create=True,
+    ):
+        resp = asyncio.run(llm_endpoint.llm_test(_="token"))
+
+    assert not resp.success
+    assert "基础地址" in resp.message
+    assert "API Base URL" in resp.message
+    assert "_set_private_attributes" not in resp.message
+
+
+def test_llm_models_maps_internal_private_attribute_error_to_base_url_hint():
+    """LLM 模型列表遇到 SDK 内部属性错误时应提示检查基础地址。"""
+    with patch.object(
+        llm_endpoint.LLMHelper,
+        "get_models",
+        AsyncMock(
+            side_effect=AttributeError(
+                "'str' object has no attribute '_set_private_attributes'"
+            )
+        ),
+        create=True,
+    ):
+        resp = asyncio.run(
+            llm_endpoint.get_llm_models(
+                provider="openai",
+                api_key="sk-test",
+                base_url="https://example.com",
+                _="token",
+            )
+        )
+
+    assert not resp.success
+    assert "基础地址" in resp.message
+    assert "API Base URL" in resp.message
+    assert "_set_private_attributes" not in resp.message


### PR DESCRIPTION
### **User description**
## 变更说明
- 统一 LLM 错误清理入口，继续对 API Key 与 Authorization 信息做脱敏。
- 将 OpenAI-compatible SDK 返回格式解析异常映射为可读的 Base URL 配置提示，避免将 `_set_private_attributes` 等内部属性名直接展示给用户。
- 让 `/api/v1/llm/models` 与 `/api/v1/llm/test` 复用同一套错误提示逻辑。

## 影响路径
- `app/api/endpoints/llm.py`
- `tests/test_llm_endpoint_error_messages.py`

## 验证
- `tests/run.py`：1559 passed, 1 skipped
- `python -m pylint app`：10.00/10
- `git diff --check`

本 PR 为 Codex 协作提交


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- 统一 LLM 错误清理

- 模型列表错误脱敏

- 隐藏 SDK 内部属性

- 补充端点错误测试


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>llm.py</strong><dd><code>统一 LLM 端点错误脱敏提示</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/api/endpoints/llm.py

<ul><li>将 <code>_sanitize_llm_test_error</code> 泛化为 <code>_sanitize_llm_error</code><br> <li> 识别 <code>_set_private_attributes</code> 内部属性错误<br> <li> 为模型列表端点复用脱敏提示<br> <li> 优化 <code>API Base URL</code> 配置提示</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6021/files#diff-8b111eddd1ee2ed595465dac90f8e8d46d738a97ba33abc4514d657cbc121cb0">+13/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_llm_endpoint_error_messages.py</strong><dd><code>补充 LLM 错误提示回归测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_llm_endpoint_error_messages.py

<ul><li>新增 LLM 测试端点内部属性错误断言<br> <li> 新增模型列表端点错误提示测试<br> <li> 验证 <code>_set_private_attributes</code> 不回显给用户<br> <li> 覆盖 <code>API Base URL</code> 提示行为</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6021/files#diff-81d30761686e8c43bae550717072132b59b118e928359a2bb516be88a701c2ee">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

