### PR TITLE
fix: restrict download save paths to configured roots

### DIFF
--- a/app/agent/tools/impl/add_download_tasks.py
+++ b/app/agent/tools/impl/add_download_tasks.py
@@ -15,7 +15,7 @@ from app.core.config import settings
 from app.core.context import Context
 from app.core.metainfo import MetaInfo
 from app.db.site_oper import SiteOper
-from app.helper.directory import DirectoryHelper
+from app.helper.directory import DirectoryHelper, validate_download_save_path
 from app.log import logger
 from app.schemas import FileURI, TorrentInfo
 from app.utils.crypto import HashUtils
@@ -183,8 +183,8 @@ class AddDownloadTasksTool(MoviePilotTool):
     @staticmethod
     def _resolve_direct_download_dir(save_path: Optional[str]) -> Optional[Path]:
         """解析直接下载使用的目录，优先使用 save_path，其次使用默认下载目录"""
-        if save_path:
-            return Path(save_path)
+        if save_path is not None:
+            return Path(validate_download_save_path(save_path))
 
         download_dirs = DirectoryHelper().get_download_dirs()
         if not download_dirs:
@@ -225,6 +225,8 @@ class AddDownloadTasksTool(MoviePilotTool):
         merged_labels: Optional[str],
     ) -> tuple[Optional[str], Optional[str]]:
         """同步提交带上下文的下载任务，避免站点下载与下载器调用阻塞事件循环。"""
+        if save_path is not None:
+            save_path = validate_download_save_path(save_path)
         return DownloadChain().download_single(
             context=context,
             downloader=downloader,
@@ -244,6 +246,12 @@ class AddDownloadTasksTool(MoviePilotTool):
             torrent_inputs = self._normalize_torrent_urls(torrent_url)
             if not torrent_inputs:
                 return "错误：torrent_url 不能为空。"
+
+            if save_path is not None:
+                try:
+                    save_path = validate_download_save_path(save_path)
+                except ValueError as err:
+                    return f"参数错误：save_path {str(err)}"
 
             merged_labels = self._merge_labels_with_system_tag(labels)
             success_count = 0

--- a/app/agent/tools/impl/update_download_tasks.py
+++ b/app/agent/tools/impl/update_download_tasks.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 from app.agent.tools.base import MoviePilotTool
 from app.agent.tools.tags import ToolTag
 from app.chain.download import DownloadChain
+from app.helper.directory import validate_download_save_path
 from app.log import logger
 
 
@@ -149,6 +150,18 @@ class UpdateDownloadTasksTool(MoviePilotTool):
                     cls._build_result("resolve_downloader", False, "未找到下载任务或下载器不可用")
                 ],
             }
+
+        if save_path is not None:
+            try:
+                save_path = validate_download_save_path(save_path)
+            except ValueError:
+                return {
+                    "hash": hash_value,
+                    "downloader": resolved_downloader,
+                    "results": [
+                        cls._build_result("save_path", False, "保存目录不在允许的下载目录范围内")
+                    ],
+                }
 
         results = []
         if tags:

--- a/app/chain/download.py
+++ b/app/chain/download.py
@@ -18,7 +18,7 @@ from app.core.meta import MetaBase
 from app.core.metainfo import MetaInfo
 from app.db.downloadhistory_oper import DownloadHistoryOper
 from app.db.mediaserver_oper import MediaServerOper
-from app.helper.directory import DirectoryHelper
+from app.helper.directory import DirectoryHelper, validate_download_save_path
 from app.helper.thread import ThreadHelper
 from app.helper.torrent import TorrentHelper
 from app.log import logger
@@ -107,19 +107,27 @@ class DownloadChain(ChainBase):
     def _resolve_media_download_dir(
             media_info: MediaInfo,
             save_path: Optional[str] = None,
-    ) -> Union[str, Path]:
+    ) -> Tuple[Optional[str], Optional[Path], str]:
         """
         根据媒体信息解析下载目录。
         """
         storage = 'local'
-        if save_path:
-            return storage, Path(save_path)
+        if save_path is not None:
+            try:
+                validated_save_path = validate_download_save_path(save_path)
+            except ValueError as err:
+                logger.warn(str(err))
+                return None, None, str(err)
+            if re.match(r"^[A-Za-z]:/", validated_save_path):
+                return storage, Path(validated_save_path), ""
+            file_uri = FileURI.from_uri(validated_save_path)
+            return file_uri.storage or storage, Path(file_uri.path), ""
 
         dir_info = DirectoryHelper().get_dir(media_info, include_unsorted=True)
         storage = dir_info.storage if dir_info else storage
         if not dir_info:
             logger.error(f"未找到下载目录：{media_info.type.value} {media_info.title_year}")
-            return None
+            return None, None, "未找到下载目录"
 
         if not dir_info.media_type and dir_info.download_type_folder:
             download_dir = Path(dir_info.download_path) / media_info.type.value
@@ -129,7 +137,7 @@ class DownloadChain(ChainBase):
         if not dir_info.media_category and dir_info.download_category_folder and media_info.category:
             download_dir = download_dir / media_info.category
 
-        return storage, download_dir
+        return storage, download_dir, ""
 
     @staticmethod
     def _upload_subtitle_file(
@@ -293,12 +301,12 @@ class DownloadChain(ChainBase):
         if not mediainfo:
             return False, "无法识别媒体信息", []
 
-        storage, target_dir = self._resolve_media_download_dir(
+        storage, target_dir, error_msg = self._resolve_media_download_dir(
             media_info=mediainfo,
             save_path=save_path,
         )
         if not target_dir:
-            return False, "未找到下载目录", []
+            return False, error_msg or "未找到下载目录", []
 
         request = RequestUtils(
             cookies=subtitle.site_cookie,
@@ -527,8 +535,15 @@ class DownloadChain(ChainBase):
                     f"Reason: {event_data.reason}")
                 return (None, "下载被事件取消") if return_detail else None
             # 如果事件修改了下载路径，使用新路径
-            if event_data.options and event_data.options.get("save_path"):
+            if event_data.options and "save_path" in event_data.options:
                 save_path = event_data.options.get("save_path")
+
+        if save_path is not None:
+            try:
+                save_path = validate_download_save_path(save_path)
+            except ValueError as err:
+                logger.warn(str(err))
+                return (None, str(err)) if return_detail else None
 
         # 补充完整的media数据
         if not _media.genre_ids:
@@ -570,7 +585,7 @@ class DownloadChain(ChainBase):
 
         storage = 'local'
         # 下载目录
-        if save_path:
+        if save_path is not None:
             download_dir = Path(save_path)
         else:
             # 根据媒体信息查询下载目录配置

--- a/app/helper/directory.py
+++ b/app/helper/directory.py
@@ -1,15 +1,17 @@
 import re
-from pathlib import Path
+from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
 from typing import List, Optional, Tuple
 
 from app import schemas
 from app.core.context import MediaInfo
 from app.db.systemconfig_oper import SystemConfigOper
 from app.log import logger
-from app.schemas.types import SystemConfigKey
+from app.schemas.types import StorageSchema, SystemConfigKey
 from app.utils.system import SystemUtils
 
 JINJA2_VAR_PATTERN = re.compile(r"\{\{.*?}}", re.DOTALL)
+WINDOWS_DRIVE_PATTERN = re.compile(r"^[A-Za-z]:[\\/]")
+WINDOWS_DRIVE_PREFIX_PATTERN = re.compile(r"^[A-Za-z]:")
 
 
 class DirectoryHelper:
@@ -169,3 +171,118 @@ class DirectoryHelper:
         # 媒体根路径
         media_root = rename_path.parents[rename_format_level - 1]
         return media_root
+
+
+def _split_file_uri(value: str) -> Tuple[str, str]:
+    """
+    拆分 FileURI 字符串，保留原始路径用于安全校验。
+    """
+    for storage in StorageSchema:
+        protocol = f"{storage.value}:"
+        if value.startswith(protocol):
+            return storage.value, value[len(protocol):]
+    return "local", value
+
+
+def _normalize_safe_posix_path(raw_path: str) -> PurePosixPath:
+    """
+    规范化保存目录路径，并拒绝跨目录或跨平台歧义写法。
+    """
+    if not raw_path:
+        raise ValueError("保存路径不能为空")
+    if "\\" in raw_path:
+        raise ValueError("保存路径不能包含反斜杠")
+    if raw_path.startswith("//"):
+        raise ValueError("保存路径不能使用 UNC 路径")
+    if WINDOWS_DRIVE_PATTERN.match(raw_path):
+        raise ValueError("保存路径不能使用 Windows 盘符路径")
+    if not raw_path.startswith("/"):
+        raise ValueError("保存路径必须是绝对路径")
+
+    path = PurePosixPath(raw_path)
+    parts = [part for part in path.parts if part != "/"]
+    if ".." in parts:
+        raise ValueError("保存路径不能包含上级目录")
+    if parts and re.fullmatch(r"[A-Za-z]:", parts[0]):
+        raise ValueError("保存路径不能使用 Windows 盘符路径")
+    return path
+
+
+def _normalize_safe_windows_path(raw_path: str) -> PureWindowsPath:
+    """
+    规范化已配置的 Windows 盘符路径；UNC 与反斜杠写法不参与下载目录 allowlist。
+    """
+    if not raw_path:
+        raise ValueError("保存路径不能为空")
+    if "\\" in raw_path:
+        raise ValueError("保存路径不能包含反斜杠")
+    if raw_path.startswith("//"):
+        raise ValueError("保存路径不能使用 UNC 路径")
+    if not WINDOWS_DRIVE_PATTERN.match(raw_path):
+        raise ValueError("保存路径必须是 Windows 绝对路径")
+
+    path = PureWindowsPath(raw_path)
+    if ".." in path.parts:
+        raise ValueError("保存路径不能包含上级目录")
+    return path
+
+
+def _normalize_download_path(raw_path: str, storage: str) -> Tuple[str, PurePath]:
+    """
+    按存储类型解析下载路径，本地允许 POSIX 或已配置的 Windows drive，远端保持 FileURI POSIX 语义。
+    """
+    path_value = str(raw_path or "").strip()
+    if storage == "local" and WINDOWS_DRIVE_PREFIX_PATTERN.match(path_value):
+        return "windows", _normalize_safe_windows_path(path_value)
+    return "posix", _normalize_safe_posix_path(path_value)
+
+
+def _download_path_uri(storage: str, path: PurePath) -> str:
+    """
+    生成可传给下载器的 save_path，保持 /download/paths 暴露的本地和远端路径风格。
+    """
+    path_value = path.as_posix()
+    if storage == "local":
+        return path_value
+    return schemas.FileURI(storage=storage, path=path_value).uri
+
+
+def _normalize_download_root(dir_info: schemas.TransferDirectoryConf) -> Optional[Tuple[str, str, PurePath]]:
+    """
+    读取下载目录配置中的根路径；无效配置不参与用户 save_path allowlist。
+    """
+    if not dir_info.download_path:
+        return None
+    storage = dir_info.storage or "local"
+    try:
+        path_style, root_path = _normalize_download_path(dir_info.download_path, storage)
+        return storage, path_style, root_path
+    except ValueError as err:
+        logger.warn(f"跳过无效下载目录配置：{str(err)}")
+        return None
+
+
+def validate_download_save_path(save_path: str) -> str:
+    """
+    校验用户传入的下载保存目录，/download/paths 暴露的下载目录配置是允许写入的公共合同。
+
+    :param save_path: 下载保存目录，支持本地 /path 或远端 <storage>:/path
+    :return: 可直接传给下载接口的规范化保存目录
+    """
+    value = str(save_path or "").strip()
+    storage, raw_path = _split_file_uri(value)
+    target_style, target_path = _normalize_download_path(raw_path, storage)
+
+    for dir_info in DirectoryHelper().get_download_dirs():
+        root = _normalize_download_root(dir_info)
+        if not root:
+            continue
+        root_storage, root_style, root_path = root
+        if storage != root_storage:
+            continue
+        if target_style != root_style:
+            continue
+        if target_path == root_path or target_path.is_relative_to(root_path):
+            return _download_path_uri(storage, target_path)
+
+    raise ValueError("保存路径不在允许的下载目录范围内")

--- a/tests/test_download_save_path_allowlist.py
+++ b/tests/test_download_save_path_allowlist.py
@@ -1,0 +1,439 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import app.agent.tools.impl.add_download_tasks as add_tasks_module
+import app.agent.tools.impl.update_download_tasks as update_tasks_module
+import app.chain.download as download_module
+from app.agent.tools.impl.add_download_tasks import AddDownloadTasksTool
+from app.agent.tools.impl.update_download_tasks import UpdateDownloadTasksTool
+from app.chain.download import DownloadChain
+from app.core.context import Context, MediaInfo, SubtitleInfo, TorrentInfo
+from app.core.metainfo import MetaInfo
+from app.helper.directory import validate_download_save_path
+from app.schemas import DownloaderTorrent, TransferDirectoryConf
+from app.schemas.types import MediaType
+
+
+def _download_dirs():
+    return [
+        TransferDirectoryConf(
+            name="本地下载",
+            priority=1,
+            storage="local",
+            download_path="/downloads",
+        ),
+        TransferDirectoryConf(
+            name="动漫远程下载",
+            priority=2,
+            storage="rclone",
+            download_path="/media/anime",
+        ),
+    ]
+
+
+def _windows_download_dirs():
+    return [
+        TransferDirectoryConf(
+            name="Windows 下载",
+            priority=1,
+            storage="local",
+            download_path="C:/downloads",
+        ),
+    ]
+
+
+@pytest.fixture(autouse=True)
+def patch_download_dirs(monkeypatch):
+    monkeypatch.setattr(
+        "app.helper.directory.DirectoryHelper.get_download_dirs",
+        lambda _self: _download_dirs(),
+    )
+
+
+@pytest.mark.parametrize(
+    ("save_path", "expected"),
+    [
+        ("/downloads", "/downloads"),
+        ("/downloads/movie/demo", "/downloads/movie/demo"),
+        ("rclone:/media/anime/sub", "rclone:/media/anime/sub"),
+    ],
+)
+def test_validate_download_save_path_accepts_configured_roots_and_children(save_path, expected):
+    assert validate_download_save_path(save_path) == expected
+
+
+@pytest.mark.parametrize(
+    ("save_path", "expected"),
+    [
+        ("C:/downloads", "C:/downloads"),
+        ("C:/downloads/movie", "C:/downloads/movie"),
+    ],
+)
+def test_validate_download_save_path_accepts_windows_configured_root_and_children(
+    monkeypatch,
+    save_path,
+    expected,
+):
+    monkeypatch.setattr(
+        "app.helper.directory.DirectoryHelper.get_download_dirs",
+        lambda _self: _windows_download_dirs(),
+    )
+
+    assert validate_download_save_path(save_path) == expected
+
+
+@pytest.mark.parametrize(
+    "save_path",
+    [
+        "C:/other",
+        "D:/downloads",
+        "C:/downloads/../Windows",
+        "C:\\downloads\\movie",
+        "\\\\server\\share\\downloads",
+    ],
+)
+def test_validate_download_save_path_rejects_windows_paths_outside_configured_root(
+    monkeypatch,
+    save_path,
+):
+    monkeypatch.setattr(
+        "app.helper.directory.DirectoryHelper.get_download_dirs",
+        lambda _self: _windows_download_dirs(),
+    )
+
+    with pytest.raises(ValueError):
+        validate_download_save_path(save_path)
+
+
+@pytest.mark.parametrize(
+    "save_path",
+    [
+        "/etc",
+        "/downloads/../etc",
+        "/downloads\\..\\etc",
+        "C:/downloads",
+        "\\\\server\\share\\downloads",
+        "//server/share/downloads",
+        "relative/downloads",
+        "",
+        "   ",
+        "rclone:/media/movies",
+        "smb:/media/anime/sub",
+    ],
+)
+def test_validate_download_save_path_rejects_paths_outside_configured_roots(save_path):
+    with pytest.raises(ValueError):
+        validate_download_save_path(save_path)
+
+
+def _build_context() -> Context:
+    return Context(
+        meta_info=MetaInfo("Demo Movie 2026"),
+        media_info=MediaInfo(
+            type=MediaType.MOVIE,
+            title="Demo Movie",
+            year="2026",
+            tmdb_id=1,
+            genre_ids=[18],
+        ),
+        torrent_info=TorrentInfo(
+            title="Demo Movie 2026",
+            enclosure="https://example.test/demo.torrent",
+            site_cookie="uid=1",
+            site_name="TestSite",
+        ),
+    )
+
+
+def _build_download_chain() -> DownloadChain:
+    chain = DownloadChain.__new__(DownloadChain)
+    chain.download = MagicMock()
+    chain.post_message = MagicMock()
+    chain.messagehelper = MagicMock()
+    return chain
+
+
+def test_download_single_rejects_bad_save_path_before_downloader(monkeypatch):
+    monkeypatch.setattr(download_module.eventmanager, "send_event", lambda *args, **kwargs: None)
+    chain = _build_download_chain()
+
+    download_id, error_msg = chain.download_single(
+        context=_build_context(),
+        torrent_content=b"torrent-content",
+        save_path="/etc",
+        return_detail=True,
+    )
+
+    assert download_id is None
+    assert "保存路径" in error_msg
+    chain.download.assert_not_called()
+
+
+def test_download_single_rejects_event_overridden_bad_save_path_before_downloader(monkeypatch):
+    event_data = SimpleNamespace(cancel=False, source="plugin", reason="", options={"save_path": "/etc"})
+    monkeypatch.setattr(
+        download_module.eventmanager,
+        "send_event",
+        lambda *args, **kwargs: SimpleNamespace(event_data=event_data),
+    )
+    chain = _build_download_chain()
+
+    download_id, error_msg = chain.download_single(
+        context=_build_context(),
+        torrent_content=b"torrent-content",
+        save_path="/downloads",
+        return_detail=True,
+    )
+
+    assert download_id is None
+    assert "保存路径" in error_msg
+    chain.download.assert_not_called()
+
+
+@pytest.mark.parametrize("save_path", ["", "   "])
+def test_download_single_rejects_explicit_empty_save_path_before_default_fallback(monkeypatch, save_path):
+    monkeypatch.setattr(download_module.eventmanager, "send_event", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        download_module.DirectoryHelper,
+        "get_dir",
+        lambda *_args, **_kwargs: TransferDirectoryConf(storage="local", download_path="/downloads"),
+    )
+    chain = _build_download_chain()
+
+    download_id, error_msg = chain.download_single(
+        context=_build_context(),
+        torrent_content=b"torrent-content",
+        save_path=save_path,
+        return_detail=True,
+    )
+
+    assert download_id is None
+    assert "保存路径" in error_msg
+    chain.download.assert_not_called()
+
+
+def test_download_single_rejects_event_empty_save_path_override_before_downloader(monkeypatch):
+    event_data = SimpleNamespace(cancel=False, source="plugin", reason="", options={"save_path": ""})
+    monkeypatch.setattr(
+        download_module.eventmanager,
+        "send_event",
+        lambda *args, **kwargs: SimpleNamespace(event_data=event_data),
+    )
+    chain = _build_download_chain()
+
+    download_id, error_msg = chain.download_single(
+        context=_build_context(),
+        torrent_content=b"torrent-content",
+        save_path="/downloads",
+        return_detail=True,
+    )
+
+    assert download_id is None
+    assert "保存路径" in error_msg
+    chain.download.assert_not_called()
+
+
+def test_resolve_media_download_dir_rejects_bad_subtitle_save_path():
+    media_info = MediaInfo(
+        type=MediaType.MOVIE,
+        title="Demo Movie",
+        year="2026",
+        tmdb_id=1,
+    )
+
+    storage, target_dir, error_msg = DownloadChain._resolve_media_download_dir(
+        media_info=media_info,
+        save_path="/etc",
+    )
+
+    assert storage is None
+    assert target_dir is None
+    assert error_msg == "保存路径不在允许的下载目录范围内"
+
+
+def test_download_subtitle_returns_specific_error_for_bad_save_path():
+    chain = DownloadChain.__new__(DownloadChain)
+    chain.recognize_media = MagicMock(
+        return_value=MediaInfo(
+            type=MediaType.MOVIE,
+            title="Demo Movie",
+            year="2026",
+            tmdb_id=1,
+        )
+    )
+    subtitle = SubtitleInfo(
+        title="Demo Movie",
+        enclosure="https://example.test/subtitle.srt",
+    )
+
+    success, message, saved_files = chain.download_subtitle(
+        subtitle=subtitle,
+        save_path="/etc",
+    )
+
+    assert not success
+    assert message == "保存路径不在允许的下载目录范围内"
+    assert saved_files == []
+
+
+@pytest.mark.parametrize("save_path", ["", "   "])
+def test_resolve_media_download_dir_rejects_explicit_empty_save_path_before_default_fallback(
+    monkeypatch,
+    save_path,
+):
+    monkeypatch.setattr(
+        download_module.DirectoryHelper,
+        "get_dir",
+        lambda *_args, **_kwargs: TransferDirectoryConf(storage="local", download_path="/downloads"),
+    )
+    media_info = MediaInfo(
+        type=MediaType.MOVIE,
+        title="Demo Movie",
+        year="2026",
+        tmdb_id=1,
+    )
+
+    storage, target_dir, error_msg = DownloadChain._resolve_media_download_dir(
+        media_info=media_info,
+        save_path=save_path,
+    )
+
+    assert storage is None
+    assert target_dir is None
+    assert "保存路径" in error_msg
+
+
+def test_add_download_tasks_direct_magnet_rejects_bad_save_path_before_downloader():
+    with pytest.raises(ValueError):
+        AddDownloadTasksTool._resolve_direct_download_dir("/etc")
+
+
+@pytest.mark.parametrize("save_path", ["", "   "])
+def test_add_download_tasks_direct_magnet_rejects_explicit_empty_save_path_before_default_fallback(save_path):
+    with pytest.raises(ValueError):
+        AddDownloadTasksTool._resolve_direct_download_dir(save_path)
+
+
+def test_add_download_tasks_cached_context_rejects_bad_save_path_before_download_single(monkeypatch):
+    download_chain = MagicMock()
+    monkeypatch.setattr(add_tasks_module, "DownloadChain", lambda: download_chain)
+
+    with pytest.raises(ValueError):
+        AddDownloadTasksTool._download_single_sync(
+            context=_build_context(),
+            downloader="qb",
+            save_path="/etc",
+            merged_labels=None,
+        )
+
+    download_chain.download_single.assert_not_called()
+
+
+@pytest.mark.parametrize("save_path", ["", "   "])
+def test_add_download_tasks_cached_context_rejects_explicit_empty_save_path_before_download_single(
+    monkeypatch,
+    save_path,
+):
+    download_chain = MagicMock()
+    monkeypatch.setattr(add_tasks_module, "DownloadChain", lambda: download_chain)
+
+    with pytest.raises(ValueError):
+        AddDownloadTasksTool._download_single_sync(
+            context=_build_context(),
+            downloader="qb",
+            save_path=save_path,
+            merged_labels=None,
+        )
+
+    download_chain.download_single.assert_not_called()
+
+
+def test_update_download_tasks_rejects_bad_save_path_before_update_torrent(monkeypatch):
+    hash_value = "a" * 40
+    download_chain = MagicMock()
+    download_chain.list_torrents.return_value = [
+        DownloaderTorrent(downloader="qb", hash=hash_value, title="Demo")
+    ]
+    monkeypatch.setattr(update_tasks_module, "DownloadChain", lambda: download_chain)
+
+    result = UpdateDownloadTasksTool._update_download_sync(
+        hash_value=hash_value,
+        save_path="/etc",
+    )
+
+    assert result["downloader"] == "qb"
+    assert result["results"] == [
+        {
+            "operation": "save_path",
+            "success": False,
+            "message": "保存目录不在允许的下载目录范围内",
+        }
+    ]
+    download_chain.update_torrent.assert_not_called()
+
+
+def test_update_download_tasks_passes_normalized_save_path_to_update_torrent(monkeypatch):
+    hash_value = "b" * 40
+    download_chain = MagicMock()
+    download_chain.list_torrents.return_value = [
+        DownloaderTorrent(downloader="qb", hash=hash_value, title="Demo")
+    ]
+    download_chain.update_torrent.return_value = {"save_path": True}
+    monkeypatch.setattr(update_tasks_module, "DownloadChain", lambda: download_chain)
+
+    result = UpdateDownloadTasksTool._update_download_sync(
+        hash_value=hash_value,
+        save_path="rclone:/media/anime/sub",
+    )
+
+    assert result["results"][0]["success"] is True
+    download_chain.update_torrent.assert_called_once_with(
+        hash_string=hash_value,
+        downloader="qb",
+        download_limit=None,
+        upload_limit=None,
+        tracker_list=None,
+        save_path="rclone:/media/anime/sub",
+        category=None,
+        ratio_limit=None,
+        seeding_time_limit=None,
+    )
+
+
+def test_add_download_tasks_run_rejects_bad_save_path_before_partial_download(monkeypatch):
+    tool = AddDownloadTasksTool(session_id="session-1", user_id="10001")
+    download_chain = MagicMock()
+    monkeypatch.setattr(add_tasks_module, "DownloadChain", lambda: download_chain)
+
+    result = asyncio.run(
+        tool.run(
+            torrent_url=["magnet:?xt=urn:btih:123"],
+            save_path="/etc",
+        )
+    )
+
+    assert "save_path" in result
+    download_chain.download.assert_not_called()
+
+
+@pytest.mark.parametrize("save_path", ["", "   "])
+def test_add_download_tasks_run_rejects_explicit_empty_save_path_before_partial_download(
+    monkeypatch,
+    save_path,
+):
+    tool = AddDownloadTasksTool(session_id="session-1", user_id="10001")
+    download_chain = MagicMock()
+    monkeypatch.setattr(add_tasks_module, "DownloadChain", lambda: download_chain)
+
+    result = asyncio.run(
+        tool.run(
+            torrent_url=["magnet:?xt=urn:btih:123"],
+            save_path=save_path,
+        )
+    )
+
+    assert "save_path" in result
+    download_chain.download.assert_not_called()


### PR DESCRIPTION
### **User description**
## 变更说明

将用户传入的下载 `save_path` 限制到 `/download/paths` 暴露的下载目录根及其子路径。校验覆盖主下载链、字幕下载目录解析、Agent 添加下载工具和 Agent 更新下载工具。

## 影响范围

- `app/helper/directory.py`
- `app/chain/download.py`
- `app/agent/tools/impl/add_download_tasks.py`
- `app/agent/tools/impl/update_download_tasks.py`
- `tests/test_download_save_path_allowlist.py`

## 兼容性

未传 `save_path` 时继续使用现有默认目录选择。显式传入空路径、路径穿越、未配置根、不同 storage 或不同 Windows drive 的路径会被拒绝。已配置的本地 POSIX、远程 FileURI，以及 forward-slash 形式的 Windows drive 根及子路径继续可用。

## 验证

- `python -m pytest tests/test_download_save_path_allowlist.py -q` -> 41 passed
- `python -m py_compile app/helper/directory.py app/chain/download.py app/agent/tools/impl/add_download_tasks.py app/agent/tools/impl/update_download_tasks.py`
- `git diff --check`

本 PR 为 Codex 协作提交


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- 限制 `save_path` 到配置目录

- 校验主下载与字幕路径

- 覆盖 Agent 添加/更新工具

- 新增保存路径白名单测试


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>add_download_tasks.py</strong><dd><code>Agent 添加下载路径安全校验</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/agent/tools/impl/add_download_tasks.py

<ul><li>引入 <code>validate_download_save_path</code> 校验<br> <li> 直接下载目录拒绝非法路径<br> <li> 缓存上下文下载前验证路径<br> <li> <code>run</code> 返回明确参数错误</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6054/files#diff-3101de3ae1e052ef89cdf87657fb0ce1ec15f5112480d1fde25497405c41571b">+11/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>update_download_tasks.py</strong><dd><code>Agent 更新下载路径安全校验</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/agent/tools/impl/update_download_tasks.py

- 更新任务前校验 `save_path`
- 非法路径返回操作失败结果
- 使用规范化路径调用下载器更新


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6054/files#diff-7439e33168abb2329109eebabe22a02b628443d7857ab4678e1a443ea8e29c3b">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>download.py</strong><dd><code>下载链统一限制保存路径</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/chain/download.py

- 主下载流程验证保存路径
- 事件覆盖路径也纳入校验
- 字幕下载返回具体路径错误
- 显式空路径不再回退默认目录


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6054/files#diff-465dca72daf1459ec043549e88962cd2af9b4c1a7ee973405c93158414b406eb">+25/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>directory.py</strong><dd><code>下载目录白名单验证工具</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/helper/directory.py

<ul><li>新增下载路径白名单校验器<br> <li> 支持本地、远端和 Windows 根<br> <li> 拒绝穿越、相对、UNC、反斜杠路径<br> <li> 基于配置下载根判断子路径</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6054/files#diff-9a483013438153a77fad4c550f9b8bf65e18043f36ae8789c10bf0c08a24a0ae">+119/-2</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_download_save_path_allowlist.py</strong><dd><code>下载保存路径白名单测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_download_save_path_allowlist.py

- 覆盖允许根及子目录
- 测试非法路径拒绝场景
- 验证下载链提前阻断
- 覆盖 Agent 添加和更新工具


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6054/files#diff-e59aa226ceb4e0d301f3856a1282af114c76667cd4ab4256bbeacc57c43038e3">+439/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

