### PR TITLE
fix(webpush): Windows Edge WNS push returns 400 without cache policy

### DIFF
--- a/app/api/endpoints/message.py
+++ b/app/api/endpoints/message.py
@@ -17,7 +17,7 @@ from app.db.message_oper import MessageOper
 from app.db.systemconfig_oper import SystemConfigOper
 from app.db.user_oper import get_current_active_superuser
 from app.helper.service import ServiceConfigHelper
-from app.helper.webpush import is_webpush_subscription_gone
+from app.helper.webpush import is_webpush_subscription_gone, webpush_options_for_endpoint
 from app.log import logger
 from app.modules.wechat.WXBizMsgCrypt3 import WXBizMsgCrypt
 from app.schemas.types import MessageChannel, SystemConfigKey
@@ -316,6 +316,7 @@ def send_notification(
                 data=json.dumps(payload.model_dump()),
                 vapid_private_key=settings.VAPID.get("privateKey"),
                 vapid_claims={"sub": settings.VAPID.get("subject")},
+                **webpush_options_for_endpoint(sub.get("endpoint")),
             )
         except WebPushException as err:
             logger.error(f"WebPush发送失败: {str(err)}")

--- a/app/helper/webpush.py
+++ b/app/helper/webpush.py
@@ -2,6 +2,9 @@ from typing import Any
 
 from pywebpush import WebPushException
 
+# WNS 默认 TTL（秒）；ttl>0 时需配 X-WNS-Cache-Policy: cache
+_WNS_DEFAULT_TTL = 86400
+
 
 def is_webpush_subscription_gone(error: WebPushException) -> bool:
     """
@@ -10,3 +13,25 @@ def is_webpush_subscription_gone(error: WebPushException) -> bool:
     response: Any = getattr(error, "response", None)
     status_code = getattr(response, "status_code", None) or getattr(response, "status", None)
     return status_code in {404, 410}
+
+
+def is_wns_endpoint(endpoint: str | None) -> bool:
+    """
+    判断是否为 Microsoft WNS（Edge/Windows）推送端点。
+    """
+    return bool(endpoint and "notify.windows.com" in endpoint)
+
+
+def webpush_options_for_endpoint(endpoint: str | None) -> dict[str, Any]:
+    """
+    按推送服务返回 pywebpush 额外参数。
+
+    WNS 要求 TTL 与 X-WNS-Cache-Policy 一致，否则返回 400。
+    见 https://github.com/web-push-libs/pywebpush/issues/162
+    """
+    if not is_wns_endpoint(endpoint):
+        return {}
+    return {
+        "ttl": _WNS_DEFAULT_TTL,
+        "headers": {"X-WNS-Cache-Policy": "cache"},
+    }

--- a/app/modules/webpush/__init__.py
+++ b/app/modules/webpush/__init__.py
@@ -4,7 +4,7 @@ from typing import Union, Tuple
 from pywebpush import webpush, WebPushException
 
 from app.core.config import global_vars, settings
-from app.helper.webpush import is_webpush_subscription_gone
+from app.helper.webpush import is_webpush_subscription_gone, webpush_options_for_endpoint
 from app.log import logger
 from app.modules import _ModuleBase, _MessageBase
 from app.schemas import Notification
@@ -95,6 +95,7 @@ class WebPushModule(_ModuleBase, _MessageBase):
                             vapid_claims={
                                 "sub": settings.VAPID.get("subject")
                             },
+                            **webpush_options_for_endpoint(sub.get("endpoint")),
                         )
                     except WebPushException as err:
                         logger.error(f"WebPush发送失败: {str(err)}")

--- a/tests/test_webpush_helper.py
+++ b/tests/test_webpush_helper.py
@@ -1,0 +1,43 @@
+from app.helper.webpush import (
+    is_webpush_subscription_gone,
+    is_wns_endpoint,
+    webpush_options_for_endpoint,
+)
+from pywebpush import WebPushException
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+
+def test_is_webpush_subscription_gone_for_expired_status_codes() -> None:
+    for status_code in (404, 410):
+        err = WebPushException("gone")
+        err.response = _FakeResponse(status_code)
+        assert is_webpush_subscription_gone(err)
+
+
+def test_is_webpush_subscription_gone_for_other_errors() -> None:
+    err = WebPushException("bad request")
+    err.response = _FakeResponse(400)
+    assert not is_webpush_subscription_gone(err)
+
+
+def test_is_wns_endpoint_detects_windows_push_url() -> None:
+    assert is_wns_endpoint("https://wns2-sg2p.notify.windows.com/w/?token=abc")
+    assert not is_wns_endpoint("https://web.push.apple.com/abc")
+    assert not is_wns_endpoint(None)
+    assert not is_wns_endpoint("")
+
+
+def test_webpush_options_for_wns_endpoint() -> None:
+    options = webpush_options_for_endpoint("https://wns2-pn1p.notify.windows.com/x")
+    assert options == {
+        "ttl": 86400,
+        "headers": {"X-WNS-Cache-Policy": "cache"},
+    }
+
+
+def test_webpush_options_for_non_wns_endpoint() -> None:
+    assert webpush_options_for_endpoint("https://fcm.googleapis.com/fcm/send/abc") == {}


### PR DESCRIPTION
### **User description**
## Summary

- Fix Web Push delivery to **Windows Edge PWA** (WNS endpoints under `notify.windows.com`).
- `pywebpush` defaults to `ttl=0`, but Microsoft WNS returns **400 Bad Request** unless `TTL` and `X-WNS-Cache-Policy` are consistent ([pywebpush#162](https://github.com/web-push-libs/pywebpush/issues/162)).
- Add `webpush_options_for_endpoint()` and apply it in `WebPushModule` and `/message/webpush/send`.
- APNs / FCM endpoints are unchanged (empty extra options).

## Problem

On Windows Edge (installed PWA), subscriptions succeed (`wns2-*.notify.windows.com`), but push fails with:

```
WebPushException: Push failed: 400 Bad Request
```

iOS (`web.push.apple.com`) works because Apple does not enforce the WNS cache policy headers.

## Solution

For WNS endpoints only:

```python
{
    "ttl": 86400,
    "headers": {"X-WNS-Cache-Policy": "cache"},
}
```

Verified on a production deployment: Windows notifications and PWA taskbar badges work after this change.

## Test plan

- [x] Unit tests for `is_wns_endpoint` / `webpush_options_for_endpoint` / subscription-gone helper
- [x] Manual: Windows Edge PWA subscribe → `/api/v1/message/webpush/send` → system notification received (no 400)
- [x] Manual: iOS Web Push still works
- [x] Manual: PWA badge increments on push and clears after "mark all read"


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- 为 WNS 推送添加缓存策略

- 统一 WebPush 端点参数

- 增加 WNS 相关单测


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>message.py</strong><dd><code>接口发送支持 WNS 推送参数</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/api/endpoints/message.py

<ul><li>引入 <code>webpush_options_for_endpoint</code><br> <li> 发送 WebPush 时按端点追加参数<br> <li> 支持 WNS 所需 TTL 与缓存头</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6034/files#diff-91b13ce9ddade8db8a7058897674480f69480949efd2f348e3d97ae33afdfaef">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>WebPush 模块适配 WNS 参数</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/modules/webpush/__init__.py

<ul><li>引入 <code>webpush_options_for_endpoint</code><br> <li> 模块推送时传入端点专属参数<br> <li> 修复 Windows Edge WNS 400 失败</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6034/files#diff-3e414f9f667d825dea9d2113623040c0cad0d33a02da2a686e20fe446566494f">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webpush.py</strong><dd><code>新增 WNS WebPush 参数辅助方法</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/helper/webpush.py

<ul><li>新增 WNS 默认 TTL 常量<br> <li> 添加 <code>is_wns_endpoint</code> 端点识别<br> <li> 添加 <code>webpush_options_for_endpoint</code> 参数生成<br> <li> 为 WNS 返回缓存策略请求头</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6034/files#diff-0d52cc1117cd3c6aee01cbc944da34252fd2cf834dd127e31c876e3f8fb4467b">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_webpush_helper.py</strong><dd><code>补充 WebPush 辅助函数测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_webpush_helper.py

- 覆盖失效订阅状态码判断
- 验证 WNS 端点识别逻辑
- 验证 WNS 与非 WNS 参数输出


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6034/files#diff-31a987f7369af8ec4b80ccd35dfeb71f0253363bbcf1e67c6d5a25d7a4e23382">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

