### PR TITLE
docs: clarify API_TOKEN administrator contract

### DIFF
--- a/app/api/endpoints/anthropic.py
+++ b/app/api/endpoints/anthropic.py
@@ -39,6 +39,9 @@ def _anthropic_error_response(
 
 
 def _check_auth(api_key: Optional[str]) -> Optional[JSONResponse]:
+    """
+    Anthropic 兼容接口以 API_TOKEN 认证受信客户端，认证通过即按管理员级 Agent 集成处理。
+    """
     if not api_key or api_key != settings.API_TOKEN:
         return _anthropic_error_response(
             "invalid x-api-key",
@@ -122,6 +125,7 @@ async def messages(
 
     session_seed = anthropic_version or "anthropic"
     session_id = build_session_id(f"{session_seed}:{uuid.uuid4().hex}", SESSION_PREFIX)
+    # 兼容接口的 API_TOKEN 客户端按管理员级 MoviePilot Agent 集成处理。
     agent = _CollectingMoviePilotAgent(
         session_id=session_id,
         user_id=session_id,

--- a/app/api/endpoints/mcp.py
+++ b/app/api/endpoints/mcp.py
@@ -19,6 +19,7 @@ router = APIRouter()
 # MCP 协议版本
 MCP_PROTOCOL_VERSIONS = ["2025-11-25", "2025-06-18", "2024-11-05"]
 MCP_PROTOCOL_VERSION = MCP_PROTOCOL_VERSIONS[0]  # 默认使用最新版本
+# MCP 经 API_TOKEN / X-API-KEY 认证后是管理员级集成入口；隐藏工具只收敛暴露面，不构成权限边界。
 MCP_HIDDEN_TOOLS = {
     "execute_command",
     "search_web",

--- a/app/api/endpoints/openai.py
+++ b/app/api/endpoints/openai.py
@@ -231,6 +231,9 @@ def _error_response(
 def _check_auth(
     credentials: Optional[HTTPAuthorizationCredentials],
 ) -> Optional[JSONResponse]:
+    """
+    OpenAI 兼容接口以 API_TOKEN 认证受信客户端，认证通过即按管理员级 Agent 集成处理。
+    """
     if not credentials or credentials.scheme.lower() != "bearer":
         return _error_response(
             "Invalid bearer token.",
@@ -317,6 +320,7 @@ async def chat_completions(
 
     session_id = build_session_id(session_key, SESSION_PREFIX)
     username = str(payload.user or "openai-client")
+    # 兼容接口的 API_TOKEN 客户端按管理员级 MoviePilot Agent 集成处理。
     agent = _CollectingMoviePilotAgent(
         session_id=session_id,
         user_id=session_key,
@@ -409,6 +413,7 @@ async def responses(
 
     session_key = str(payload.user or uuid.uuid4())
     session_id = build_session_id(session_key, SESSION_PREFIX)
+    # 兼容接口的 API_TOKEN 客户端按管理员级 MoviePilot Agent 集成处理。
     agent = _CollectingMoviePilotAgent(
         session_id=session_id,
         user_id=session_key,

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -316,7 +316,9 @@ def __verify_key(key: str | None, expected_key: str, key_type: str) -> str:
 
 def verify_apitoken(token: Annotated[str | None, Security(__get_api_token)]) -> str:
     """
-    使用 API Token 进行身份认证
+    使用 API Token 进行受信第三方集成认证。
+
+    校验值来自 settings.API_TOKEN；通过后只确认集成凭据有效，不生成 per-user 权限上下文。
     :param token: API Token，从 URL 查询参数中获取 token=xxx
     :return: 返回校验通过的 API Token
     """
@@ -325,7 +327,9 @@ def verify_apitoken(token: Annotated[str | None, Security(__get_api_token)]) -> 
 
 def verify_apikey(apikey: Annotated[str | None, Security(__get_api_key)]) -> str:
     """
-    使用 API Key 进行身份认证
+    使用 API Key 形式进行受信第三方集成认证。
+
+    请求字段名兼容 API Key，实际校验值来自 settings.API_TOKEN，不生成 per-user 权限上下文。
     :param apikey: API Key，从 URL 查询参数中获取 apikey=xxx，或请求头中获取 X-API-KEY=xxx
     :return: 返回校验通过的 API Key
     """

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -11,6 +11,14 @@ MoviePilot 实现了标准的 **Model Context Protocol (MCP)**，允许 AI 智�
     *   Header: `X-API-KEY: <你的API_KEY>`
     *   Query: `?apikey=<你的API_KEY>`
 
+### 安全提示
+
+MCP 使用系统配置中的 `API_TOKEN` 作为认证密钥，文档中的 API KEY 是请求字段名。该密钥应按管理员级 secret 保管，持有者可作为受信第三方集成调用暴露的 MoviePilot 工具。
+
+- 优先使用 `X-API-KEY` 请求头；查询参数更容易出现在代理、浏览器或客户端日志中。
+- 不要在缺少 HTTPS、访问控制和网络隔离的情况下，将 MCP、OpenAI 或 Anthropic 兼容接口直接暴露到公网。
+- MCP 隐藏工具列表只用于减少默认暴露面，不是 per-user 权限系统。
+
 ## 2. 标准 MCP 协议 (JSON-RPC 2.0)
 
 ### 端点

--- a/docs/rules/11-quality-and-security.md
+++ b/docs/rules/11-quality-and-security.md
@@ -78,6 +78,8 @@ The `API_TOKEN` value in `settings` is the source of truth. It is set at initial
 
 ### Endpoint Authorization
 
+- API-token authenticated integration endpoints are administrator-level surfaces unless a specific endpoint documents a narrower contract.
+- Do not infer user-scoped authorization from a valid `API_TOKEN`; use an explicit user identity dependency when behavior must be scoped to a logged-in user.
 - Use the existing FastAPI dependency functions (e.g., `get_current_user`, `get_current_active_superuser`) — check `app/api/endpoints/` for usage patterns.
 - Do not add manual token parsing inside endpoint functions. Always use the project's dependency injection.
 - Superuser-only operations must explicitly require the superuser dependency.


### PR DESCRIPTION
### **User description**
## 变更说明

明确 `API_TOKEN` 在 OpenAI、Anthropic 兼容接口和 MCP 入口中的管理员级集成契约：认证通过表示受信第三方集成，不生成 per-user 权限上下文。

## 影响范围

- `app/core/security.py`
- `app/api/endpoints/openai.py`
- `app/api/endpoints/anthropic.py`
- `app/api/endpoints/mcp.py`
- `docs/mcp-api.md`
- `docs/rules/11-quality-and-security.md`

## 兼容性

仅补充注释和文档说明，不改变运行时鉴权行为，也不影响现有依赖 `API_TOKEN` 的第三方生态。

## 验证

- `python -m py_compile app/core/security.py app/api/endpoints/openai.py app/api/endpoints/anthropic.py app/api/endpoints/mcp.py`
- `git diff --check`

本 PR 为 Codex 协作提交


___

### **PR Type**
Documentation


___

### **Description**
- 明确 `API_TOKEN` 管理员契约

- 说明兼容接口信任边界

- 补充 MCP 安全提示


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>anthropic.py</strong><dd><code>阐明 Anthropic 接口认证契约</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/api/endpoints/anthropic.py

<ul><li>为 <code>_check_auth</code> 增加认证契约说明<br> <li> 标注 Anthropic 兼容客户端为管理员级集成<br> <li> 强调认证通过不代表用户级上下文</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6048/files#diff-53cd3289e2d4c4ee7c6ce6217b2e0714e017cbab278fa3de3f3f356f1ca59ddd">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mcp.py</strong><dd><code>说明 MCP 管理员级入口边界</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/api/endpoints/mcp.py

- 注释说明 MCP 入口的管理员级属性
- 明确隐藏工具不是权限边界
- 将暴露面收敛与授权隔离区分


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6048/files#diff-eea14829ca3126d2a6b6be6ebc66363484279c78bacdf5d63c0c494dec2b5c83">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>openai.py</strong><dd><code>阐明 OpenAI 兼容接口契约</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/api/endpoints/openai.py

<ul><li>为 <code>_check_auth</code> 增加管理员级认证说明<br> <li> 标注 Chat Completions 客户端集成属性<br> <li> 标注 Responses 客户端集成属性</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6048/files#diff-a89b7190bb98b1ceb541dce4cbfcdaa91d5bc19ff3fcbe0d3a77ef8f49438682">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>security.py</strong><dd><code>明确 API Token 安全语义</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/core/security.py

<ul><li>更新 <code>verify_apitoken</code> 文档说明<br> <li> 更新 <code>verify_apikey</code> 文档说明<br> <li> 明确校验 <code>settings.API_TOKEN</code> 不生成用户上下文</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6048/files#diff-c9f63674da15ba0104a60e22cad69666f07ac477c086d86cf5354c428c7775c5">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mcp-api.md</strong><dd><code>补充 MCP 接口安全说明</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/mcp-api.md

<ul><li>新增 MCP 安全提示章节<br> <li> 说明 <code>API_TOKEN</code> 是实际认证密钥<br> <li> 建议优先使用 <code>X-API-KEY</code> 请求头<br> <li> 警示公网暴露和隐藏工具限制</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6048/files#diff-860aa2aade878effdfaecd7f5d3d5610fddd6478a8ede6ecad1762a0a703cd78">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>11-quality-and-security.md</strong><dd><code>强化 API_TOKEN 授权规范</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/rules/11-quality-and-security.md

- 增加端点授权规则说明
- 明确 `API_TOKEN` 默认管理员级表面
- 要求用户级行为使用显式身份依赖


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6048/files#diff-6fb9ca27881fc13ebe51bb7bf10b9a7ccd76449b5fa172b0ca2000bb45e2083b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

