### PR TITLE
fix: rebind resource cookie on user changes

### DIFF
--- a/app/core/security.py
+++ b/app/core/security.py
@@ -169,6 +169,15 @@ def set_or_refresh_resource_token_cookie(
                 # 根据剩余时长提前刷新令牌
                 if remaining_time < timedelta(seconds=(settings.RESOURCE_ACCESS_TOKEN_EXPIRE_SECONDS / 3)):
                     raise jwt.ExpiredSignatureError
+            expected_claims = {
+                "sub": str(payload.sub),
+                "username": payload.username,
+                "super_user": payload.super_user,
+                "level": payload.level,
+                "purpose": "resource",
+            }
+            if any(decoded_token.get(claim) != value for claim, value in expected_claims.items()):
+                raise jwt.InvalidTokenError("资源令牌身份或权限上下文不匹配")
         except jwt.PyJWTError:
             logger.debug(f"Token error occurred. refreshing token")
         except Exception as e:

--- a/tests/test_resource_token_cookie_secure_flag.py
+++ b/tests/test_resource_token_cookie_secure_flag.py
@@ -1,9 +1,12 @@
+import datetime
 from unittest import TestCase
 
+import jwt
 from fastapi import Response
 
 from app import schemas
-from app.core.security import set_or_refresh_resource_token_cookie
+from app.core.config import settings
+from app.core.security import ALGORITHM, create_access_token, set_or_refresh_resource_token_cookie
 
 
 class FakeURL:
@@ -16,13 +19,62 @@ class FakeRequest:
     最小化的请求桩对象，仅提供 set_or_refresh_resource_token_cookie 所需属性。
     """
 
-    def __init__(self, scheme: str, headers: dict | None = None) -> None:
+    def __init__(self, scheme: str, headers: dict | None = None, cookies: dict | None = None) -> None:
         self.url = FakeURL(scheme)
         self.headers = headers or {}
-        self.cookies: dict = {}
+        self.cookies: dict = cookies or {}
 
 
 class ResourceTokenCookieSecureFlagTest(TestCase):
+    def _build_request_with_resource_cookie(
+            self,
+            *,
+            userid: int = 1,
+            username: str = "test",
+            super_user: bool = False,
+            level: int = 1,
+            purpose: str = "resource"
+    ) -> FakeRequest:
+        resource_token = create_access_token(
+            userid=userid,
+            username=username,
+            super_user=super_user,
+            level=level,
+            purpose=purpose,
+        )
+        return FakeRequest(
+            scheme="https",
+            cookies={settings.PROJECT_NAME: resource_token},
+        )
+
+    def _build_request_with_resource_secret_cookie(
+            self,
+            *,
+            userid: int = 1,
+            username: str = "test",
+            super_user: bool = False,
+            level: int = 1,
+            purpose: str = "authentication"
+    ) -> FakeRequest:
+        now = datetime.datetime.now(datetime.UTC)
+        resource_token = jwt.encode(
+            {
+                "exp": now + datetime.timedelta(seconds=settings.RESOURCE_ACCESS_TOKEN_EXPIRE_SECONDS),
+                "iat": now,
+                "sub": str(userid),
+                "username": username,
+                "super_user": super_user,
+                "level": level,
+                "purpose": purpose,
+            },
+            settings.RESOURCE_SECRET_KEY,
+            algorithm=ALGORITHM,
+        )
+        return FakeRequest(
+            scheme="https",
+            cookies={settings.PROJECT_NAME: resource_token},
+        )
+
     def test_secure_flag_set_when_https_terminated_at_reverse_proxy(self):
         """
         当反向代理（如 nginx）终止 HTTPS 并以 HTTP 转发给后端时，
@@ -36,3 +88,57 @@ class ResourceTokenCookieSecureFlagTest(TestCase):
 
         set_cookie_header = response.headers.get("set-cookie", "")
         self.assertIn("Secure", set_cookie_header)
+
+    def test_existing_matching_resource_cookie_is_reused(self):
+        request = self._build_request_with_resource_cookie()
+        response = Response()
+        payload = schemas.TokenPayload(sub=1, username="test", super_user=False, level=1)
+
+        set_or_refresh_resource_token_cookie(request, response, payload)
+
+        self.assertIsNone(response.headers.get("set-cookie"))
+
+    def test_existing_resource_cookie_with_different_sub_is_replaced(self):
+        request = self._build_request_with_resource_cookie(userid=2)
+        response = Response()
+        payload = schemas.TokenPayload(sub=1, username="test", super_user=False, level=1)
+
+        set_or_refresh_resource_token_cookie(request, response, payload)
+
+        self.assertIn(f"{settings.PROJECT_NAME}=", response.headers.get("set-cookie", ""))
+
+    def test_existing_resource_cookie_with_different_username_is_replaced(self):
+        request = self._build_request_with_resource_cookie(username="other")
+        response = Response()
+        payload = schemas.TokenPayload(sub=1, username="test", super_user=False, level=1)
+
+        set_or_refresh_resource_token_cookie(request, response, payload)
+
+        self.assertIn(f"{settings.PROJECT_NAME}=", response.headers.get("set-cookie", ""))
+
+    def test_existing_resource_cookie_with_different_super_user_is_replaced(self):
+        request = self._build_request_with_resource_cookie(super_user=True)
+        response = Response()
+        payload = schemas.TokenPayload(sub=1, username="test", super_user=False, level=1)
+
+        set_or_refresh_resource_token_cookie(request, response, payload)
+
+        self.assertIn(f"{settings.PROJECT_NAME}=", response.headers.get("set-cookie", ""))
+
+    def test_existing_resource_cookie_with_different_level_is_replaced(self):
+        request = self._build_request_with_resource_cookie(level=2)
+        response = Response()
+        payload = schemas.TokenPayload(sub=1, username="test", super_user=False, level=1)
+
+        set_or_refresh_resource_token_cookie(request, response, payload)
+
+        self.assertIn(f"{settings.PROJECT_NAME}=", response.headers.get("set-cookie", ""))
+
+    def test_existing_resource_signed_cookie_with_wrong_purpose_is_replaced(self):
+        request = self._build_request_with_resource_secret_cookie(purpose="authentication")
+        response = Response()
+        payload = schemas.TokenPayload(sub=1, username="test", super_user=False, level=1)
+
+        set_or_refresh_resource_token_cookie(request, response, payload)
+
+        self.assertIn(f"{settings.PROJECT_NAME}=", response.headers.get("set-cookie", ""))


### PR DESCRIPTION
### **User description**
## 变更说明

在登录和 token 刷新时校验 resource cookie 中的用户身份与权限载荷。如果 `sub`、`username`、`super_user`、`level` 或 `purpose` 与当前用户不一致，则重新签发 resource cookie。

## 影响范围

- `app/core/security.py`
- `tests/test_resource_token_cookie_secure_flag.py`

## 兼容性

该改动只影响用户切换或权限变化后 resource cookie 的刷新行为。正常同一用户、同一权限的请求不会重复写 cookie。

## 验证

- `python -m pytest tests/test_resource_token_cookie_secure_flag.py -q` -> 7 passed
- `python -m py_compile app/core/security.py`
- `git diff --check`

本 PR 为 Codex 协作提交


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- 校验 resource cookie 身份载荷

- 不匹配时重新签发 cookie

- 覆盖用户与权限变更测试


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security.py</strong><dd><code>增加资源令牌上下文校验</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/core/security.py

- 校验现有资源令牌声明
- 比对 `sub`、`username` 等权限载荷
- 声明不匹配时触发刷新


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6049/files#diff-c9f63674da15ba0104a60e22cad69666f07ac477c086d86cf5354c428c7775c5">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_resource_token_cookie_secure_flag.py</strong><dd><code>增加资源 cookie 刷新测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_resource_token_cookie_secure_flag.py

<ul><li>扩展 <code>FakeRequest</code> 支持 cookies<br> <li> 新增资源 cookie 构造辅助方法<br> <li> 测试匹配 cookie 复用行为<br> <li> 覆盖用户、权限、用途不匹配刷新</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6049/files#diff-eb43745fbefeae9c8ad0f0824b0d36634b8850e2e9b5af3fdb0f17025969c6b6">+109/-3</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

