### PR TITLE
fix: handle Telegram urllib3 header formatter compatibility

### DIFF
--- a/app/modules/telegram/compat.py
+++ b/app/modules/telegram/compat.py
@@ -1,0 +1,24 @@
+def ensure_urllib3_header_param_compat() -> None:
+    """
+    pyTelegramBotAPI imports urllib3.fields.format_header_param at import time.
+    Some urllib3-future builds only expose newer formatter names.
+    RFC 2231 formatting is kept as the last fallback because it encodes
+    non-ASCII values differently from urllib3's old default.
+    """
+    try:
+        from urllib3 import fields
+    except ImportError:
+        return
+
+    if hasattr(fields, "format_header_param"):
+        return
+
+    for fallback_name in (
+        "format_header_param_html5",
+        "format_multipart_header_param",
+        "format_header_param_rfc2231",
+    ):
+        fallback = getattr(fields, fallback_name, None)
+        if fallback is not None:
+            fields.format_header_param = fallback
+            return

--- a/app/modules/telegram/telegram.py
+++ b/app/modules/telegram/telegram.py
@@ -8,36 +8,41 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 from urllib.parse import urljoin, quote
 
-from telebot import TeleBot, apihelper
-from telebot.types import (
+from app.modules.telegram.compat import ensure_urllib3_header_param_compat
+
+# Must run before importing pyTelegramBotAPI.
+ensure_urllib3_header_param_compat()
+
+from telebot import TeleBot, apihelper  # noqa: E402
+from telebot.types import (  # noqa: E402
     BotCommand,
     InlineKeyboardMarkup,
     InlineKeyboardButton,
     InputMediaPhoto,
 )
 try:
-    from telebot.types import ForceReply
+    from telebot.types import ForceReply  # noqa: E402
 except ImportError:
     ForceReply = None
-from telegramify_markdown import standardize, telegramify  # noqa
+from telegramify_markdown import standardize, telegramify  # noqa: E402
 try:
-    from telegramify_markdown import entities_to_markdownv2  # noqa
+    from telegramify_markdown import entities_to_markdownv2  # noqa: E402
 except ImportError:
     entities_to_markdownv2 = None
 try:
-    from telegramify_markdown.content import ContentTypes, File, Photo, Text
+    from telegramify_markdown.content import ContentTypes, File, Photo, Text  # noqa: E402
 except ImportError:
-    from telegramify_markdown.type import ContentTypes, File, Photo, Text
+    from telegramify_markdown.type import ContentTypes, File, Photo, Text  # noqa: E402
 
-from app.core.config import settings
-from app.core.context import MediaInfo, Context
-from app.core.metainfo import MetaInfo
-from app.helper.image import ImageHelper
-from app.helper.thread import ThreadHelper
-from app.log import logger
-from app.utils.common import retry
-from app.utils.http import RequestUtils
-from app.utils.string import StringUtils
+from app.core.config import settings  # noqa: E402
+from app.core.context import MediaInfo, Context  # noqa: E402
+from app.core.metainfo import MetaInfo  # noqa: E402
+from app.helper.image import ImageHelper  # noqa: E402
+from app.helper.thread import ThreadHelper  # noqa: E402
+from app.log import logger  # noqa: E402
+from app.utils.common import retry  # noqa: E402
+from app.utils.http import RequestUtils  # noqa: E402
+from app.utils.string import StringUtils  # noqa: E402
 
 
 TELEGRAM_PARSE_MODE_MARKDOWN = "MarkdownV2"

--- a/tests/test_telegram_urllib3_compat.py
+++ b/tests/test_telegram_urllib3_compat.py
@@ -1,0 +1,112 @@
+import importlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_ensure_urllib3_header_param_compat_adds_best_available_alias(monkeypatch):
+    """urllib3 future 缺少旧别名时，应补齐最接近的新入口。"""
+    from app.modules.telegram.compat import ensure_urllib3_header_param_compat
+
+    def multipart_formatter(name, value):
+        return f"multipart:{name}={value}"
+
+    def rfc2231_formatter(name, value):
+        return f"rfc2231:{name}={value}"
+
+    fake_fields = SimpleNamespace(
+        format_multipart_header_param=multipart_formatter,
+        format_header_param_rfc2231=rfc2231_formatter,
+    )
+    fake_urllib3 = SimpleNamespace(fields=fake_fields)
+    monkeypatch.setitem(sys.modules, "urllib3", fake_urllib3)
+
+    ensure_urllib3_header_param_compat()
+
+    assert fake_fields.format_header_param is multipart_formatter
+
+
+def test_ensure_urllib3_header_param_compat_prefers_html5_formatter(monkeypatch):
+    """旧版本 urllib3 的 html5 formatter 存在时，应优先保持原别名语义。"""
+    from app.modules.telegram.compat import ensure_urllib3_header_param_compat
+
+    def html5_formatter(name, value):
+        return f"html5:{name}={value}"
+
+    def multipart_formatter(name, value):
+        return f"multipart:{name}={value}"
+
+    fake_fields = SimpleNamespace(
+        format_header_param_html5=html5_formatter,
+        format_multipart_header_param=multipart_formatter,
+    )
+    fake_urllib3 = SimpleNamespace(fields=fake_fields)
+    monkeypatch.setitem(sys.modules, "urllib3", fake_urllib3)
+
+    ensure_urllib3_header_param_compat()
+
+    assert fake_fields.format_header_param is html5_formatter
+
+
+def test_ensure_urllib3_header_param_compat_keeps_existing_formatter(monkeypatch):
+    """已有 format_header_param 时不应覆盖，避免改变 urllib3 正常行为。"""
+    from app.modules.telegram.compat import ensure_urllib3_header_param_compat
+
+    def existing_formatter(name, value):
+        return f"existing:{name}={value}"
+
+    def rfc2231_formatter(name, value):
+        return f"fallback:{name}={value}"
+
+    fake_fields = SimpleNamespace(
+        format_header_param=existing_formatter,
+        format_header_param_rfc2231=rfc2231_formatter,
+    )
+    fake_urllib3 = SimpleNamespace(fields=fake_fields)
+    monkeypatch.setitem(sys.modules, "urllib3", fake_urllib3)
+
+    ensure_urllib3_header_param_compat()
+
+    assert fake_fields.format_header_param is existing_formatter
+
+
+def test_ensure_urllib3_header_param_compat_noops_without_fallback(monkeypatch):
+    """没有任何可用 fallback 时保持 no-op，让原始导入错误暴露。"""
+    from app.modules.telegram.compat import ensure_urllib3_header_param_compat
+
+    fake_fields = SimpleNamespace()
+    fake_urllib3 = SimpleNamespace(fields=fake_fields)
+    monkeypatch.setitem(sys.modules, "urllib3", fake_urllib3)
+
+    ensure_urllib3_header_param_compat()
+
+    assert not hasattr(fake_fields, "format_header_param")
+
+
+def test_telegram_module_imports_when_urllib3_header_alias_missing(monkeypatch):
+    """导入 Telegram 模块前旧别名缺失时，应先补齐再导入 telebot。"""
+    from urllib3 import fields
+
+    if not any(
+        hasattr(fields, name)
+        for name in (
+            "format_header_param_html5",
+            "format_multipart_header_param",
+            "format_header_param_rfc2231",
+        )
+    ):
+        pytest.skip("urllib3 has no compatible header formatter fallback")
+
+    monkeypatch.delattr(fields, "format_header_param", raising=False)
+    for module_name in list(sys.modules):
+        if (
+            module_name == "app.modules.telegram.telegram"
+            or module_name.startswith("telebot")
+        ):
+            monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    telegram_module = importlib.import_module("app.modules.telegram.telegram")
+
+    assert telegram_module.Telegram
+    assert hasattr(fields, "format_header_param")


### PR DESCRIPTION
### **User description**
## 变更说明

修复 Telegram 模块在部分 urllib3-future / urllib3 组合下导入失败的问题。

现象是在导入 `telebot` 时，`pyTelegramBotAPI` 仍会访问 `urllib3.fields.format_header_param`；但部分环境里该旧别名已不存在，只保留了新的 header formatter 名称，导致 Telegram 通知模块启动前即失败。

## 修复方式

- 新增 `app.modules.telegram.compat.ensure_urllib3_header_param_compat()`。
- 在 `telegram.py` 导入 `pyTelegramBotAPI` 前执行兼容检查。
- 仅当 `urllib3.fields.format_header_param` 缺失时补齐别名，已有旧别名时不覆盖。
- fallback 顺序为 `format_header_param_html5`、`format_multipart_header_param`、`format_header_param_rfc2231`。
- 不修改依赖版本、不修改配置项、不改变 Telegram 以外的模块初始化逻辑。

边界说明：这个补丁保护 MoviePilot Telegram 模块自身的 `telebot` 导入路径；如果其他入口在 Telegram 模块之前直接导入 `telebot`，仍应在对应入口前执行同类兼容逻辑。

## 测试

已验证：

```bash
pytest tests/test_telegram_urllib3_compat.py tests/test_telegram.py -q
python -m py_compile app/modules/telegram/compat.py app/modules/telegram/telegram.py tests/test_telegram_urllib3_compat.py tests/test_telegram.py
git diff --check --cached
```

结果：`26 passed`。现有 Telegram 长文本测试仍有原本的 `.content is deprecated` warning，本 PR 未改动该行为。


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- 修复 Telegram 导入兼容

- 增加 urllib3 formatter 回退

- 添加兼容性测试覆盖


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>compat.py</strong><dd><code>新增 urllib3 头参数兼容补丁</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/modules/telegram/compat.py

<ul><li>新增 <code>ensure_urllib3_header_param_compat</code><br> <li> 缺失旧别名时注入 fallback<br> <li> 优先使用 <code>html5</code>/<code>multipart</code> formatter<br> <li> 保留无 fallback 时的原始行为</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6074/files#diff-15b4a81413685878e7b7e2bbbf4cde414227ab6487db170682fd014445141623">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>telegram.py</strong><dd><code>Telegram 导入前执行 urllib3 兼容</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/modules/telegram/telegram.py

<ul><li>在导入 <code>telebot</code> 前执行兼容检查<br> <li> 避免 <code>format_header_param</code> 缺失导致启动失败<br> <li> 为延后导入添加 <code>noqa: E402</code></ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6074/files#diff-2adc65f0078654c4472bf3d3e211ddd3548b5841e2232ffbefcb0cd3400d49dd">+22/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_telegram_urllib3_compat.py</strong><dd><code>添加 Telegram urllib3 兼容测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_telegram_urllib3_compat.py

<ul><li>覆盖 fallback 选择顺序<br> <li> 验证已有 formatter 不被覆盖<br> <li> 验证无 fallback 时保持 no-op<br> <li> 验证 Telegram 模块可正常导入</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6074/files#diff-edb69339d0a206689c04393e576a5689f0ed080ec48abf9de580a8d085dae455">+112/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

