### PR TITLE
fix: restrict non-admin agent log file access

### DIFF
--- a/app/agent/prompt/__init__.py
+++ b/app/agent/prompt/__init__.py
@@ -315,8 +315,6 @@ class PromptManager:
             "项目根目录": settings.ROOT_PATH,
             "配置目录": settings.CONFIG_PATH,
             "临时目录": settings.TEMP_PATH,
-            "日志目录": settings.LOG_PATH,
-            "主日志文件": settings.LOG_PATH / "moviepilot.log",
         }
         return [f"  - {label}: `{path}`" for label, path in paths.items()]
 

--- a/app/agent/tools/base.py
+++ b/app/agent/tools/base.py
@@ -425,7 +425,6 @@ class MoviePilotTool(BaseTool, metaclass=ABCMeta):
         """
         roots = [
             settings.CONFIG_PATH / "agent",
-            settings.LOG_PATH,
         ]
         resolved_roots = []
         for root in roots:
@@ -461,7 +460,7 @@ class MoviePilotTool(BaseTool, metaclass=ABCMeta):
         allowed_text = "、".join(str(root) for root in allowed_roots)
         return (
             resolved_path,
-            f"抱歉，普通用户只能{operation}Agent配置目录和日志目录内的文件或目录：{allowed_text}",
+            f"抱歉，普通用户只能{operation}Agent配置目录内的文件或目录：{allowed_text}",
         )
 
     async def _check_local_storage_access(
@@ -483,7 +482,7 @@ class MoviePilotTool(BaseTool, metaclass=ABCMeta):
                 return None, None
             return (
                 None,
-                f"抱歉，普通用户只能{operation}本地配置目录、Agent记忆目录和日志目录，不能访问远程存储。",
+                f"抱歉，普通用户只能{operation}本地Agent配置目录，不能访问远程存储。",
             )
 
         return await self._check_local_file_access(path=path, operation=operation)

--- a/app/agent/tools/impl/edit_file.py
+++ b/app/agent/tools/impl/edit_file.py
@@ -28,7 +28,7 @@ class EditFileTool(MoviePilotTool):
     description: str = (
         "Edit a local text file by replacing specific old text with new text. "
         "Non-admin users can only edit files inside the MoviePilot Agent config "
-        "and log directories."
+        "directory."
     )
     args_schema: Type[BaseModel] = EditFileInput
 

--- a/app/agent/tools/impl/write_file.py
+++ b/app/agent/tools/impl/write_file.py
@@ -26,7 +26,7 @@ class WriteFileTool(MoviePilotTool):
     ]
     description: str = (
         "Write full content to a local text file. Non-admin users can only write "
-        "inside the MoviePilot Agent config and log directories."
+        "inside the MoviePilot Agent config directory."
     )
     args_schema: Type[BaseModel] = WriteFileInput
 

--- a/tests/test_agent_prompt_secrets.py
+++ b/tests/test_agent_prompt_secrets.py
@@ -21,10 +21,12 @@ def test_moviepilot_info_does_not_expose_api_token_or_database_password(monkeypa
     assert "db.example.local" not in moviepilot_info
     assert str(settings.CONFIG_PATH) in moviepilot_info
     assert str(settings.TEMP_PATH) in moviepilot_info
-    assert str(settings.LOG_PATH) in moviepilot_info
-    assert str(settings.LOG_PATH / "moviepilot.log") in moviepilot_info
+    assert str(settings.LOG_PATH) not in moviepilot_info
+    assert str(settings.LOG_PATH / "moviepilot.log") not in moviepilot_info
     assert str(settings.LOG_PATH / "moviepilot.stdout.log") not in moviepilot_info
     assert str(settings.LOG_PATH / "moviepilot.frontend.stdout.log") not in moviepilot_info
+    assert "日志目录" not in moviepilot_info
+    assert "主日志文件" not in moviepilot_info
     assert str(settings.CONFIG_PATH / "agent") not in moviepilot_info
     assert str(settings.CONFIG_PATH / "agent" / "memory") not in moviepilot_info
     assert str(settings.CONFIG_PATH / "agent" / "skills") not in moviepilot_info

--- a/tests/test_agent_resource_flow_permissions.py
+++ b/tests/test_agent_resource_flow_permissions.py
@@ -187,7 +187,7 @@ def test_non_admin_file_tools_can_access_config_directory(tmp_path, monkeypatch)
 def test_non_admin_file_tools_block_paths_outside_allowed_roots(
     tmp_path, monkeypatch
 ):
-    """普通用户不能通过文件工具访问配置、记忆和日志目录外的路径。"""
+    """普通用户不能通过文件工具访问 Agent 配置目录外的路径。"""
     config_path = tmp_path / "config"
     outside_path = tmp_path / "outside.txt"
     outside_path.write_text("secret", encoding="utf-8")
@@ -208,7 +208,44 @@ def test_non_admin_file_tools_block_paths_outside_allowed_roots(
     assert "普通用户只能写入" in write_result
     assert "普通用户只能编辑" in edit_result
     assert "普通用户只能列出" in list_result
+    assert "日志目录" not in read_result
+    assert "日志目录" not in write_result
+    assert "日志目录" not in edit_result
+    assert "日志目录" not in list_result
     assert outside_path.read_text(encoding="utf-8") == "secret"
+    list_directory.assert_not_called()
+
+
+def test_non_admin_file_tools_block_log_directory(tmp_path, monkeypatch):
+    """普通用户不能通过文件工具读写运行日志目录。"""
+    config_path = tmp_path / "config"
+    monkeypatch.setattr(settings, "CONFIG_DIR", str(config_path))
+    log_path = settings.LOG_PATH / "moviepilot.log"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text("secret log", encoding="utf-8")
+
+    read_tool = ReadFileTool(session_id="session-1", user_id="10001")
+    write_tool = WriteFileTool(session_id="session-1", user_id="10001")
+    edit_tool = EditFileTool(session_id="session-1", user_id="10001")
+    list_tool = ListDirectoryTool(session_id="session-1", user_id="10001")
+
+    read_result = asyncio.run(read_tool.run(str(log_path)))
+    write_result = asyncio.run(write_tool.run(str(log_path), "changed"))
+    edit_result = asyncio.run(edit_tool.run(str(log_path), "secret log", "changed"))
+    with patch.object(
+        ListDirectoryTool, "_list_directory_sync", return_value="listed"
+    ) as list_directory:
+        list_result = asyncio.run(list_tool.run(str(settings.LOG_PATH)))
+
+    assert "普通用户只能读取" in read_result
+    assert "普通用户只能写入" in write_result
+    assert "普通用户只能编辑" in edit_result
+    assert "普通用户只能列出" in list_result
+    assert "日志目录" not in read_result
+    assert "日志目录" not in write_result
+    assert "日志目录" not in edit_result
+    assert "日志目录" not in list_result
+    assert log_path.read_text(encoding="utf-8") == "secret log"
     list_directory.assert_not_called()
 
 


### PR DESCRIPTION
### **User description**
## 变更说明

收窄非管理员 Agent 文件工具的可访问路径，移除对日志目录的读写能力，并同步更新工具描述和提示词测试。

## 影响范围

- `app/agent/tools/base.py`
- `app/agent/tools/impl/write_file.py`
- `app/agent/tools/impl/edit_file.py`
- `app/agent/prompt/__init__.py`
- `tests/test_agent_resource_flow_permissions.py`
- `tests/test_agent_prompt_secrets.py`

## 兼容性

非管理员 Agent 不再能通过文件工具读取或写入日志目录。管理员能力和现有 HTTP 日志访问边界不在本 PR 中调整。

## 验证

- `python -m pytest tests/test_agent_resource_flow_permissions.py tests/test_agent_prompt_secrets.py -q` -> 14 passed
- `python -m py_compile app/agent/tools/base.py app/agent/prompt/__init__.py app/agent/tools/impl/write_file.py app/agent/tools/impl/edit_file.py`
- `git diff --check`

本 PR 为 Codex 协作提交


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- 收紧非管理员文件访问边界

- 移除提示词日志路径暴露

- 更新文件工具权限说明

- 增加日志目录回归测试


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>移除提示词中的日志路径</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/agent/prompt/__init__.py

- 从运行路径提示中移除日志目录。
- 不再暴露 `moviepilot.log` 主日志路径。


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6050/files#diff-044f5b1c4deec211ecbaa838ce594afd79f74e57c738eea1ad95aa3d592b6176">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>base.py</strong><dd><code>收紧普通用户文件访问根目录</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/agent/tools/base.py

<ul><li>将普通用户本地文件根目录限制为 <code>CONFIG_PATH/agent</code>。<br> <li> 移除普通用户对 <code>settings.LOG_PATH</code> 的访问权限。<br> <li> 更新本地和远程存储拒绝提示文案。</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6050/files#diff-39d3582bedb7397892bdfa8851a5678fb2b58a37a542c5dc30e534aa39a7a269">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>edit_file.py</strong><dd><code>更新编辑工具权限描述</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/agent/tools/impl/edit_file.py

- 更新 `edit_file` 工具描述。
- 明确非管理员只能编辑 Agent 配置目录。


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6050/files#diff-11047adf59803e6cb0731672d350126f6886e8bacf086ba1ab6936b3c50c7a45">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>write_file.py</strong><dd><code>更新写入工具权限描述</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/agent/tools/impl/write_file.py

- 更新 `write_file` 工具描述。
- 明确非管理员只能写入 Agent 配置目录。


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6050/files#diff-c7dcfbe2b95829d6e7e1b6d2a77f0deb2d3121a78ebf7d5a107a9369b03dcf98">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_agent_prompt_secrets.py</strong><dd><code>覆盖提示词日志路径隐藏</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_agent_prompt_secrets.py

- 断言提示词不包含日志目录路径。
- 断言提示词不包含主日志文件路径。
- 校验 `日志目录` 和 `主日志文件` 标签不泄露。


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6050/files#diff-bf7cff886c03a5cedba14fde81a941354052a4c99902fb004a359aac0fa24614">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_agent_resource_flow_permissions.py</strong><dd><code>增加日志目录访问回归测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_agent_resource_flow_permissions.py

<ul><li>更新普通用户文件访问边界测试说明。<br> <li> 增加拒绝提示不包含日志目录的断言。<br> <li> 新增日志目录读写编辑列出阻断测试。<br> <li> 校验日志内容未被修改。</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6050/files#diff-71aff4de1a1817dbe4440ddaf0cf549c9a028a5151c7d3d9267cd7b934707f56">+38/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

