### PR TITLE
fix(subscribe): record movie completion priority

### DIFF
--- a/app/chain/subscribe.py
+++ b/app/chain/subscribe.py
@@ -1306,17 +1306,15 @@ class SubscribeChain(ChainBase):
                 logger.debug(f"search Lock released at {datetime.now()}")
 
     @staticmethod
-    def __update_movie_best_version_download_priority(
+    def __update_movie_download_priority(
             subscribe: Subscribe,
             mediainfo: MediaInfo,
             downloads: Optional[List[Context]],
     ):
         """
-        记录电影洗版本轮下载资源优先级。
+        记录电影本轮下载资源优先级，用作后续电影洗版的起始质量状态。
         """
         if not downloads:
-            return
-        if not subscribe.best_version:
             return
         priority = max([item.torrent_info.pri_order for item in downloads])
         now = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
@@ -1330,7 +1328,7 @@ class SubscribeChain(ChainBase):
         })
         subscribe.current_priority = priority
         subscribe.last_update = now
-        if priority != 100:
+        if subscribe.best_version and priority != 100:
             # 正在洗版，更新资源优先级
             logger.info(f'{mediainfo.title_year} 正在洗版，更新资源优先级为 {priority}')
 
@@ -1348,6 +1346,12 @@ class SubscribeChain(ChainBase):
             self.__record_subscribe_download_facts(subscribe=subscribe, mediainfo=mediainfo, downloads=downloads)
         elif downloads:
             self.__update_subscribe_note(subscribe=subscribe, downloads=downloads)
+        if downloads and meta.type == MediaType.MOVIE:
+            self.__update_movie_download_priority(
+                subscribe=subscribe,
+                mediainfo=mediainfo,
+                downloads=downloads,
+            )
         # 是否完成订阅
         if not subscribe.best_version:
             # 普通订阅：先按 lefts 写 lack，再判断完成
@@ -1366,13 +1370,6 @@ class SubscribeChain(ChainBase):
                 logger.info(f'{mediainfo.title_year} 未下载完整，继续订阅 ...')
             return
 
-        if downloads and meta.type == MediaType.MOVIE:
-            # 电影没有按集质量事实，只能用 current_priority 表达洗版下载质量。
-            self.__update_movie_best_version_download_priority(
-                subscribe=subscribe,
-                mediainfo=mediainfo,
-                downloads=downloads,
-            )
         if meta.type == MediaType.TV:
             self.__refresh_subscribe_progress_with_no_exists(
                 no_exists=lefts,

--- a/tests/test_subscribe_chain.py
+++ b/tests/test_subscribe_chain.py
@@ -1903,7 +1903,7 @@ class SubscribeNoteTrackingTest(TestCase):
 
         with patch.object(SUBSCRIBE_CHAIN_MODULE, "SubscribeOper", _SubscribeOper), patch.object(
             SubscribeChain,
-            "_SubscribeChain__update_movie_best_version_download_priority",
+            "_SubscribeChain__update_movie_download_priority",
         ), patch.object(
             SubscribeChain,
             "_SubscribeChain__finish_subscribe",
@@ -2819,3 +2819,44 @@ class SubscribeDownloadFactsTest(TestCase):
             )
 
         refresh_mock.assert_not_called()
+
+    def test_movie_normal_download_records_current_priority_before_completion(self):
+        subscribe = self._build_subscribe(
+            type=MediaType.MOVIE.value,
+            best_version=0,
+            best_version_full=0,
+            current_priority=None,
+            episode_priority={},
+            note=[],
+            tmdbid=30003,
+            total_episode=1,
+            lack_episode=1,
+        )
+        download = self._download(episodes=[], pri_order=90)
+        download.media_info = SimpleNamespace(type=MediaType.MOVIE, tmdb_id=30003, douban_id=None)
+        download.meta_info = SimpleNamespace(episode_list=[], season_list=[])
+        updates = []
+        finished = []
+
+        class _SubscribeOper:
+            def update(self, subscribe_id, payload):
+                updates.append(payload)
+
+        chain = self.SubscribeChain()
+
+        def finish_probe(subscribe, **_kwargs):
+            finished.append(subscribe.current_priority)
+
+        with patch.object(self.module, "SubscribeOper", return_value=_SubscribeOper()), \
+                patch.object(chain, "_SubscribeChain__finish_subscribe", side_effect=finish_probe):
+            chain.finish_subscribe_or_not(
+                subscribe=subscribe,
+                meta=SimpleNamespace(type=MediaType.MOVIE),
+                mediainfo=SimpleNamespace(title_year="下载事实电影 (2026)"),
+                downloads=[download],
+                lefts={},
+            )
+
+        self.assertEqual(subscribe.current_priority, 90)
+        self.assertEqual(finished, [90])
+        self.assertIn({"current_priority": 90, "last_update": subscribe.last_update}, updates)


### PR DESCRIPTION
### **User description**
## 背景
电影普通订阅完成时主程序会写入完成标记并删除订阅记录，`SubscribeComplete` 事件只能携带删除前的订阅快照。当前普通电影下载完成链路没有记录本轮资源优先级，后续自动洗版无法从事件快照判断起始质量。

## 变更
- 电影下载完成判断前写入本轮下载资源最高 `pri_order` 到 `current_priority`。
- 保留电影洗版下载时更新当前优先级的行为，只有洗版订阅且未达顶档时继续输出洗版进度日志。
- 电视剧仍走 `note` / `episode_priority` 和订阅进度刷新逻辑，不套用电影整体优先级。
- 补充普通电影完成前写入 `current_priority` 的单测。

## 验证
- `tests/run.py`
- `python -m pylint app`
- `git diff --check`

Refs https://github.com/InfinityPacer/MoviePilot-Plugins/issues/240

本 PR 为 Codex 协作提交


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- 普通电影完成前记录优先级

- 泛化电影下载优先级更新

- 保留洗版日志触发条件

- 补充完成前记录测试


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>subscribe.py</strong><dd><code>调整电影下载优先级记录流程</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/chain/subscribe.py

<ul><li>将 <code>__update_movie_best_version_download_priority</code> 泛化为 <br><code>__update_movie_download_priority</code><br> <li> 普通电影订阅完成判断前写入 <code>current_priority</code><br> <li> 仅洗版订阅且未达顶级时输出进度日志</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6033/files#diff-cad6359993258638e5dfa201eb0e98e5e79a162161b40ecb593410aabfc336b7">+9/-12</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_subscribe_chain.py</strong><dd><code>覆盖电影完成前优先级记录</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_subscribe_chain.py

- 更新私有方法名相关 mock
- 新增普通电影完成前记录优先级测试
- 验证完成事件前 `current_priority` 已更新


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6033/files#diff-05f686d8f473e2a3e44a85570209c156b7deffb4e7d452e42931b75eb612b45a">+42/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

