### PR TITLE
perf(docker): skip recursive chown of /app and /public by default

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -65,6 +65,7 @@ function load_config_from_app_env() {
         ["GITHUB_TOKEN"]=""
         ["MOVIEPILOT_AUTO_UPDATE"]="release"
         ["MOVIEPILOT_DOCKER_KEEPALIVE_ON_FAILURE"]="true"
+        ["MOVIEPILOT_FORCE_CHOWN"]="false"
         ["MOVIEPILOT_SAFE_MODE"]="false"
         ["BROWSER_EMULATION"]="cloakbrowser"
 
@@ -315,6 +316,70 @@ function ensure_backend_runtime_dependencies() {
     INFO "→ 已自动恢复主程序依赖，继续启动后端。"
 }
 
+function force_chown_image_paths_if_requested() {
+    local force="${MOVIEPILOT_FORCE_CHOWN:-false}"
+    force="${force,,}"
+
+    if [ "${force}" != "true" ] && [ "${force}" != "1" ] && [ "${force}" != "yes" ]; then
+        return 0
+    fi
+
+    WARN "→ MOVIEPILOT_FORCE_CHOWN 已启用，将递归修复 /app、/public 权限，可能显著增加启动耗时。"
+
+    local path
+    for path in "$@"; do
+        [ -e "${path}" ] || continue
+        chown -R moviepilot:moviepilot "${path}"
+    done
+}
+
+function correct_home_permissions() {
+    [ -e "${HOME}" ] || return 0
+
+    local force="${MOVIEPILOT_FORCE_CHOWN:-false}"
+    force="${force,,}"
+
+    chown moviepilot:moviepilot "${HOME}"
+    [ -e "${HOME}/.cloakbrowser" ] && chown -h moviepilot:moviepilot "${HOME}/.cloakbrowser"
+
+    if [ "${force}" = "true" ] || [ "${force}" = "1" ] || [ "${force}" = "yes" ]; then
+        [ -e "${HOME}/.cloakbrowser" ] && chown -R moviepilot:moviepilot "${HOME}/.cloakbrowser"
+    elif [ -e "${HOME}/.cloakbrowser" ]; then
+        INFO "→ 默认跳过 ${HOME}/.cloakbrowser 递归权限校正，如遇浏览器缓存权限错误可设置 MOVIEPILOT_FORCE_CHOWN=true 后重启一次。"
+    fi
+
+    find "${HOME}" -mindepth 1 -maxdepth 1 ! -name ".cloakbrowser" -exec chown -R moviepilot:moviepilot {} +
+}
+
+function chown_plugin_runtime_path() {
+    local plugin_path="${1:-}"
+    [ -n "${plugin_path}" ] || return 0
+    [ -e "${plugin_path}" ] || return 0
+    local current_owner
+    current_owner="$(stat -c '%u:%g' "${plugin_path}" 2>/dev/null || true)"
+    [ "${current_owner}" = "${PUID}:${PGID}" ] && return 0
+    chown -h moviepilot:moviepilot "${plugin_path}"
+}
+
+function correct_file_permissions() {
+    local chown_start
+    local chown_end
+    chown_start=$(date +%s)
+
+    INFO "→ 正在校正文件权限..."
+    force_chown_image_paths_if_requested /app /public
+    chown_plugin_runtime_path /app/app/plugins
+    correct_home_permissions
+    chown -R moviepilot:moviepilot \
+        "${CONFIG_DIR}" \
+        /var/lib/nginx \
+        /var/log/nginx
+    chown moviepilot:moviepilot /etc/hosts /tmp
+
+    chown_end=$(date +%s)
+    INFO "→ 文件权限校正完成，耗时 $(( chown_end - chown_start )) 秒。"
+}
+
 # 使用env配置
 load_config_from_app_env
 apply_package_cache_env
@@ -354,14 +419,7 @@ groupmod -o -g "${PGID}" moviepilot
 usermod -o -u "${PUID}" moviepilot
 
 # 更改文件权限
-chown -R moviepilot:moviepilot \
-    "${HOME}" \
-    /app \
-    /public \
-    "${CONFIG_DIR}" \
-    /var/lib/nginx \
-    /var/log/nginx
-chown moviepilot:moviepilot /etc/hosts /tmp
+correct_file_permissions
 
 # 启动前优先确认主运行环境仍然健康，避免插件依赖污染导致服务直接起不来。
 ensure_backend_runtime_dependencies

--- a/tests/test_docker_entrypoint_permissions.py
+++ b/tests/test_docker_entrypoint_permissions.py
@@ -1,0 +1,172 @@
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_entrypoint_functions(tmp_path: Path) -> Path:
+    content = (ROOT / "docker" / "entrypoint.sh").read_text(encoding="utf-8")
+    marker = "# 使用env配置"
+    assert marker in content
+    functions = tmp_path / "entrypoint-functions.sh"
+    functions.write_text(content.split(marker, 1)[0], encoding="utf-8")
+    return functions
+
+
+def _write_fake_chown(tmp_path: Path) -> Path:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    chown = fake_bin / "chown"
+    chown.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            printf '%s\\n' "$*" >> "${MP_CHOWN_LOG}"
+            """
+        ),
+        encoding="utf-8",
+    )
+    chown.chmod(0o755)
+    return fake_bin
+
+
+def _run_permission_case(tmp_path: Path, body: str, env: dict[str, str] | None = None) -> str:
+    functions = _write_entrypoint_functions(tmp_path)
+    fake_bin = _write_fake_chown(tmp_path)
+    chown_log = tmp_path / "chown.log"
+    app_dir = tmp_path / "app"
+    public_dir = tmp_path / "public"
+    home_dir = tmp_path / "home"
+    (app_dir / "app" / "plugins").mkdir(parents=True)
+    public_dir.mkdir()
+    (home_dir / ".cloakbrowser").mkdir(parents=True)
+    (home_dir / "runtime").mkdir()
+    (app_dir / "app" / "plugins" / "plugin.py").write_text("# plugin\n", encoding="utf-8")
+    (public_dir / "index.html").write_text("<!doctype html>\n", encoding="utf-8")
+    (home_dir / ".cloakbrowser" / "chrome").write_text("browser cache\n", encoding="utf-8")
+    (home_dir / "runtime" / "state").write_text("state\n", encoding="utf-8")
+    external_target = tmp_path / "external-target"
+    external_target.write_text("external\n", encoding="utf-8")
+    (app_dir / "external-link").symlink_to(external_target)
+
+    case_env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "MP_CHOWN_LOG": str(chown_log),
+        "ENTRYPOINT_FUNCTIONS": str(functions),
+        "APP_DIR": str(app_dir),
+        "PUBLIC_DIR": str(public_dir),
+        "HOME_DIR": str(home_dir),
+        "CONFIG_DIR": str(tmp_path / "config"),
+        "PUID": str(os.getuid()),
+        "PGID": str(os.getgid()),
+    }
+    if env:
+        case_env.update(env)
+
+    script = textwrap.dedent(
+        f"""\
+        set -euo pipefail
+        source "${{ENTRYPOINT_FUNCTIONS}}"
+        {body}
+        """
+    )
+    subprocess.run(["bash", "-c", script], check=True, env=case_env)
+    return chown_log.read_text(encoding="utf-8") if chown_log.exists() else ""
+
+
+def test_image_paths_are_not_chowned_by_default_regardless_of_owner(tmp_path: Path) -> None:
+    log = _run_permission_case(
+        tmp_path,
+        'force_chown_image_paths_if_requested "${APP_DIR}" "${PUBLIC_DIR}"',
+        env={"PUID": "999999", "PGID": "999999"},
+    )
+
+    assert log == ""
+
+
+def test_image_paths_force_chown_uses_recursive_repair(tmp_path: Path) -> None:
+    log = _run_permission_case(
+        tmp_path,
+        'MOVIEPILOT_FORCE_CHOWN=true force_chown_image_paths_if_requested "${APP_DIR}" "${PUBLIC_DIR}"',
+    )
+
+    assert log.startswith("-R moviepilot:moviepilot ")
+    assert "/app" in log
+    assert "/public" in log
+
+
+def test_image_paths_force_chown_accepts_numeric_and_yes_values(tmp_path: Path) -> None:
+    for force_value in ("1", "YES"):
+        case_path = tmp_path / force_value.lower()
+        case_path.mkdir()
+        log = _run_permission_case(
+            case_path,
+            f'MOVIEPILOT_FORCE_CHOWN={force_value} force_chown_image_paths_if_requested "${{APP_DIR}}" "${{PUBLIC_DIR}}"',
+        )
+
+        assert log.startswith("-R moviepilot:moviepilot ")
+        assert "/app" in log
+        assert "/public" in log
+
+
+def test_plugin_directory_skips_chown_when_owner_matches(tmp_path: Path) -> None:
+    log = _run_permission_case(
+        tmp_path,
+        'chown_plugin_runtime_path "${APP_DIR}/app/plugins"',
+    )
+
+    assert log == ""
+
+
+def test_plugin_directory_chowns_only_root_directory_when_owner_mismatches(tmp_path: Path) -> None:
+    log = _run_permission_case(
+        tmp_path,
+        'chown_plugin_runtime_path "${APP_DIR}/app/plugins"',
+        env={"PUID": "999999", "PGID": "999999"},
+    )
+
+    assert log == f"-h moviepilot:moviepilot {tmp_path}/app/app/plugins\n"
+
+
+def test_home_permissions_skip_cloakbrowser_cache_by_default(tmp_path: Path) -> None:
+    log = _run_permission_case(
+        tmp_path,
+        'HOME="${HOME_DIR}" correct_home_permissions',
+    )
+
+    lines = log.splitlines()
+    assert f"moviepilot:moviepilot {tmp_path}/home" in lines
+    assert f"-h moviepilot:moviepilot {tmp_path}/home/.cloakbrowser" in lines
+    assert f"-R moviepilot:moviepilot {tmp_path}/home/runtime" in lines
+    assert not any(line.startswith("-R ") and ".cloakbrowser" in line for line in lines)
+
+
+def test_home_permissions_force_chown_repairs_cloakbrowser_cache(tmp_path: Path) -> None:
+    log = _run_permission_case(
+        tmp_path,
+        'MOVIEPILOT_FORCE_CHOWN=yes HOME="${HOME_DIR}" correct_home_permissions',
+    )
+
+    assert f"-R moviepilot:moviepilot {tmp_path}/home/.cloakbrowser" in log
+
+
+def test_runtime_writable_paths_are_still_corrected(tmp_path: Path) -> None:
+    log = _run_permission_case(
+        tmp_path,
+        'HOME="${HOME_DIR}" correct_file_permissions',
+        env={"PUID": "999999", "PGID": "999999"},
+    )
+
+    lines = log.splitlines()
+    assert f"moviepilot:moviepilot {tmp_path}/home" in lines
+    assert f"-h moviepilot:moviepilot {tmp_path}/home/.cloakbrowser" in lines
+    assert f"-R moviepilot:moviepilot {tmp_path}/home/runtime" in lines
+    assert f"-R moviepilot:moviepilot {tmp_path}/config /var/lib/nginx /var/log/nginx" in lines
+    assert "moviepilot:moviepilot /etc/hosts /tmp" in lines
+    assert not any(line.startswith("-R ") and ".cloakbrowser" in line for line in lines)
+    assert not any(f"{tmp_path}/app " in line for line in lines)
+    assert not any(f"{tmp_path}/public" in line for line in lines)


### PR DESCRIPTION
### **User description**
## 变更说明

Closes #6032。

修复 Docker 容器启动时无条件递归 `chown /app /public` 导致的长时间无日志真空期。

原 entrypoint 每次启动都会递归修复 `$HOME`、`/app`、`/public`、`$CONFIG_DIR`、nginx 目录等路径。其中 `/app` 和 `/public` 是镜像内置程序/前端资源目录，容器重建或自定义 `PUID/PGID` 时递归 `chown` 容易触发 overlayfs copy-up，导致启动前长时间无日志输出。

本 PR 调整为：

- 默认不再递归 `chown /app /public`
- 保留运行期可写目录权限修复：`$HOME`、`$CONFIG_DIR`、`/var/lib/nginx`、`/var/log/nginx`、`/etc/hosts`、`/tmp`
- `/app/app/plugins` 仅修复插件根目录本身 ownership，保证运行期可创建新插件目录，但不递归处理镜像内置插件文件
- 新增 `MOVIEPILOT_FORCE_CHOWN=false`
  - 设置为 `true` / `1` / `yes` 时，恢复旧行为，递归修复 `/app` 和 `/public`

## 兼容性说明

默认行为不再修复 `/app`、`/public` 以及镜像内置插件子目录的递归 ownership。

如遇以下场景，可临时设置：

```yaml
MOVIEPILOT_FORCE_CHOWN=true
```

启动一次后恢复默认即可：

- 曾修改过 `PUID/PGID`，已有插件目录 ownership 不一致
- 需要强制修复镜像内置插件目录权限
- 需要回退到旧的递归修复行为排查问题

该开关会重新引入较长启动耗时，仅建议临时使用。

自动更新路径已核查：`mp_update.sh` 在 `groupmod/usermod` 和 `correct_file_permissions` 前执行，仍以 root 写入 `/app`、`/public`，不依赖运行用户 ownership。

## 实测结果

启动完成判定使用日志正则，不固定端口：

```text
Application startup complete
Uvicorn running on http://0.0.0.0:[0-9]+
```

### PUID=1000 / PGID=1001

旧方案下，该场景可复现权限校正阶段长时间卡住：`find /app ... -exec chown ...` 进程等待在 `jbd2_log_wait_commit`，2 分 54 秒后仍未完成权限校正。

本 PR 后：

| 项目 | 结果 |
| --- | --- |
| 权限校正耗时 | 8 秒 |
| `/app` | 保持 `0:0` |
| `/public` | 保持 `0:0` |
| `/app/app/plugins` | `1000:1001` |
| Uvicorn | `http://0.0.0.0:3004` |
| Docker health | healthy |
| 前端访问 | HTTP 200 |

### 默认 root 场景

| 项目 | 结果 |
| --- | --- |
| 权限校正耗时 | 1 秒 |
| Uvicorn | `http://0.0.0.0:3003` |
| Docker health | healthy |
| 前端访问 | HTTP 200 |

## 验证

```bash
pytest tests/test_docker_entrypoint_permissions.py -q
bash -n docker/entrypoint.sh
bash scripts/dev/simulate_docker_package_env.sh
git diff --check
DOCKER_BUILDKIT=1 docker build -f docker/Dockerfile -t moviepilot-selective-chown:local .
```

结果：

- `tests/test_docker_entrypoint_permissions.py`：6 passed
- `bash -n docker/entrypoint.sh`：通过
- `simulate_docker_package_env.sh`：通过
- `git diff --check`：通过
- Docker build：通过

全量测试：

```bash
python tests/run.py
```

结果：

```text
1772 passed, 1 skipped, 1 failed
```

失败项为既有日期边界用例：

```text
tests/test_data_cleanup_chain.py::DataCleanupChainTest::test_transferhistory_keeps_boundary_records
```

该失败与 Docker entrypoint 权限逻辑无关。


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- 默认跳过镜像路径递归 `chown`

- 避免递归处理 `.cloakbrowser` 缓存

- 新增强制修复权限开关

- 补充入口脚本权限测试


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entrypoint.sh</strong><dd><code>优化启动权限校正避免递归阻塞</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/entrypoint.sh

<ul><li>新增 <code>MOVIEPILOT_FORCE_CHOWN</code> 默认配置。<br> <li> 默认不再递归修复 <code>/app</code>、<code>/public</code>。<br> <li> 默认跳过 <code>.cloakbrowser</code> 缓存递归 <code>chown</code>。<br> <li> 新增权限校正耗时日志与分层函数。</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6071/files#diff-4f5cabe26761257a4d685a6edc7a43e0fe0f78762f50eeb48530f2bd3b3ee7ca">+66/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_docker_entrypoint_permissions.py</strong><dd><code>覆盖 Docker 权限校正行为</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_docker_entrypoint_permissions.py

<ul><li>新增入口脚本权限函数单元测试。<br> <li> 使用伪造 <code>chown</code> 记录调用参数。<br> <li> 覆盖强制修复、插件目录和缓存跳过场景。<br> <li> 验证运行期可写路径仍被修复。</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6071/files#diff-5ae750ae44b4c58158bbda154afb02a057bb2d134994534091c181187b167504">+172/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

