### PR TITLE
新增动漫花园 RSS 索引器

### DIFF
--- a/app/api/endpoints/site.py
+++ b/app/api/endpoints/site.py
@@ -79,6 +79,8 @@ async def add_site(
     site_in.name = site_info.get("name")
     site_in.id = None
     site_in.public = 1 if site_info.get("public") else 0
+    if "is_active" in site_info:
+        site_in.is_active = bool(site_info.get("is_active"))
     site = Site(**site_in.model_dump())
     site.create(db)
     # 通知站点更新

--- a/app/modules/indexer/__init__.py
+++ b/app/modules/indexer/__init__.py
@@ -9,6 +9,7 @@ from app.log import logger
 from app.modules import _ModuleBase
 from app.modules.indexer.parser import SiteParserBase
 from app.modules.indexer.spider import SiteSpider
+from app.modules.indexer.spider.dmhy import DMHYSpider
 from app.modules.indexer.spider.haidan import HaiDanSpider
 from app.modules.indexer.spider.hddolby import HddolbySpider
 from app.modules.indexer.spider.mtorrent import MTorrentSpider
@@ -21,6 +22,7 @@ from app.schemas.types import MediaType, ModuleType, OtherModulesType
 from app.utils.string import StringUtils
 
 SPIDER_PARSER_CLASSES = {
+    "DMHY": DMHYSpider,
     "TNodeSpider": TNodeSpider,
     "TorrentLeech": TorrentLeech,
     "mTorrent": MTorrentSpider,
@@ -264,6 +266,12 @@ class IndexerModule(_ModuleBase):
                     cat=cat,
                     page=page
                 )
+            elif site.get('parser') == "DMHY":
+                error_flag, result = DMHYSpider(site).search(
+                    keyword=search_word,
+                    mtype=mtype,
+                    page=page
+                )
             else:
                 error_flag, result = self.__spider_search(
                     search_word=search_word,
@@ -398,6 +406,12 @@ class IndexerModule(_ModuleBase):
                     keyword=search_word,
                     mtype=mtype,
                     cat=cat,
+                    page=page
+                )
+            elif site.get('parser') == "DMHY":
+                error_flag, result = await DMHYSpider(site).async_search(
+                    keyword=search_word,
+                    mtype=mtype,
                     page=page
                 )
             else:

--- a/app/modules/indexer/spider/dmhy.py
+++ b/app/modules/indexer/spider/dmhy.py
@@ -32,10 +32,6 @@ class DMHYSpider:
         self._proxy = bool(indexer.get("proxy"))
         self._ua = indexer.get("ua") or settings.USER_AGENT
         self._timeout = int(indexer.get("timeout") or 20)
-        try:
-            self._size = int(indexer.get("result_num") or self._size)
-        except (TypeError, ValueError):
-            self._size = 40
 
     @classmethod
     def get_search_page_size(cls, keyword: Optional[str] = None) -> Optional[int]:

--- a/app/modules/indexer/spider/dmhy.py
+++ b/app/modules/indexer/spider/dmhy.py
@@ -1,0 +1,208 @@
+from typing import List, Optional, Tuple
+from urllib.parse import urlencode
+
+from fastapi.concurrency import run_in_threadpool
+
+from app.core.config import settings
+from app.helper.rss import RssHelper
+from app.log import logger
+from app.schemas.types import MediaType
+
+
+class DMHYSpider:
+    """
+    动漫花园公开 RSS 搜索。
+
+    动漫花园搜索结果可通过 RSS 返回结构化的标题、详情页、发布时间和
+    magnet 链接，比 HTML 页面更适合作为 MoviePilot 索引入口。
+    """
+
+    _size = 40
+    _rss_path = "topics/rss/rss.xml"
+    _season_pack_sort_id = "31"
+    _season_pack_label = "季度全集"
+
+    def __init__(self, indexer: dict):
+        self._indexerid = indexer.get("id")
+        self._name = indexer.get("name") or "动漫花园"
+        self._domain = (
+            indexer.get("domain") or indexer.get("url") or "https://dmhy.anoneko.com/"
+        ).rstrip("/") + "/"
+        self._rss = indexer.get("rss")
+        self._proxy = bool(indexer.get("proxy"))
+        self._ua = indexer.get("ua") or settings.USER_AGENT
+        self._timeout = int(indexer.get("timeout") or 20)
+        try:
+            self._size = int(indexer.get("result_num") or self._size)
+        except (TypeError, ValueError):
+            self._size = 40
+
+    @classmethod
+    def get_search_page_size(cls, keyword: Optional[str] = None) -> Optional[int]:
+        """
+        获取搜索接口单页容量。
+        """
+        return cls._size
+
+    def __build_rss_url(
+            self, keyword: Optional[str] = None, sort_id: Optional[str] = None
+    ) -> str:
+        """
+        生成动漫花园 RSS 搜索地址。
+        """
+        base = self._rss or f"{self._domain}{self._rss_path}"
+        params = {}
+        if keyword:
+            params["keyword"] = keyword
+        if sort_id:
+            params["sort_id"] = sort_id
+        if not params:
+            return base
+        separator = "&" if "?" in base else "?"
+        return f"{base}{separator}{urlencode(params)}"
+
+    @staticmethod
+    def __format_pubdate(value):
+        """
+        将 RSS 发布时间统一转换为字符串。
+        """
+        if not value:
+            return None
+        if hasattr(value, "strftime"):
+            return value.strftime("%Y-%m-%d %H:%M:%S")
+        return str(value)
+
+    @staticmethod
+    def __normalize_size(value) -> int:
+        """
+        规范化 RSS 文件大小，忽略动漫花园 magnet 占位大小。
+        """
+        try:
+            size = int(value or 0)
+        except (TypeError, ValueError):
+            return 0
+        return size if size > 1 else 0
+
+    def __parse_items(
+            self,
+            items: list,
+            mtype: MediaType = None,
+            page: Optional[int] = 0,
+            season_pack: bool = False,
+    ) -> List[dict]:
+        """
+        解析 RSS 条目为 MoviePilot 种子字段。
+        """
+        torrents = []
+        if not items:
+            return torrents
+
+        start = max(int(page or 0), 0) * self._size
+        end = start + self._size
+        category = mtype.value if isinstance(mtype, MediaType) else MediaType.UNKNOWN.value
+
+        for item in items[start:end]:
+            title = item.get("title")
+            enclosure = item.get("enclosure")
+            if not title or not enclosure:
+                continue
+            labels = [self._season_pack_label] if season_pack else []
+            torrents.append({
+                "title": title,
+                "description": "",
+                "enclosure": enclosure,
+                "page_url": item.get("link"),
+                "pubdate": self.__format_pubdate(item.get("pubdate")),
+                "size": self.__normalize_size(item.get("size")),
+                "seeders": 0,
+                "peers": 0,
+                "grabs": 0,
+                "downloadvolumefactor": 1,
+                "uploadvolumefactor": 1,
+                "category": category,
+                "labels": labels,
+            })
+        return torrents
+
+    @staticmethod
+    def __merge_torrents(*groups: List[dict]) -> List[dict]:
+        """
+        合并不同 RSS 分类返回的重复种子，并保留补充标签。
+        """
+        merged = []
+        by_key = {}
+        for group in groups:
+            for item in group or []:
+                key = item.get("enclosure") or item.get("page_url") or item.get("title")
+                if not key:
+                    continue
+                existing = by_key.get(key)
+                if not existing:
+                    by_key[key] = item
+                    merged.append(item)
+                    continue
+                labels = list(
+                    dict.fromkeys((existing.get("labels") or []) + (item.get("labels") or []))
+                )
+                existing["labels"] = labels
+        return merged
+
+    def search(
+            self,
+            keyword: str,
+            mtype: MediaType = None,
+            page: Optional[int] = 0,
+            **kwargs,
+    ) -> Tuple[bool, List[dict]]:
+        """
+        搜索动漫花园 RSS 资源。
+        """
+        rss = RssHelper()
+        url = self.__build_rss_url(keyword)
+        items = rss.parse(
+            url=url,
+            proxy=self._proxy,
+            timeout=self._timeout,
+            ua=self._ua,
+        )
+        if items is False or items is None:
+            logger.warn(f"{self._name} RSS 搜索失败：{url}")
+            return True, []
+
+        torrents = self.__parse_items(items, mtype=mtype, page=page)
+
+        season_url = self.__build_rss_url(keyword, sort_id=self._season_pack_sort_id)
+        season_items = rss.parse(
+            url=season_url,
+            proxy=self._proxy,
+            timeout=self._timeout,
+            ua=self._ua,
+        )
+        if season_items is False or season_items is None:
+            logger.warn(f"{self._name} 季度全集 RSS 补充搜索失败：{season_url}")
+            return False, torrents
+
+        season_torrents = self.__parse_items(
+            season_items,
+            mtype=mtype,
+            page=page,
+            season_pack=True,
+        )
+        return False, self.__merge_torrents(torrents, season_torrents)
+
+    async def async_search(
+            self,
+            keyword: str,
+            mtype: MediaType = None,
+            page: Optional[int] = 0,
+            **kwargs,
+    ) -> Tuple[bool, List[dict]]:
+        """
+        异步搜索动漫花园 RSS 资源。
+        """
+        return await run_in_threadpool(
+            self.search,
+            keyword=keyword,
+            mtype=mtype,
+            page=page,
+        )

--- a/app/modules/indexer/spider/dmhy.py
+++ b/app/modules/indexer/spider/dmhy.py
@@ -1,5 +1,5 @@
 from typing import List, Optional, Tuple
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urljoin
 
 from fastapi.concurrency import run_in_threadpool
 
@@ -25,13 +25,34 @@ class DMHYSpider:
     def __init__(self, indexer: dict):
         self._indexerid = indexer.get("id")
         self._name = indexer.get("name") or "动漫花园"
-        self._domain = (
-            indexer.get("domain") or indexer.get("url") or "https://dmhy.anoneko.com/"
-        ).rstrip("/") + "/"
-        self._rss = indexer.get("rss")
+        self._domain = self.__normalize_base_url(
+            indexer.get("url") or indexer.get("domain")
+        )
+        self._rss = self.__normalize_rss_url(indexer.get("rss"))
         self._proxy = bool(indexer.get("proxy"))
         self._ua = indexer.get("ua") or settings.USER_AGENT
         self._timeout = int(indexer.get("timeout") or 20)
+
+    @staticmethod
+    def __normalize_base_url(value: Optional[str]) -> str:
+        """
+        补齐站点基址协议并统一保留结尾斜杠。
+        """
+        base_url = str(value or "https://dmhy.anoneko.com/").strip()
+        if not base_url.startswith(("http://", "https://")):
+            base_url = f"https://{base_url}"
+        return base_url.rstrip("/") + "/"
+
+    def __normalize_rss_url(self, value: Optional[str]) -> Optional[str]:
+        """
+        将相对 RSS 地址补齐为完整 URL。
+        """
+        rss_url = str(value or "").strip()
+        if not rss_url:
+            return None
+        if rss_url.startswith(("http://", "https://")):
+            return rss_url
+        return urljoin(self._domain, rss_url)
 
     @classmethod
     def get_search_page_size(cls, keyword: Optional[str] = None) -> Optional[int]:

--- a/tests/test_dmhy_spider.py
+++ b/tests/test_dmhy_spider.py
@@ -109,6 +109,35 @@ def test_dmhy_spider_search_returns_primary_results_when_season_pack_fails(monke
     assert torrents[0]["seeders"] == 0
 
 
+def test_dmhy_spider_uses_fixed_rss_page_size_when_result_num_is_configured(monkeypatch):
+    """
+    动漫花园 RSS 页容量固定，不能被站点 result_num 改写。
+    """
+
+    def fake_parse(self, url, **kwargs):
+        query = parse_qs(urlparse(url).query)
+        if query.get("sort_id") == ["31"]:
+            return []
+        return [
+            {
+                "title": f"测试动画第{index}集",
+                "enclosure": f"magnet:?xt=urn:btih:episode{index}",
+                "size": "1",
+            }
+            for index in range(45)
+        ]
+
+    monkeypatch.setattr("app.modules.indexer.spider.dmhy.RssHelper.parse", fake_parse)
+
+    error, torrents = DMHYSpider(_indexer(result_num=2)).search(keyword="测试动画")
+
+    assert not error
+    assert len(torrents) == 40
+    assert IndexerModule.get_search_page_size(
+        {"parser": "DMHY", "result_num": 2}, keyword="测试"
+    ) == 40
+
+
 def test_indexer_module_registers_dmhy_parser():
     """
     验证索引模块已注册动漫花园专用解析器。

--- a/tests/test_dmhy_spider.py
+++ b/tests/test_dmhy_spider.py
@@ -109,6 +109,54 @@ def test_dmhy_spider_search_returns_primary_results_when_season_pack_fails(monke
     assert torrents[0]["seeders"] == 0
 
 
+def test_dmhy_spider_prefers_url_and_normalizes_relative_rss(monkeypatch):
+    """
+    站点 domain 为裸域时，应优先使用完整 url 并补齐相对 RSS 地址。
+    """
+    calls = []
+
+    def fake_parse(self, url, **kwargs):
+        calls.append(url)
+        return []
+
+    monkeypatch.setattr("app.modules.indexer.spider.dmhy.RssHelper.parse", fake_parse)
+
+    error, torrents = DMHYSpider(
+        _indexer(
+            domain="anoneko.com",
+            url="https://dmhy.anoneko.com/",
+            rss="/topics/rss/rss.xml",
+        )
+    ).search(keyword="测试 动画")
+
+    assert not error
+    assert torrents == []
+    assert calls[0].startswith("https://dmhy.anoneko.com/topics/rss/rss.xml?")
+    assert parse_qs(urlparse(calls[0]).query)["keyword"] == ["测试 动画"]
+    assert parse_qs(urlparse(calls[1]).query)["sort_id"] == ["31"]
+
+
+def test_dmhy_spider_adds_scheme_to_bare_domain(monkeypatch):
+    """
+    只有裸域名时，应补齐 https 协议后生成 RSS 地址。
+    """
+    calls = []
+
+    def fake_parse(self, url, **kwargs):
+        calls.append(url)
+        return []
+
+    monkeypatch.setattr("app.modules.indexer.spider.dmhy.RssHelper.parse", fake_parse)
+
+    error, torrents = DMHYSpider(
+        _indexer(domain="dmhy.anoneko.com", url=None, rss=None)
+    ).search(keyword="测试")
+
+    assert not error
+    assert torrents == []
+    assert calls[0].startswith("https://dmhy.anoneko.com/topics/rss/rss.xml?")
+
+
 def test_dmhy_spider_uses_fixed_rss_page_size_when_result_num_is_configured(monkeypatch):
     """
     动漫花园 RSS 页容量固定，不能被站点 result_num 改写。

--- a/tests/test_dmhy_spider.py
+++ b/tests/test_dmhy_spider.py
@@ -1,0 +1,116 @@
+from datetime import datetime
+from urllib.parse import parse_qs, urlparse
+
+from app.modules.indexer import IndexerModule
+from app.modules.indexer.spider.dmhy import DMHYSpider
+from app.schemas.types import MediaType
+
+
+def _indexer(**kwargs):
+    """
+    构造动漫花园测试索引器。
+    """
+    data = {
+        "id": 1,
+        "name": "动漫花园",
+        "domain": "https://dmhy.anoneko.com/",
+        "parser": "DMHY",
+        "result_num": 40,
+        "timeout": 15,
+    }
+    data.update(kwargs)
+    return data
+
+
+def test_dmhy_spider_search_merges_default_and_season_pack_rss(monkeypatch):
+    """
+    验证搜索会合并普通 RSS 和季度全集 RSS，并对重复种子补充标签。
+    """
+    calls = []
+
+    def fake_parse(self, url, **kwargs):
+        """
+        按 URL 返回不同 RSS 条目。
+        """
+        calls.append((url, kwargs))
+        query = parse_qs(urlparse(url).query)
+        if query.get("sort_id") == ["31"]:
+            return [
+                {
+                    "title": "测试动画季度全集",
+                    "enclosure": "magnet:?xt=urn:btih:season",
+                    "link": "https://dmhy.anoneko.com/topics/view/2.html",
+                    "size": "1",
+                    "pubdate": datetime(2026, 7, 8, 1, 2, 3),
+                },
+                {
+                    "title": "测试动画第一集",
+                    "enclosure": "magnet:?xt=urn:btih:episode",
+                    "link": "https://dmhy.anoneko.com/topics/view/1.html",
+                    "size": "1",
+                },
+            ]
+        return [
+            {
+                "title": "测试动画第一集",
+                "enclosure": "magnet:?xt=urn:btih:episode",
+                "link": "https://dmhy.anoneko.com/topics/view/1.html",
+                "size": "1",
+            }
+        ]
+
+    monkeypatch.setattr("app.modules.indexer.spider.dmhy.RssHelper.parse", fake_parse)
+
+    error, torrents = DMHYSpider(_indexer()).search(
+        keyword="测试 动画",
+        mtype=MediaType.TV,
+    )
+
+    assert not error
+    assert [torrent["title"] for torrent in torrents] == ["测试动画第一集", "测试动画季度全集"]
+    assert torrents[0]["labels"] == ["季度全集"]
+    assert torrents[0]["size"] == 0
+    assert torrents[1]["pubdate"] == "2026-07-08 01:02:03"
+    assert torrents[1]["category"] == MediaType.TV.value
+    assert len(calls) == 2
+    assert parse_qs(urlparse(calls[0][0]).query)["keyword"] == ["测试 动画"]
+    assert parse_qs(urlparse(calls[1][0]).query)["sort_id"] == ["31"]
+
+
+def test_dmhy_spider_search_returns_primary_results_when_season_pack_fails(monkeypatch):
+    """
+    验证季度全集补充搜索失败时，普通搜索结果仍可返回。
+    """
+
+    def fake_parse(self, url, **kwargs):
+        """
+        模拟季度全集 RSS 请求失败。
+        """
+        query = parse_qs(urlparse(url).query)
+        if query.get("sort_id") == ["31"]:
+            return False
+        return [
+            {
+                "title": "测试动画第一集",
+                "enclosure": "magnet:?xt=urn:btih:episode",
+                "description": "<p>很长的发布正文</p>",
+                "size": 12345,
+            }
+        ]
+
+    monkeypatch.setattr("app.modules.indexer.spider.dmhy.RssHelper.parse", fake_parse)
+
+    error, torrents = DMHYSpider(_indexer()).search(keyword="测试动画")
+
+    assert not error
+    assert len(torrents) == 1
+    assert torrents[0]["description"] == ""
+    assert torrents[0]["size"] == 12345
+    assert torrents[0]["seeders"] == 0
+
+
+def test_indexer_module_registers_dmhy_parser():
+    """
+    验证索引模块已注册动漫花园专用解析器。
+    """
+    assert IndexerModule.get_search_page_size({"parser": "DMHY"}, keyword="测试") == 40

--- a/tests/test_site_cookie_endpoint.py
+++ b/tests/test_site_cookie_endpoint.py
@@ -1,8 +1,15 @@
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
 
 from app import schemas
 from app.api.endpoints import site as site_endpoint
+
+
+@pytest.fixture()
+def anyio_backend():
+    return "asyncio"
 
 
 def test_update_cookie_by_body_uses_request_body():
@@ -62,3 +69,52 @@ def test_update_cookie_legacy_get_keeps_query_params():
         password="password",
         two_step_code=None,
     )
+
+
+@pytest.mark.anyio
+async def test_add_site_honors_indexer_default_disabled_status(monkeypatch):
+    """
+    资源包声明默认关闭时，新增站点应保存为未启用。
+    """
+    created_site = {}
+
+    class FakeSitesHelper:
+        auth_level = 2
+
+        async def async_get_indexer(self, domain):
+            assert domain == "anoneko.com"
+            return {
+                "name": "动漫花园",
+                "public": True,
+                "is_active": False,
+            }
+
+    class FakeSite:
+        @staticmethod
+        async def async_get_by_domain(db, domain):
+            assert domain == "anoneko.com"
+            return None
+
+        def __init__(self, **kwargs):
+            created_site.update(kwargs)
+
+        def create(self, db):
+            created_site["created"] = True
+
+    send_event = AsyncMock()
+    monkeypatch.setattr(site_endpoint, "SitesHelper", FakeSitesHelper)
+    monkeypatch.setattr(site_endpoint, "Site", FakeSite)
+    monkeypatch.setattr(site_endpoint.eventmanager, "async_send_event", send_event)
+
+    response = await site_endpoint.add_site(
+        db=Mock(),
+        site_in=schemas.Site(url="https://dmhy.anoneko.com/"),
+        _=Mock(),
+    )
+
+    assert response.success is True
+    assert created_site["name"] == "动漫花园"
+    assert created_site["public"] == 1
+    assert created_site["is_active"] is False
+    assert created_site["created"] is True
+    send_event.assert_awaited_once()


### PR DESCRIPTION
## 变更
- 新增动漫花园公开 RSS 索引器，支持 `parser: DMHY` 搜索 magnet 资源。
- 普通 RSS 搜索会合并“季度全集”分类结果，并对重复种子补充“季度全集”标签。
- 动漫花园 RSS 使用固定页容量，避免与索引模块分页判断不一致。
- 动漫花园 RSS 地址会优先使用站点完整 `url`，并补齐裸域协议与相对 RSS 路径。
- 新增站点时支持资源包声明 `is_active: false`，便于将动漫花园默认保持关闭。

## 边界
本次只增加索引器解析能力，不包含任何用户私有站点配置、Cookie、下载器路径或本地资源包内容。站点清单是否新增动漫花园及其默认关闭状态由资源包提供。

## 验证
- `venv/Scripts/python.exe -m pytest tests/test_dmhy_spider.py tests/test_site_cookie_endpoint.py tests/test_search_ai_recommend.py::SearchChainAIRecommendTest::test_indexer_module_search_page_size_uses_spider_metadata`：10 passed
- `venv/Scripts/python.exe -m pylint app/modules/indexer/spider/dmhy.py app/modules/indexer/__init__.py app/api/endpoints/site.py tests/test_dmhy_spider.py tests/test_site_cookie_endpoint.py`：10.00/10
- `git diff --check`
- `git diff --cached --check`
- 敏感信息扫描无命中