### PR TITLE
修复 qBittorrent 已完成但未做种任务无法被识别的问题

### DIFF
--- a/app/modules/qbittorrent/qbittorrent.py
+++ b/app/modules/qbittorrent/qbittorrent.py
@@ -259,9 +259,34 @@ class Qbittorrent:
         """
         if not self.qbc:
             return None
-        # completed会包含移动状态 改为获取seeding状态 包含活动上传, 正在做种, 及强制做种
-        torrents, error = self.get_torrents(status="seeding", ids=ids, tags=tags)
-        return None if error else torrents or []
+        torrents, error = self.get_torrents(status="completed", ids=ids, tags=tags)
+        if error:
+            return None
+        ret_torrents = []
+        for torrent in torrents or []:
+            state = str(torrent.get("state") or "").strip().lower()
+            progress = torrent.get("progress") or 0
+            amount_left = torrent.get("amount_left") or 0
+            if (
+                    progress >= 1
+                    and amount_left <= 0
+                    and state not in {
+                        "allocating",
+                        "checkingdl",
+                        "checkingup",
+                        "downloading",
+                        "error",
+                        "forceddl",
+                        "missingfiles",
+                        "metadl",
+                        "moving",
+                        "queueddl",
+                        "stalleddl",
+                        "unknown",
+                    }
+            ):
+                ret_torrents.append(torrent)
+        return ret_torrents
 
     def get_downloading_torrents(self, ids: Union[str, list] = None,
                                  tags: Union[str, list] = None) -> Optional[List[TorrentDictionary]]:

--- a/tests/test_qbittorrent_compat.py
+++ b/tests/test_qbittorrent_compat.py
@@ -317,6 +317,53 @@ def test_completed_status_includes_qbittorrent_finished_upload_states():
     server.get_torrents.assert_called_once_with(tags="moviepilot-tag")
 
 
+def test_get_completed_torrents_includes_finished_stopped_tasks():
+    """
+    已完成但不再做种的 qBittorrent 任务仍应进入待整理列表。
+    """
+    fake_client = MagicMock()
+    fake_client.torrents_info.return_value = [
+        {
+            "hash": "hash-stalled-up",
+            "progress": 1,
+            "amount_left": 0,
+            "state": "stalledUP",
+        },
+        {
+            "hash": "hash-stopped-up",
+            "progress": 1,
+            "amount_left": 0,
+            "state": "stoppedUP",
+        },
+        {
+            "hash": "hash-moving",
+            "progress": 1,
+            "amount_left": 0,
+            "state": "moving",
+        },
+        {
+            "hash": "hash-metadata",
+            "progress": 0,
+            "amount_left": 0,
+            "state": "metaDL",
+        },
+        {
+            "hash": "hash-download-left",
+            "progress": 0.9,
+            "amount_left": 1024,
+            "state": "stalledDL",
+        },
+    ]
+
+    with patch.object(Qbittorrent, "_Qbittorrent__login_qbittorrent", return_value=fake_client):
+        downloader = Qbittorrent(host="http://127.0.0.1", port=8080, username="admin", password="adminadmin")
+
+    torrents = downloader.get_completed_torrents()
+
+    assert [torrent["hash"] for torrent in torrents] == ["hash-stalled-up", "hash-stopped-up"]
+    fake_client.torrents_info.assert_called_once_with(torrent_hashes=None, status_filter="completed")
+
+
 def test_list_torrents_include_all_tags_removes_builtin_tag_filter():
     """
     智能体扩大查询范围时，qBittorrent 查询应取消内置标签过滤。


### PR DESCRIPTION
### **User description**
## 摘要
- qBittorrent 完成任务检测改为查询已完成任务，而不是只查询正在做种任务。
- 过滤未完成、移动中、获取元数据中和错误状态，保留已完成但暂停或未做种的任务。
- 增加回归测试，覆盖完成后不做种的任务仍能被 MoviePilot 识别。

## 验证
- `pytest tests/test_qbittorrent_compat.py`
- `pylint app/modules/qbittorrent/qbittorrent.py`
- `git diff --check upstream/v2..HEAD`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- 识别已完成未做种任务

- 过滤未完成异常状态

- 添加 qBittorrent 回归测试


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>qbittorrent.py</strong><dd><code>完善已完成种子筛选逻辑</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/modules/qbittorrent/qbittorrent.py

<ul><li><code>get_completed_torrents</code> 改为查询 <code>completed</code> 状态。<br> <li> 通过 <code>progress</code>、<code>amount_left</code> 校验完成度。<br> <li> 排除下载、移动、校验、错误等未就绪状态。<br> <li> 保留暂停上传等已完成未做种任务。</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6076/files#diff-8871eebff9a71ce04b457b8db499406d9c7dbbb7a65229906e6af140104710ad">+28/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_qbittorrent_compat.py</strong><dd><code>增加完成未做种回归测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_qbittorrent_compat.py

<ul><li>新增已完成但停止做种任务测试。<br> <li> 覆盖 <code>stalledUP</code> 与 <code>stoppedUP</code> 状态。<br> <li> 验证移动、取元数据、未完成任务被过滤。<br> <li> 确认使用 <code>completed</code> 状态查询 qBittorrent。</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot/pull/6076/files#diff-3a8e72b4e232b162b52ae4ec527946dbc4b363a1f359738019a5da204c5eb0a9">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

