### PR TITLE
fix: protect CookieCloud update uploads with optional header

### DIFF
--- a/app/api/servcookie.py
+++ b/app/api/servcookie.py
@@ -1,10 +1,11 @@
 import gzip
+import hmac
 import json
 from typing import Annotated, Callable, Any, Dict, Optional
 
 import aiofiles
 from anyio import Path as AsyncPath
-from fastapi import APIRouter, Body, Depends, HTTPException, Path, Request, Response
+from fastapi import APIRouter, Body, Depends, Header, HTTPException, Path, Request, Response
 from fastapi.responses import PlainTextResponse
 from fastapi.routing import APIRoute
 
@@ -44,6 +45,24 @@ async def verify_server_enabled():
     return True
 
 
+async def verify_update_auth(
+    x_cookiecloud_auth: Annotated[
+        Optional[str], Header(alias="X-CookieCloud-Auth")
+    ] = None,
+):
+    """
+    校验CookieCloud上传接口的可选共享认证头。
+    """
+    expected_header = (settings.COOKIECLOUD_AUTH_HEADER or "").strip()
+    if not expected_header:
+        return True
+
+    provided_header = (x_cookiecloud_auth or "").strip()
+    if not hmac.compare_digest(provided_header, expected_header):
+        raise HTTPException(status_code=403, detail="CookieCloud认证失败")
+    return True
+
+
 cookie_router = APIRouter(
     route_class=GzipRoute,
     tags=["servcookie"],
@@ -61,7 +80,7 @@ async def post_root():
     return "Hello MoviePilot! COOKIECLOUD API ROOT = /cookiecloud"
 
 
-@cookie_router.post("/update")
+@cookie_router.post("/update", dependencies=[Depends(verify_update_auth)])
 async def update_cookie(req: schemas.CookieData):
     """
     上传Cookie数据

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -377,6 +377,8 @@ class ConfigModel(BaseModel):
     COOKIECLOUD_KEY: Optional[str] = None
     # CookieCloud端对端加密密码
     COOKIECLOUD_PASSWORD: Optional[str] = None
+    # CookieCloud本地上传接口的X-CookieCloud-Auth期望值，留空表示不校验
+    COOKIECLOUD_AUTH_HEADER: Optional[str] = None
     # CookieCloud同步间隔（分钟）
     COOKIECLOUD_INTERVAL: Optional[int] = 60 * 24
     # CookieCloud同步黑名单，多个域名,分割

--- a/tests/test_cookiecloud_routes.py
+++ b/tests/test_cookiecloud_routes.py
@@ -1,0 +1,117 @@
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from app.api import servcookie
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture()
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture()
+def cookiecloud_app(tmp_path, monkeypatch):
+    settings = SimpleNamespace(
+        COOKIE_PATH=tmp_path,
+        COOKIECLOUD_ENABLE_LOCAL=True,
+        COOKIECLOUD_AUTH_HEADER=None,
+    )
+    monkeypatch.setattr(servcookie, "settings", settings)
+
+    app = FastAPI()
+    app.include_router(servcookie.cookie_router, prefix="/cookiecloud")
+    return app
+
+
+def make_client(app):
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://testserver",
+    )
+
+
+async def test_update_rejects_when_local_cookiecloud_disabled(cookiecloud_app):
+    servcookie.settings.COOKIECLOUD_ENABLE_LOCAL = False
+    servcookie.settings.COOKIECLOUD_AUTH_HEADER = "secret"
+
+    async with make_client(cookiecloud_app) as client:
+        response = await client.post(
+            "/cookiecloud/update",
+            json={"uuid": "abcde", "encrypted": "payload"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "本地CookieCloud服务器未启用"
+
+
+@pytest.mark.parametrize("auth_header", [None, "", "   "])
+async def test_update_allows_legacy_clients_when_auth_header_unconfigured(
+    cookiecloud_app, auth_header
+):
+    servcookie.settings.COOKIECLOUD_AUTH_HEADER = auth_header
+
+    async with make_client(cookiecloud_app) as client:
+        response = await client.post(
+            "/cookiecloud/update",
+            json={"uuid": "abcde", "encrypted": "payload"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"action": "done"}
+    assert json.loads((servcookie.settings.COOKIE_PATH / "abcde.json").read_text()) == {
+        "encrypted": "payload"
+    }
+
+
+async def test_update_allows_matching_auth_header(cookiecloud_app):
+    servcookie.settings.COOKIECLOUD_AUTH_HEADER = "  secret-token  "
+
+    async with make_client(cookiecloud_app) as client:
+        response = await client.post(
+            "/cookiecloud/update",
+            json={"uuid": "abcde", "encrypted": "payload"},
+            headers={"X-CookieCloud-Auth": "secret-token"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"action": "done"}
+
+
+@pytest.mark.parametrize("headers", [{}, {"X-CookieCloud-Auth": "wrong"}])
+async def test_update_rejects_missing_or_wrong_auth_header(cookiecloud_app, headers):
+    servcookie.settings.COOKIECLOUD_AUTH_HEADER = "secret-token"
+
+    async with make_client(cookiecloud_app) as client:
+        response = await client.post(
+            "/cookiecloud/update",
+            json={"uuid": "abcde", "encrypted": "payload"},
+            headers=headers,
+        )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "CookieCloud认证失败"
+
+
+async def test_get_routes_do_not_require_auth_header(cookiecloud_app, monkeypatch):
+    servcookie.settings.COOKIECLOUD_AUTH_HEADER = "secret-token"
+
+    async def load_encrypt_data(uuid):
+        assert uuid == "abcde"
+        return {"encrypted": "payload"}
+
+    monkeypatch.setattr(servcookie, "load_encrypt_data", load_encrypt_data)
+
+    async with make_client(cookiecloud_app) as client:
+        get_response = await client.get("/cookiecloud/get/abcde")
+        post_response = await client.post("/cookiecloud/get/abcde")
+
+    assert get_response.status_code == 200
+    assert get_response.json() == {"encrypted": "payload"}
+    assert post_response.status_code == 200
+    assert post_response.json() == {"encrypted": "payload"}


### PR DESCRIPTION
### **User description**
## 变更说明

新增默认关闭的 `COOKIECLOUD_AUTH_HEADER` 配置。配置后，`/cookiecloud/update` 需要请求头 `X-CookieCloud-Auth` 匹配该共享 secret；未配置时保持原 CookieCloud 协议兼容。`/cookiecloud/get/{uuid}` 不受该 header 保护。

## 影响范围

- `app/core/config.py`
- `app/api/servcookie.py`
- `tests/test_cookiecloud_routes.py`

## 兼容性

默认留空时行为不变。启用后，无法直接发送 header 的 CookieCloud 客户端可通过受控反向代理注入 `X-CookieCloud-Auth`。

## 联动 PR

前端设置项会在 MoviePilot-Frontend 另一个 draft PR 中提交，用于暴露同名配置字段。

## 验证

- `python -m pytest tests/test_cookiecloud_routes.py -q` -> 8 passed
- `python -m py_compile app/core/config.py app/api/servcookie.py`
- `git diff --check`

本 PR 为 Codex 协作提交


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- 保护 CookieCloud 上传接口

- 保持默认协议兼容

- 增加路由认证测试


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>servcookie.py</strong><dd><code>上传接口增加可选认证保护</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/api/servcookie.py

<ul><li>引入 <code>hmac</code> 与 <code>Header</code> 依赖。<br> <li> 新增 <code>verify_update_auth</code> 校验 <code>X-CookieCloud-Auth</code>。<br> <li> 未配置 <code>COOKIECLOUD_AUTH_HEADER</code> 时跳过校验。<br> <li> 仅为 <code>/cookiecloud/update</code> 添加认证依赖。</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6053/files#diff-2f46e7cdb15a0e6354379e42548c6dd46ae74f88a5aa0706d888881c3b8863b3">+21/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>新增 CookieCloud 认证头配置</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/core/config.py

- 新增 `COOKIECLOUD_AUTH_HEADER` 配置项。
- 配置为空时表示不校验上传认证头。


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6053/files#diff-46319cab8aa9cca75fe586084b86c07f241657d02b324944bb7d300ce560039b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_cookiecloud_routes.py</strong><dd><code>覆盖 CookieCloud 路由认证行为</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_cookiecloud_routes.py

<ul><li>新增 FastAPI 测试应用夹具。<br> <li> 覆盖本地服务关闭的拒绝逻辑。<br> <li> 验证认证头缺失、错误和匹配行为。<br> <li> 确认 <code>/get/{uuid}</code> 路由不受认证影响。</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6053/files#diff-ade96542be7845e69edd9f98928ec1564f0d8926e2549cbd53472d6efea3ec9e">+117/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

