### PR TITLE
fix: require manage access for workflows

### DIFF
--- a/app/api/endpoints/workflow.py
+++ b/app/api/endpoints/workflow.py
@@ -10,11 +10,14 @@ from app import schemas
 from app.chain.workflow import WorkflowChain
 from app.core.config import global_vars
 from app.core.plugin import PluginManager
-from app.core.security import verify_token
 from app.workflow import WorkFlowManager
 from app.db import get_async_db, get_db
-from app.db.models import Workflow
+from app.db.models import Workflow, User
 from app.db.systemconfig_oper import SystemConfigOper
+from app.db.user_oper import (
+    get_current_active_manage_user,
+    get_current_active_manage_user_async,
+)
 from app.db.workflow_oper import WorkflowOper
 from app.helper.server import MoviePilotServerHelper
 from app.scheduler import Scheduler
@@ -30,7 +33,7 @@ WORKFLOW_TRIGGER_MANUAL = "manual"
 @router.get("/", summary="所有工作流", response_model=List[schemas.Workflow])
 async def list_workflows(
     db: AsyncSession = Depends(get_async_db),
-    _: schemas.TokenPayload = Depends(verify_token),
+    _: User = Depends(get_current_active_manage_user_async),
 ) -> Any:
     """
     获取工作流列表
@@ -42,7 +45,7 @@ async def list_workflows(
 async def create_workflow(
     workflow: schemas.Workflow,
     db: AsyncSession = Depends(get_async_db),
-    _: schemas.TokenPayload = Depends(verify_token),
+    _: User = Depends(get_current_active_manage_user_async),
 ) -> Any:
     """
     创建工作流
@@ -62,7 +65,7 @@ async def create_workflow(
 
 @router.get("/plugin/actions", summary="查询插件动作", response_model=List[dict])
 def list_plugin_actions(
-    plugin_id: str = None, _: schemas.TokenPayload = Depends(verify_token)
+    plugin_id: str = None, _: User = Depends(get_current_active_manage_user)
 ) -> Any:
     """
     获取所有动作
@@ -71,7 +74,7 @@ def list_plugin_actions(
 
 
 @router.get("/actions", summary="所有动作", response_model=List[dict])
-async def list_actions(_: schemas.TokenPayload = Depends(verify_token)) -> Any:
+async def list_actions(_: User = Depends(get_current_active_manage_user_async)) -> Any:
     """
     获取所有动作
     """
@@ -79,7 +82,7 @@ async def list_actions(_: schemas.TokenPayload = Depends(verify_token)) -> Any:
 
 
 @router.get("/event_types", summary="获取所有事件类型", response_model=List[dict])
-async def get_event_types(_: schemas.TokenPayload = Depends(verify_token)) -> Any:
+async def get_event_types(_: User = Depends(get_current_active_manage_user_async)) -> Any:
     """
     获取所有事件类型
     """
@@ -94,7 +97,7 @@ async def get_event_types(_: schemas.TokenPayload = Depends(verify_token)) -> An
 
 @router.post("/share", summary="分享工作流", response_model=schemas.Response)
 async def workflow_share(
-    workflow: schemas.WorkflowShare, _: schemas.TokenPayload = Depends(verify_token)
+    workflow: schemas.WorkflowShare, _: User = Depends(get_current_active_manage_user_async)
 ) -> Any:
     """
     分享工作流
@@ -115,7 +118,7 @@ async def workflow_share(
 
 @router.delete("/share/{share_id}", summary="删除分享", response_model=schemas.Response)
 async def workflow_share_delete(
-    share_id: int, _: schemas.TokenPayload = Depends(verify_token)
+    share_id: int, _: User = Depends(get_current_active_manage_user_async)
 ) -> Any:
     """
     删除分享
@@ -128,7 +131,7 @@ async def workflow_share_delete(
 async def workflow_fork(
     workflow: schemas.WorkflowShare,
     db: AsyncSession = Depends(get_async_db),
-    _: schemas.User = Depends(verify_token),
+    _: User = Depends(get_current_active_manage_user_async),
 ) -> Any:
     """
     复用工作流
@@ -194,7 +197,7 @@ async def workflow_shares(
     name: Optional[str] = None,
     page: Optional[int] = 1,
     count: Optional[int] = 30,
-    _: schemas.TokenPayload = Depends(verify_token),
+    _: User = Depends(get_current_active_manage_user_async),
 ) -> Any:
     """
     查询分享的工作流
@@ -208,7 +211,7 @@ async def workflow_shares(
 def run_workflow(
     workflow_id: int,
     from_begin: Optional[bool] = True,
-    _: schemas.TokenPayload = Depends(verify_token),
+    _: User = Depends(get_current_active_manage_user),
 ) -> Any:
     """
     执行工作流
@@ -225,7 +228,7 @@ def run_workflow(
 def start_workflow(
     workflow_id: int,
     db: Session = Depends(get_db),
-    _: schemas.TokenPayload = Depends(verify_token),
+    _: User = Depends(get_current_active_manage_user),
 ) -> Any:
     """
     启用工作流
@@ -259,7 +262,7 @@ def start_workflow(
 def pause_workflow(
     workflow_id: int,
     db: Session = Depends(get_db),
-    _: schemas.TokenPayload = Depends(verify_token),
+    _: User = Depends(get_current_active_manage_user),
 ) -> Any:
     """
     停用工作流
@@ -287,7 +290,7 @@ def pause_workflow(
 async def reset_workflow(
     workflow_id: int,
     db: AsyncSession = Depends(get_async_db),
-    _: schemas.TokenPayload = Depends(verify_token),
+    _: User = Depends(get_current_active_manage_user_async),
 ) -> Any:
     """
     重置工作流
@@ -308,7 +311,7 @@ async def reset_workflow(
 async def get_workflow(
     workflow_id: int,
     db: AsyncSession = Depends(get_async_db),
-    _: schemas.TokenPayload = Depends(verify_token),
+    _: User = Depends(get_current_active_manage_user_async),
 ) -> Any:
     """
     获取工作流详情
@@ -320,7 +323,7 @@ async def get_workflow(
 def update_workflow(
     workflow: schemas.Workflow,
     db: Session = Depends(get_db),
-    _: schemas.TokenPayload = Depends(verify_token),
+    _: User = Depends(get_current_active_manage_user),
 ) -> Any:
     """
     更新工作流
@@ -350,7 +353,7 @@ def update_workflow(
 def delete_workflow(
     workflow_id: int,
     db: Session = Depends(get_db),
-    _: schemas.TokenPayload = Depends(verify_token),
+    _: User = Depends(get_current_active_manage_user),
 ) -> Any:
     """
     删除工作流

--- a/app/db/user_oper.py
+++ b/app/db/user_oper.py
@@ -58,6 +58,36 @@ async def get_current_active_user_async(
     return current_user
 
 
+def _ensure_manage_user(current_user: User) -> User:
+    """
+    校验用户具备全局管理权限。
+    """
+    permissions = current_user.permissions or {}
+    if not current_user.is_superuser and not bool(permissions.get("manage")):
+        raise HTTPException(
+            status_code=400, detail="用户权限不足"
+        )
+    return current_user
+
+
+def get_current_active_manage_user(
+        current_user: User = Depends(get_current_active_user),
+) -> User:
+    """
+    获取当前拥有管理权限的激活用户。
+    """
+    return _ensure_manage_user(current_user)
+
+
+async def get_current_active_manage_user_async(
+        current_user: User = Depends(get_current_active_user_async),
+) -> User:
+    """
+    异步获取当前拥有管理权限的激活用户。
+    """
+    return _ensure_manage_user(current_user)
+
+
 def get_current_active_superuser(
         current_user: User = Depends(get_current_user),
 ) -> User:

--- a/tests/test_workflow_authorization.py
+++ b/tests/test_workflow_authorization.py
@@ -1,0 +1,91 @@
+import asyncio
+import inspect
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from fastapi.routing import APIRoute
+
+from app.api.endpoints import workflow as workflow_endpoint
+from app.core.security import verify_token
+from app.db.user_oper import (
+    get_current_active_manage_user,
+    get_current_active_manage_user_async,
+    get_current_active_user,
+    get_current_active_user_async,
+)
+
+
+def _declared_dependencies(func):
+    """读取接口函数签名中直接声明的 FastAPI 依赖函数。"""
+    dependencies = []
+    for parameter in inspect.signature(func).parameters.values():
+        default = parameter.default
+        dependency = getattr(default, "dependency", None)
+        if dependency:
+            dependencies.append(dependency)
+    return dependencies
+
+
+def _workflow_routes():
+    """返回 Workflow API 当前注册的所有路由。"""
+    return [
+        route
+        for route in workflow_endpoint.router.routes
+        if isinstance(route, APIRoute)
+    ]
+
+
+@pytest.mark.parametrize(
+    "user",
+    [
+        SimpleNamespace(is_superuser=True, permissions={}),
+        SimpleNamespace(is_superuser=False, permissions={"manage": True}),
+    ],
+)
+def test_workflow_manage_dependency_allows_superuser_or_manage_user(user):
+    """Workflow 管理边界允许超级管理员或拥有 manage 权限的用户。"""
+    assert get_current_active_manage_user(current_user=user) is user
+    assert asyncio.run(get_current_active_manage_user_async(current_user=user)) is user
+
+
+@pytest.mark.parametrize("permissions", [None, {}, {"manage": False}])
+def test_workflow_manage_dependency_rejects_regular_user(permissions):
+    """Workflow 管理边界拒绝不具备 manage 权限的普通用户。"""
+    user = SimpleNamespace(is_superuser=False, permissions=permissions)
+
+    with pytest.raises(HTTPException) as sync_exc_info:
+        get_current_active_manage_user(current_user=user)
+    assert sync_exc_info.value.status_code == 400
+    assert sync_exc_info.value.detail == "用户权限不足"
+
+    with pytest.raises(HTTPException) as async_exc_info:
+        asyncio.run(get_current_active_manage_user_async(current_user=user))
+    assert async_exc_info.value.status_code == 400
+    assert async_exc_info.value.detail == "用户权限不足"
+
+
+def test_workflow_manage_dependencies_reuse_active_user_resolution():
+    """Workflow 管理依赖复用激活用户解析，保留未激活用户拒绝策略。"""
+    assert _declared_dependencies(get_current_active_manage_user) == [
+        get_current_active_user
+    ]
+    assert _declared_dependencies(get_current_active_manage_user_async) == [
+        get_current_active_user_async
+    ]
+
+
+def test_workflow_routes_require_manage_dependency_not_bare_verify_token():
+    """Workflow 路由必须使用管理权限依赖，不能直接裸用 verify_token。"""
+    routes = _workflow_routes()
+    assert routes
+
+    for route in routes:
+        dependencies = _declared_dependencies(route.endpoint)
+        assert verify_token not in dependencies, route.path
+        if inspect.iscoroutinefunction(route.endpoint):
+            assert get_current_active_manage_user_async in dependencies, route.path
+            assert get_current_active_manage_user not in dependencies, route.path
+        else:
+            assert get_current_active_manage_user in dependencies, route.path
+            assert get_current_active_manage_user_async not in dependencies, route.path


### PR DESCRIPTION
### **User description**
## 变更说明

为 Workflow 管理接口增加后端 `manage` 权限校验。超级用户和拥有 `permissions.manage=true` 的用户可继续管理全局 Workflow；普通认证用户不再能直接调用这些接口。

## 影响范围

- `app/db/user_oper.py`
- `app/api/endpoints/workflow.py`
- `tests/test_workflow_authorization.py`

## 兼容性

Workflow 是全局自动化对象，本 PR 不引入 owner-only 语义。后端权限边界与前端 Workflow 入口的 `manage` 可见性保持一致。

## 验证

- `python -m pytest tests/test_workflow_authorization.py -q` -> 7 passed
- `python -m py_compile app/db/user_oper.py app/api/endpoints/workflow.py tests/test_workflow_authorization.py`
- `git diff --check`

本 PR 为 Codex 协作提交


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- 收紧 Workflow 访问控制

- 新增 manage 权限依赖

- 覆盖路由授权测试


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workflow.py</strong><dd><code>Workflow 路由改用管理权限校验</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/api/endpoints/workflow.py

<ul><li>将 Workflow 路由依赖从 <code>verify_token</code> 替换为管理权限依赖。<br> <li> 区分同步与异步接口，分别使用 <code>get_current_active_manage_user</code> 和 <br><code>get_current_active_manage_user_async</code>。<br> <li> 引入 <code>User</code> 类型，统一接口权限参数类型。</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6052/files#diff-42371b414f9e51424bf2c7e1d532751a3bd4defd8eb86d471d0a8376a33f4dd0">+21/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>user_oper.py</strong><dd><code>新增当前管理用户依赖</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/db/user_oper.py

<ul><li>新增 <code>_ensure_manage_user</code> 统一校验管理权限。<br> <li> 允许超级用户或 <code>permissions.manage=true</code> 用户访问。<br> <li> 为同步和异步调用新增管理用户依赖函数。<br> <li> 权限不足时返回 <code>400</code> 和 <code>用户权限不足</code>。</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6052/files#diff-0ef58e66db48a3de1fe0db7df8f296869ce5b29c7c03b144e8e9bc61fd89f479">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_workflow_authorization.py</strong><dd><code>覆盖 Workflow 授权边界测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_workflow_authorization.py

<ul><li>新增管理权限依赖的放行与拒绝测试。<br> <li> 验证管理依赖复用激活用户解析。<br> <li> 检查所有 Workflow 路由不再直接使用 <code>verify_token</code>。<br> <li> 校验同步与异步路由使用对应权限依赖。</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6052/files#diff-12fa891f2944877eb118950851cb472dbf714061d10c627412e03b5a0b6506a7">+91/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

