### PR TITLE
新增搜索结果磁力探测接口

### DIFF
--- a/app/api/endpoints/search.py
+++ b/app/api/endpoints/search.py
@@ -35,6 +35,9 @@ _PROBE_MAX_TIMEOUT = 60
 _PROBE_SPEED_LIMIT = 1024
 _PROBE_TAG_RETRY_TIMES = 10
 _PROBE_TAG_RETRY_INTERVAL = 1
+_PROBE_MAX_CONCURRENCY = 4
+_PROBE_QUEUE_TIMEOUT = 5
+_PROBE_SEMAPHORE = asyncio.Semaphore(_PROBE_MAX_CONCURRENCY)
 
 
 def _parse_site_list(sites: Optional[str]) -> Optional[List[int]]:
@@ -83,6 +86,16 @@ def _extract_btih(value: str) -> Optional[str]:
     except Exception as err:
         logger.debug(f"解析磁力链接 hash 失败：{err}")
     return None
+
+
+def _sanitize_probe_magnet(value: str) -> Optional[str]:
+    """
+    仅保留探测所需的 btih，避免让下载器访问用户传入的 tracker/webseed 地址。
+    """
+    info_hash = _extract_btih(value)
+    if not info_hash:
+        return None
+    return f"magnet:?xt=urn:btih:{info_hash}"
 
 
 def _as_int(value: Any, default: int = 0) -> int:
@@ -251,13 +264,17 @@ def _probe_magnet(enclosure: str, downloader: Optional[str], timeout: int) -> di
     if not enclosure or not enclosure.startswith("magnet:"):
         return {"success": False, "message": "只支持 magnet 链接探测"}
 
+    safe_enclosure = _sanitize_probe_magnet(enclosure)
+    if not safe_enclosure:
+        return {"success": False, "message": "无法解析 magnet 链接中的 btih"}
+    expected_hash = _extract_btih(safe_enclosure)
+
     module = QbittorrentModule()
     module.init_module()
     server = module.get_instance(downloader)
     if not server:
         return {"success": False, "message": "未找到可用的 qBittorrent 下载器"}
 
-    expected_hash = _extract_btih(enclosure)
     if expected_hash:
         existing_torrent = _get_first_torrent(server, hash_id=expected_hash)
         if existing_torrent:
@@ -280,7 +297,7 @@ def _probe_magnet(enclosure: str, downloader: Optional[str], timeout: int) -> di
 
     try:
         state, added_ids = server.add_torrent(
-            content=enclosure,
+            content=safe_enclosure,
             is_paused=False,
             tag=[tag],
             dl_limit=_PROBE_SPEED_LIMIT,
@@ -333,7 +350,7 @@ def _probe_magnet(enclosure: str, downloader: Optional[str], timeout: int) -> di
         message = (
             "探测完成"
             if data.get("has_metadata")
-            else "未获取到文件大小，已返回可用的 tracker 健康度"
+            else "未获取到文件大小，已返回可用的健康度信息"
         )
         result = {"success": True, "message": message, "data": data}
         return result
@@ -551,7 +568,15 @@ async def probe_search_torrent(
     enclosure = payload.get("enclosure") or payload.get("magnet")
     downloader = payload.get("downloader")
     timeout = _parse_probe_timeout(payload.get("timeout"))
-    result = await run_in_threadpool(_probe_magnet, enclosure, downloader, timeout)
+    try:
+        await asyncio.wait_for(_PROBE_SEMAPHORE.acquire(), _PROBE_QUEUE_TIMEOUT)
+    except asyncio.TimeoutError:
+        result = {"success": False, "message": "探测任务繁忙，请稍后再试"}
+    else:
+        try:
+            result = await run_in_threadpool(_probe_magnet, enclosure, downloader, timeout)
+        finally:
+            _PROBE_SEMAPHORE.release()
     return schemas.Response(
         success=bool(result.get("success")),
         message=result.get("message"),

--- a/app/api/endpoints/search.py
+++ b/app/api/endpoints/search.py
@@ -33,6 +33,8 @@ _PROBE_TAG_PREFIX = "MP_PROBE"
 _PROBE_DEFAULT_TIMEOUT = 30
 _PROBE_MAX_TIMEOUT = 60
 _PROBE_SPEED_LIMIT = 1024
+_PROBE_TAG_RETRY_TIMES = 10
+_PROBE_TAG_RETRY_INTERVAL = 1
 
 
 def _parse_site_list(sites: Optional[str]) -> Optional[List[int]]:
@@ -175,6 +177,67 @@ def _get_first_torrent(
     return torrents[0]
 
 
+def _torrent_has_tag(torrent: Optional[dict], tag: str) -> bool:
+    """
+    判断种子是否带有本次探测唯一标签。
+    """
+    if not torrent or not tag:
+        return False
+    tags = torrent.get("tags") or []
+    if isinstance(tags, str):
+        tags = tags.split(",")
+    return tag in {str(item).strip() for item in tags if item}
+
+
+def _find_probe_torrent(
+    server,
+    *,
+    tag: str,
+    hash_id: Optional[str] = None,
+    retry: int = 1,
+    interval: float = 0,
+) -> Optional[dict]:
+    """
+    按唯一探测标签查找任务，不移除标签，便于后续安全清理。
+    """
+    for index in range(max(retry, 1)):
+        torrent = None
+        if hash_id:
+            torrent = _get_first_torrent(server, hash_id=hash_id)
+            if torrent and not _torrent_has_tag(torrent, tag):
+                torrent = None
+        if not torrent:
+            torrent = _get_first_torrent(server, tag=tag)
+            if (
+                torrent
+                and hash_id
+                and str(torrent.get("hash", "")).lower() != hash_id.lower()
+            ):
+                torrent = None
+        if torrent:
+            return torrent
+        if index + 1 < retry and interval > 0:
+            time.sleep(interval)
+    return None
+
+
+def _cleanup_probe_torrent(server, *, tag: str, hash_id: Optional[str]) -> bool:
+    """
+    删除探测任务前重新确认唯一标签，避免误删已有任务。
+    """
+    torrent = _find_probe_torrent(server, tag=tag, hash_id=hash_id)
+    if not torrent:
+        return False
+    cleanup_hash = torrent.get("hash")
+    if not cleanup_hash:
+        return False
+    try:
+        return server.delete_torrents(delete_file=True, ids=cleanup_hash)
+    except Exception as err:
+        logger.warning(f"清理临时探测任务失败：{cleanup_hash} - {err}")
+        return False
+
+
 def _probe_magnet(enclosure: str, downloader: Optional[str], timeout: int) -> dict:
     """
     使用 qBittorrent 临时添加 magnet，读取 metadata/tracker 健康度后立即清理。
@@ -235,9 +298,16 @@ def _probe_magnet(enclosure: str, downloader: Optional[str], timeout: int) -> di
             return {"success": False, "message": "添加临时探测任务失败"}
 
         added_by_probe = True
-        hash_id = next(iter(added_ids or []), None) or server.get_torrent_id_by_tag(
-            tags=tag
-        )
+        hash_id = next(iter(added_ids or []), None)
+        if not hash_id:
+            probe_torrent = _find_probe_torrent(
+                server,
+                tag=tag,
+                hash_id=expected_hash,
+                retry=_PROBE_TAG_RETRY_TIMES,
+                interval=_PROBE_TAG_RETRY_INTERVAL,
+            )
+            hash_id = probe_torrent.get("hash") if probe_torrent else None
         if not hash_id:
             return {"success": False, "message": "临时探测任务已添加，但未获取到任务 hash"}
 
@@ -263,11 +333,7 @@ def _probe_magnet(enclosure: str, downloader: Optional[str], timeout: int) -> di
         return result
     finally:
         if added_by_probe and hash_id:
-            try:
-                cleanup = server.delete_torrents(delete_file=True, ids=hash_id)
-            except Exception as err:
-                cleanup = False
-                logger.warning(f"清理临时探测任务失败：{hash_id} - {err}")
+            cleanup = _cleanup_probe_torrent(server, tag=tag, hash_id=hash_id)
             if result and isinstance(result.get("data"), dict):
                 result["data"]["cleanup"] = cleanup
 

--- a/app/api/endpoints/search.py
+++ b/app/api/endpoints/search.py
@@ -225,7 +225,13 @@ def _cleanup_probe_torrent(server, *, tag: str, hash_id: Optional[str]) -> bool:
     """
     删除探测任务前重新确认唯一标签，避免误删已有任务。
     """
-    torrent = _find_probe_torrent(server, tag=tag, hash_id=hash_id)
+    torrent = _find_probe_torrent(
+        server,
+        tag=tag,
+        hash_id=hash_id,
+        retry=_PROBE_TAG_RETRY_TIMES if not hash_id else 1,
+        interval=_PROBE_TAG_RETRY_INTERVAL,
+    )
     if not torrent:
         return False
     cleanup_hash = torrent.get("hash")
@@ -332,7 +338,7 @@ def _probe_magnet(enclosure: str, downloader: Optional[str], timeout: int) -> di
         result = {"success": True, "message": message, "data": data}
         return result
     finally:
-        if added_by_probe and hash_id:
+        if added_by_probe:
             cleanup = _cleanup_probe_torrent(server, tag=tag, hash_id=hash_id)
             if result and isinstance(result.get("data"), dict):
                 result["data"]["cleanup"] = cleanup

--- a/app/api/endpoints/search.py
+++ b/app/api/endpoints/search.py
@@ -273,7 +273,7 @@ def _probe_magnet(enclosure: str, downloader: Optional[str], timeout: int) -> di
     """
     使用 qBittorrent 临时添加 magnet，读取 metadata/tracker 健康度后立即清理。
     """
-    if not enclosure or not enclosure.startswith("magnet:"):
+    if not isinstance(enclosure, str) or not enclosure.startswith("magnet:"):
         return {"success": False, "message": "只支持 magnet 链接探测"}
 
     safe_enclosure = _sanitize_probe_magnet(enclosure)

--- a/app/api/endpoints/search.py
+++ b/app/api/endpoints/search.py
@@ -30,6 +30,7 @@ router = APIRouter()
 _SSE_APPEND_FLUSH_INTERVAL = 1
 _SSE_APPEND_MAX_ITEMS = 48
 _PROBE_TAG_PREFIX = "MP_PROBE"
+_PROBE_CATEGORY = "MP_PROBE"
 _PROBE_DEFAULT_TIMEOUT = 30
 _PROBE_MAX_TIMEOUT = 60
 _PROBE_SPEED_LIMIT = 1024
@@ -202,6 +203,15 @@ def _torrent_has_tag(torrent: Optional[dict], tag: str) -> bool:
     return tag in {str(item).strip() for item in tags if item}
 
 
+def _torrent_has_probe_category(torrent: Optional[dict]) -> bool:
+    """
+    判断任务是否属于磁力探测专用分类。
+    """
+    if not torrent:
+        return False
+    return str(torrent.get("category") or "") == _PROBE_CATEGORY
+
+
 def _find_probe_torrent(
     server,
     *,
@@ -247,6 +257,8 @@ def _cleanup_probe_torrent(server, *, tag: str, hash_id: Optional[str]) -> bool:
     )
     if not torrent:
         return False
+    if not _torrent_has_probe_category(torrent):
+        return False
     cleanup_hash = torrent.get("hash")
     if not cleanup_hash:
         return False
@@ -278,15 +290,9 @@ def _probe_magnet(enclosure: str, downloader: Optional[str], timeout: int) -> di
     if expected_hash:
         existing_torrent = _get_first_torrent(server, hash_id=expected_hash)
         if existing_torrent:
-            data = _build_probe_payload(
-                existing_torrent,
-                existing=True,
-                timed_out=False,
-            )
             return {
-                "success": True,
-                "message": "该任务已在下载器中，已读取现有状态",
-                "data": data,
+                "success": False,
+                "message": "无法创建临时探测任务",
             }
 
     tag = f"{_PROBE_TAG_PREFIX}_{uuid.uuid4().hex[:12]}"
@@ -300,6 +306,7 @@ def _probe_magnet(enclosure: str, downloader: Optional[str], timeout: int) -> di
             content=safe_enclosure,
             is_paused=False,
             tag=[tag],
+            category=_PROBE_CATEGORY,
             dl_limit=_PROBE_SPEED_LIMIT,
             up_limit=_PROBE_SPEED_LIMIT,
             stop_condition="MetadataReceived",
@@ -308,15 +315,9 @@ def _probe_magnet(enclosure: str, downloader: Optional[str], timeout: int) -> di
             if expected_hash:
                 existing_torrent = _get_first_torrent(server, hash_id=expected_hash)
                 if existing_torrent:
-                    data = _build_probe_payload(
-                        existing_torrent,
-                        existing=True,
-                        timed_out=False,
-                    )
                     return {
-                        "success": True,
-                        "message": "该任务已在下载器中，已读取现有状态",
-                        "data": data,
+                        "success": False,
+                        "message": "无法创建临时探测任务",
                     }
             return {"success": False, "message": "添加临时探测任务失败"}
 

--- a/app/api/endpoints/search.py
+++ b/app/api/endpoints/search.py
@@ -1,8 +1,14 @@
 import asyncio
+import base64
 import json
+import re
+import time
+import uuid
 from typing import List, Any, Optional, AsyncIterator
+from urllib.parse import parse_qs, urlparse
 
 from fastapi import APIRouter, Depends, Body, Request
+from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import StreamingResponse
 
 from app import schemas
@@ -14,6 +20,7 @@ from app.core.metainfo import MetaInfo
 from app.core.security import verify_resource_token, verify_token
 from app.helper.locale import LocaleHelper
 from app.log import logger
+from app.modules.qbittorrent import QbittorrentModule
 from app.schemas import MediaRecognizeConvertEventData
 from app.schemas.types import MediaType, ChainEventType
 from app.utils.security import SecurityUtils
@@ -22,6 +29,10 @@ router = APIRouter()
 
 _SSE_APPEND_FLUSH_INTERVAL = 1
 _SSE_APPEND_MAX_ITEMS = 48
+_PROBE_TAG_PREFIX = "MP_PROBE"
+_PROBE_DEFAULT_TIMEOUT = 30
+_PROBE_MAX_TIMEOUT = 60
+_PROBE_SPEED_LIMIT = 1024
 
 
 def _parse_site_list(sites: Optional[str]) -> Optional[List[int]]:
@@ -38,6 +49,227 @@ def _parse_media_type(mtype: Optional[str]) -> Optional[MediaType]:
     if not mtype:
         return None
     return MediaType.from_agent(mtype) or MediaType(mtype)
+
+
+def _parse_probe_timeout(value: Any) -> int:
+    """
+    解析磁力探测超时时间，避免单次请求长时间占用后端线程。
+    """
+    try:
+        timeout = int(value or _PROBE_DEFAULT_TIMEOUT)
+    except (TypeError, ValueError):
+        timeout = _PROBE_DEFAULT_TIMEOUT
+    return max(5, min(timeout, _PROBE_MAX_TIMEOUT))
+
+
+def _extract_btih(value: str) -> Optional[str]:
+    """
+    从 magnet 链接中提取 qBittorrent 使用的 v1 info hash。
+    """
+    if not value or not value.startswith("magnet:"):
+        return None
+    try:
+        xt_values = parse_qs(urlparse(value).query).get("xt") or []
+        for xt in xt_values:
+            if not xt.lower().startswith("urn:btih:"):
+                continue
+            info_hash = xt.rsplit(":", 1)[-1].strip()
+            if re.fullmatch(r"[0-9a-fA-F]{40}", info_hash):
+                return info_hash.lower()
+            if re.fullmatch(r"[A-Z2-7a-z]{32}", info_hash):
+                return base64.b32decode(info_hash.upper()).hex()
+    except Exception as err:
+        logger.debug(f"解析磁力链接 hash 失败：{err}")
+    return None
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    """
+    将 qBittorrent 返回值安全转为整数。
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_float(value: Any, default: float = 0) -> float:
+    """
+    将 qBittorrent 返回值安全转为浮点数。
+    """
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _pick_torrent_size(torrent: dict) -> int:
+    """
+    qB 在 magnet 未拿到 metadata 前 total_size 可能是 -1，部分索引器也会使用 1B 占位。
+    """
+    total_size = _as_int(torrent.get("total_size"), -1)
+    if total_size > 1:
+        return total_size
+    size = _as_int(torrent.get("size"), 0)
+    return size if size > 1 else 0
+
+
+def _build_probe_payload(
+    torrent: Optional[dict],
+    *,
+    existing: bool,
+    timed_out: bool,
+    cleanup: Optional[bool] = None,
+) -> dict:
+    """
+    构造前端可直接回填搜索卡片的探测结果。
+    """
+    if not torrent:
+        return {
+            "existing": existing,
+            "timed_out": timed_out,
+            "cleanup": cleanup,
+            "has_metadata": False,
+            "size": 0,
+            "seeders": 0,
+            "peers": 0,
+        }
+
+    connected_seeders = _as_int(torrent.get("num_seeds"))
+    reported_seeders = _as_int(torrent.get("num_complete"))
+    connected_peers = _as_int(torrent.get("num_leechs"))
+    reported_peers = _as_int(torrent.get("num_incomplete"))
+    torrent_size = _pick_torrent_size(torrent)
+    has_metadata = bool(torrent.get("has_metadata")) or torrent_size > 0
+    return {
+        "existing": existing,
+        "timed_out": timed_out,
+        "cleanup": cleanup,
+        "hash": torrent.get("hash"),
+        "name": torrent.get("name"),
+        "state": torrent.get("state"),
+        "has_metadata": has_metadata,
+        "size": torrent_size,
+        "seeders": max(connected_seeders, reported_seeders),
+        "peers": max(connected_peers, reported_peers),
+        "connected_seeders": connected_seeders,
+        "reported_seeders": reported_seeders,
+        "connected_peers": connected_peers,
+        "reported_peers": reported_peers,
+        "availability": _as_float(torrent.get("availability")),
+    }
+
+
+def _get_first_torrent(
+    server,
+    *,
+    hash_id: Optional[str] = None,
+    tag: Optional[str] = None,
+) -> Optional[dict]:
+    """
+    从 qB 查询单个探测任务。
+    """
+    torrents, error = server.get_torrents(ids=hash_id, tags=tag)
+    if error or not torrents:
+        return None
+    return torrents[0]
+
+
+def _probe_magnet(enclosure: str, downloader: Optional[str], timeout: int) -> dict:
+    """
+    使用 qBittorrent 临时添加 magnet，读取 metadata/tracker 健康度后立即清理。
+    """
+    if not enclosure or not enclosure.startswith("magnet:"):
+        return {"success": False, "message": "只支持 magnet 链接探测"}
+
+    module = QbittorrentModule()
+    module.init_module()
+    server = module.get_instance(downloader)
+    if not server:
+        return {"success": False, "message": "未找到可用的 qBittorrent 下载器"}
+
+    expected_hash = _extract_btih(enclosure)
+    if expected_hash:
+        existing_torrent = _get_first_torrent(server, hash_id=expected_hash)
+        if existing_torrent:
+            data = _build_probe_payload(
+                existing_torrent,
+                existing=True,
+                timed_out=False,
+            )
+            return {
+                "success": True,
+                "message": "该任务已在下载器中，已读取现有状态",
+                "data": data,
+            }
+
+    tag = f"{_PROBE_TAG_PREFIX}_{uuid.uuid4().hex[:12]}"
+    hash_id = None
+    added_by_probe = False
+    last_torrent = None
+    result = None
+
+    try:
+        state, added_ids = server.add_torrent(
+            content=enclosure,
+            is_paused=False,
+            tag=[tag],
+            dl_limit=_PROBE_SPEED_LIMIT,
+            up_limit=_PROBE_SPEED_LIMIT,
+            stop_condition="MetadataReceived",
+        )
+        if not state:
+            if expected_hash:
+                existing_torrent = _get_first_torrent(server, hash_id=expected_hash)
+                if existing_torrent:
+                    data = _build_probe_payload(
+                        existing_torrent,
+                        existing=True,
+                        timed_out=False,
+                    )
+                    return {
+                        "success": True,
+                        "message": "该任务已在下载器中，已读取现有状态",
+                        "data": data,
+                    }
+            return {"success": False, "message": "添加临时探测任务失败"}
+
+        added_by_probe = True
+        hash_id = next(iter(added_ids or []), None) or server.get_torrent_id_by_tag(
+            tags=tag
+        )
+        if not hash_id:
+            return {"success": False, "message": "临时探测任务已添加，但未获取到任务 hash"}
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            last_torrent = _get_first_torrent(server, hash_id=hash_id)
+            if last_torrent and _pick_torrent_size(last_torrent) > 0:
+                break
+            time.sleep(2)
+
+        timed_out = not last_torrent or _pick_torrent_size(last_torrent) <= 0
+        data = _build_probe_payload(
+            last_torrent,
+            existing=False,
+            timed_out=timed_out,
+        )
+        message = (
+            "探测完成"
+            if data.get("has_metadata")
+            else "未获取到文件大小，已返回可用的 tracker 健康度"
+        )
+        result = {"success": True, "message": message, "data": data}
+        return result
+    finally:
+        if added_by_probe and hash_id:
+            try:
+                cleanup = server.delete_torrents(delete_file=True, ids=hash_id)
+            except Exception as err:
+                cleanup = False
+                logger.warning(f"清理临时探测任务失败：{hash_id} - {err}")
+            if result and isinstance(result.get("data"), dict):
+                result["data"]["cleanup"] = cleanup
 
 
 def _sse_event(data: dict, locale: Optional[str] = None) -> str:
@@ -232,6 +464,26 @@ async def search_latest_context(_: schemas.TokenPayload = Depends(verify_token))
             if params.get("result_type") == "subtitle"
             else [result.to_dict() for result in results],
         },
+    )
+
+
+@router.post("/probe", summary="探测磁力链接健康度", response_model=schemas.Response)
+async def probe_search_torrent(
+    payload: dict = Body(...),
+    _: schemas.TokenPayload = Depends(verify_token),
+) -> Any:
+    """
+    使用 qBittorrent 临时添加 magnet，获取真实大小和做种健康度后立即清理。
+    """
+    payload = payload or {}
+    enclosure = payload.get("enclosure") or payload.get("magnet")
+    downloader = payload.get("downloader")
+    timeout = _parse_probe_timeout(payload.get("timeout"))
+    result = await run_in_threadpool(_probe_magnet, enclosure, downloader, timeout)
+    return schemas.Response(
+        success=bool(result.get("success")),
+        message=result.get("message"),
+        data=result.get("data") or {},
     )
 
 

--- a/app/api/endpoints/search.py
+++ b/app/api/endpoints/search.py
@@ -251,7 +251,7 @@ def _cleanup_probe_torrent(server, *, tag: str, hash_id: Optional[str]) -> bool:
     if not cleanup_hash:
         return False
     try:
-        return server.delete_torrents(delete_file=True, ids=cleanup_hash)
+        return server.delete_torrents(delete_file=False, ids=cleanup_hash)
     except Exception as err:
         logger.warning(f"清理临时探测任务失败：{cleanup_hash} - {err}")
         return False

--- a/app/api/endpoints/search.py
+++ b/app/api/endpoints/search.py
@@ -290,9 +290,15 @@ def _probe_magnet(enclosure: str, downloader: Optional[str], timeout: int) -> di
     if expected_hash:
         existing_torrent = _get_first_torrent(server, hash_id=expected_hash)
         if existing_torrent:
+            data = _build_probe_payload(
+                existing_torrent,
+                existing=True,
+                timed_out=False,
+            )
             return {
-                "success": False,
-                "message": "无法创建临时探测任务",
+                "success": True,
+                "message": "该任务已在下载器中，已读取现有状态",
+                "data": data,
             }
 
     tag = f"{_PROBE_TAG_PREFIX}_{uuid.uuid4().hex[:12]}"
@@ -315,9 +321,15 @@ def _probe_magnet(enclosure: str, downloader: Optional[str], timeout: int) -> di
             if expected_hash:
                 existing_torrent = _get_first_torrent(server, hash_id=expected_hash)
                 if existing_torrent:
+                    data = _build_probe_payload(
+                        existing_torrent,
+                        existing=True,
+                        timed_out=False,
+                    )
                     return {
-                        "success": False,
-                        "message": "无法创建临时探测任务",
+                        "success": True,
+                        "message": "该任务已在下载器中，已读取现有状态",
+                        "data": data,
                     }
             return {"success": False, "message": "添加临时探测任务失败"}
 
@@ -560,12 +572,14 @@ async def search_latest_context(_: schemas.TokenPayload = Depends(verify_token))
 @router.post("/probe", summary="探测磁力链接健康度", response_model=schemas.Response)
 async def probe_search_torrent(
     payload: dict = Body(...),
-    _: schemas.TokenPayload = Depends(verify_token),
+    token: schemas.TokenPayload = Depends(verify_token),
 ) -> Any:
     """
     使用 qBittorrent 临时添加 magnet，获取真实大小和做种健康度后立即清理。
     """
     payload = payload or {}
+    if not token.super_user:
+        return schemas.Response(success=False, message="用户权限不足", data={})
     enclosure = payload.get("enclosure") or payload.get("magnet")
     downloader = payload.get("downloader")
     timeout = _parse_probe_timeout(payload.get("timeout"))

--- a/tests/test_search_probe.py
+++ b/tests/test_search_probe.py
@@ -168,7 +168,7 @@ def test_probe_new_magnet_adds_tagged_task_and_cleans_files(monkeypatch):
     assert add_kwargs["up_limit"] == search_endpoint._PROBE_SPEED_LIMIT
     assert add_kwargs["stop_condition"] == "MetadataReceived"
     assert add_kwargs["tag"][0].startswith(f"{search_endpoint._PROBE_TAG_PREFIX}_")
-    server.delete_torrents.assert_called_once_with(delete_file=True, ids=INFO_HASH)
+    server.delete_torrents.assert_called_once_with(delete_file=False, ids=INFO_HASH)
 
 
 def test_probe_rejects_magnet_without_btih(monkeypatch):
@@ -236,7 +236,7 @@ def test_probe_timeout_returns_partial_tracker_state_and_cleans(monkeypatch):
     assert result["data"]["timed_out"]
     assert result["data"]["seeders"] == 6
     assert result["data"]["cleanup"] is True
-    server.delete_torrents.assert_called_once_with(delete_file=True, ids=INFO_HASH)
+    server.delete_torrents.assert_called_once_with(delete_file=False, ids=INFO_HASH)
 
 
 def test_probe_add_without_hash_finds_tagged_task_and_cleans(monkeypatch):
@@ -293,7 +293,7 @@ def test_probe_add_without_hash_finds_tagged_task_and_cleans(monkeypatch):
     assert result["success"]
     assert result["data"]["cleanup"] is True
     server.get_torrent_id_by_tag.assert_not_called()
-    server.delete_torrents.assert_called_once_with(delete_file=True, ids=INFO_HASH)
+    server.delete_torrents.assert_called_once_with(delete_file=False, ids=INFO_HASH)
 
 
 def test_probe_cleanup_skips_task_without_unique_probe_tag(monkeypatch):

--- a/tests/test_search_probe.py
+++ b/tests/test_search_probe.py
@@ -1,0 +1,193 @@
+import base64
+from unittest.mock import MagicMock
+
+import app.api.endpoints.search as search_endpoint
+
+
+INFO_HASH = "0123456789abcdef0123456789abcdef01234567"
+MAGNET = f"magnet:?xt=urn:btih:{INFO_HASH}&dn=demo"
+
+
+class _FakeQbittorrentModule:
+    """
+    为搜索探测测试提供可控的 qBittorrent 模块。
+    """
+
+    def __init__(self, server):
+        self.server = server
+        self.init_module = MagicMock()
+
+    def get_instance(self, downloader):
+        self.downloader = downloader
+        return self.server
+
+
+def test_extract_btih_supports_hex_and_base32():
+    """
+    磁力探测应兼容 hex 与 base32 两种 btih 写法。
+    """
+    base32_hash = base64.b32encode(bytes.fromhex(INFO_HASH)).decode("ascii")
+
+    assert search_endpoint._extract_btih(MAGNET) == INFO_HASH
+    assert (
+        search_endpoint._extract_btih(f"magnet:?xt=urn:btih:{base32_hash}")
+        == INFO_HASH
+    )
+    assert search_endpoint._extract_btih("https://example.com/demo.torrent") is None
+
+
+def test_parse_probe_timeout_uses_safe_bounds():
+    """
+    探测超时时间应被限制在较小区间内，避免接口长期占用后端线程。
+    """
+    assert search_endpoint._parse_probe_timeout(None) == 30
+    assert search_endpoint._parse_probe_timeout("2") == 5
+    assert search_endpoint._parse_probe_timeout("90") == 60
+    assert search_endpoint._parse_probe_timeout("bad") == 30
+
+
+def test_build_probe_payload_uses_real_size_and_best_seeder_count():
+    """
+    探测结果应使用 qB 的真实大小，并优先取连接/汇报做种数中的较大值。
+    """
+    data = search_endpoint._build_probe_payload(
+        {
+            "hash": INFO_HASH,
+            "name": "demo",
+            "state": "metaDL",
+            "total_size": 1,
+            "size": 4096,
+            "num_seeds": 2,
+            "num_complete": 8,
+            "num_leechs": 3,
+            "num_incomplete": 4,
+            "availability": "1.5",
+        },
+        existing=False,
+        timed_out=False,
+    )
+
+    assert data["size"] == 4096
+    assert data["seeders"] == 8
+    assert data["peers"] == 4
+    assert data["has_metadata"]
+    assert data["availability"] == 1.5
+
+
+def test_probe_existing_magnet_reads_status_without_cleanup(monkeypatch):
+    """
+    磁力任务已存在时只读取状态，不应删除用户已有任务。
+    """
+    server = MagicMock()
+    server.get_torrents.return_value = (
+        [
+            {
+                "hash": INFO_HASH,
+                "name": "existing",
+                "total_size": 2048,
+                "num_seeds": 3,
+                "num_complete": 5,
+            }
+        ],
+        False,
+    )
+    module = _FakeQbittorrentModule(server)
+    monkeypatch.setattr(search_endpoint, "QbittorrentModule", lambda: module)
+
+    result = search_endpoint._probe_magnet(MAGNET, downloader="qb", timeout=5)
+
+    assert result["success"]
+    assert result["data"]["existing"]
+    assert result["data"]["size"] == 2048
+    assert result["data"]["seeders"] == 5
+    server.add_torrent.assert_not_called()
+    server.delete_torrents.assert_not_called()
+
+
+def test_probe_new_magnet_adds_tagged_task_and_cleans_files(monkeypatch):
+    """
+    新磁力探测应添加带唯一标签的临时任务，拿到 metadata 后删除任务和文件。
+    """
+    server = MagicMock()
+    server.get_torrents.side_effect = [
+        ([], False),
+        (
+            [
+                {
+                    "hash": INFO_HASH,
+                    "name": "new",
+                    "total_size": 8192,
+                    "num_seeds": 1,
+                    "num_complete": 2,
+                }
+            ],
+            False,
+        ),
+    ]
+    server.add_torrent.return_value = (True, [INFO_HASH])
+    server.delete_torrents.return_value = True
+    module = _FakeQbittorrentModule(server)
+    monkeypatch.setattr(search_endpoint, "QbittorrentModule", lambda: module)
+
+    result = search_endpoint._probe_magnet(MAGNET, downloader=None, timeout=5)
+
+    assert result["success"]
+    assert result["message"] == "探测完成"
+    assert result["data"]["cleanup"] is True
+    assert result["data"]["existing"] is False
+    assert result["data"]["size"] == 8192
+
+    add_kwargs = server.add_torrent.call_args.kwargs
+    assert add_kwargs["content"] == MAGNET
+    assert add_kwargs["is_paused"] is False
+    assert add_kwargs["dl_limit"] == search_endpoint._PROBE_SPEED_LIMIT
+    assert add_kwargs["up_limit"] == search_endpoint._PROBE_SPEED_LIMIT
+    assert add_kwargs["stop_condition"] == "MetadataReceived"
+    assert add_kwargs["tag"][0].startswith(f"{search_endpoint._PROBE_TAG_PREFIX}_")
+    server.delete_torrents.assert_called_once_with(delete_file=True, ids=INFO_HASH)
+
+
+def test_probe_timeout_returns_partial_tracker_state_and_cleans(monkeypatch):
+    """
+    超时时即使没有 metadata，也应返回 tracker 健康度并清理临时任务。
+    """
+    server = MagicMock()
+    server.get_torrents.side_effect = [
+        ([], False),
+        (
+            [
+                {
+                    "hash": INFO_HASH,
+                    "name": "pending",
+                    "state": "metaDL",
+                    "total_size": -1,
+                    "size": 0,
+                    "num_seeds": 0,
+                    "num_complete": 6,
+                    "num_leechs": 1,
+                    "num_incomplete": 2,
+                }
+            ],
+            False,
+        ),
+    ]
+    server.add_torrent.return_value = (True, [INFO_HASH])
+    server.delete_torrents.return_value = True
+    module = _FakeQbittorrentModule(server)
+    monkeypatch.setattr(search_endpoint, "QbittorrentModule", lambda: module)
+    monkeypatch.setattr(search_endpoint.time, "sleep", lambda _seconds: None)
+    monotonic_values = iter([0, 1, 6])
+    monkeypatch.setattr(
+        search_endpoint.time,
+        "monotonic",
+        lambda: next(monotonic_values),
+    )
+
+    result = search_endpoint._probe_magnet(MAGNET, downloader=None, timeout=5)
+
+    assert result["success"]
+    assert not result["data"]["has_metadata"]
+    assert result["data"]["timed_out"]
+    assert result["data"]["seeders"] == 6
+    assert result["data"]["cleanup"] is True
+    server.delete_torrents.assert_called_once_with(delete_file=True, ids=INFO_HASH)

--- a/tests/test_search_probe.py
+++ b/tests/test_search_probe.py
@@ -109,21 +109,29 @@ def test_probe_new_magnet_adds_tagged_task_and_cleans_files(monkeypatch):
     新磁力探测应添加带唯一标签的临时任务，拿到 metadata 后删除任务和文件。
     """
     server = MagicMock()
-    server.get_torrents.side_effect = [
-        ([], False),
-        (
+    first_hash_query = True
+
+    def get_torrents(ids=None, tags=None):
+        nonlocal first_hash_query
+        if ids == INFO_HASH and first_hash_query:
+            first_hash_query = False
+            return ([], False)
+        probe_tag = server.add_torrent.call_args.kwargs["tag"][0]
+        return (
             [
                 {
                     "hash": INFO_HASH,
                     "name": "new",
                     "total_size": 8192,
+                    "tags": f"MOVIEPILOT,{probe_tag}",
                     "num_seeds": 1,
                     "num_complete": 2,
                 }
             ],
             False,
-        ),
-    ]
+        )
+
+    server.get_torrents.side_effect = get_torrents
     server.add_torrent.return_value = (True, [INFO_HASH])
     server.delete_torrents.return_value = True
     module = _FakeQbittorrentModule(server)
@@ -152,9 +160,15 @@ def test_probe_timeout_returns_partial_tracker_state_and_cleans(monkeypatch):
     超时时即使没有 metadata，也应返回 tracker 健康度并清理临时任务。
     """
     server = MagicMock()
-    server.get_torrents.side_effect = [
-        ([], False),
-        (
+    first_hash_query = True
+
+    def get_torrents(ids=None, tags=None):
+        nonlocal first_hash_query
+        if ids == INFO_HASH and first_hash_query:
+            first_hash_query = False
+            return ([], False)
+        probe_tag = server.add_torrent.call_args.kwargs["tag"][0]
+        return (
             [
                 {
                     "hash": INFO_HASH,
@@ -162,6 +176,7 @@ def test_probe_timeout_returns_partial_tracker_state_and_cleans(monkeypatch):
                     "state": "metaDL",
                     "total_size": -1,
                     "size": 0,
+                    "tags": f"MOVIEPILOT,{probe_tag}",
                     "num_seeds": 0,
                     "num_complete": 6,
                     "num_leechs": 1,
@@ -169,8 +184,9 @@ def test_probe_timeout_returns_partial_tracker_state_and_cleans(monkeypatch):
                 }
             ],
             False,
-        ),
-    ]
+        )
+
+    server.get_torrents.side_effect = get_torrents
     server.add_torrent.return_value = (True, [INFO_HASH])
     server.delete_torrents.return_value = True
     module = _FakeQbittorrentModule(server)
@@ -191,3 +207,102 @@ def test_probe_timeout_returns_partial_tracker_state_and_cleans(monkeypatch):
     assert result["data"]["seeders"] == 6
     assert result["data"]["cleanup"] is True
     server.delete_torrents.assert_called_once_with(delete_file=True, ids=INFO_HASH)
+
+
+def test_probe_add_without_hash_finds_tagged_task_and_cleans(monkeypatch):
+    """
+    添加成功但接口未返回 hash 时，应按唯一标签查找并清理临时任务。
+    """
+    server = MagicMock()
+
+    def get_torrents(ids=None, tags=None):
+        if ids == INFO_HASH:
+            return (
+                [
+                    {
+                        "hash": INFO_HASH,
+                        "name": "new",
+                        "total_size": 4096,
+                        "tags": "MOVIEPILOT,MP_PROBE_test",
+                    }
+                ],
+                False,
+            )
+        if tags:
+            return (
+                [
+                    {
+                        "hash": INFO_HASH,
+                        "name": "new",
+                        "total_size": 4096,
+                        "tags": f"MOVIEPILOT,{tags}",
+                    }
+                ],
+                False,
+            )
+        return ([], False)
+
+    first_hash_query = True
+
+    def get_torrents_with_precheck(ids=None, tags=None):
+        nonlocal first_hash_query
+        if ids == INFO_HASH and first_hash_query:
+            first_hash_query = False
+            return ([], False)
+        return get_torrents(ids=ids, tags=tags)
+
+    server.get_torrents.side_effect = get_torrents_with_precheck
+    server.add_torrent.return_value = (True, [])
+    server.delete_torrents.return_value = True
+    module = _FakeQbittorrentModule(server)
+    monkeypatch.setattr(search_endpoint, "QbittorrentModule", lambda: module)
+    monkeypatch.setattr(search_endpoint.time, "sleep", lambda _seconds: None)
+
+    result = search_endpoint._probe_magnet(MAGNET, downloader=None, timeout=5)
+
+    assert result["success"]
+    assert result["data"]["cleanup"] is True
+    server.get_torrent_id_by_tag.assert_not_called()
+    server.delete_torrents.assert_called_once_with(delete_file=True, ids=INFO_HASH)
+
+
+def test_probe_cleanup_skips_task_without_unique_probe_tag(monkeypatch):
+    """
+    清理前如果唯一探测标签不存在，不应删除下载器中的任务。
+    """
+    server = MagicMock()
+    server.get_torrents.side_effect = [
+        ([], False),
+        (
+            [
+                {
+                    "hash": INFO_HASH,
+                    "name": "new",
+                    "total_size": 4096,
+                    "tags": "MP_PROBE_test",
+                }
+            ],
+            False,
+        ),
+        (
+            [
+                {
+                    "hash": INFO_HASH,
+                    "name": "new",
+                    "total_size": 4096,
+                    "tags": "MOVIEPILOT",
+                }
+            ],
+            False,
+        ),
+        ([], False),
+    ]
+    server.add_torrent.return_value = (True, [INFO_HASH])
+    module = _FakeQbittorrentModule(server)
+    monkeypatch.setattr(search_endpoint, "QbittorrentModule", lambda: module)
+
+    result = search_endpoint._probe_magnet(MAGNET, downloader=None, timeout=5)
+
+    assert result["success"]
+    assert result["data"]["cleanup"] is False
+    server.delete_torrents.assert_not_called()

--- a/tests/test_search_probe.py
+++ b/tests/test_search_probe.py
@@ -41,8 +41,8 @@ def test_sanitize_probe_magnet_keeps_only_btih():
     探测添加到下载器前应移除 tracker/webseed 等外部连接参数。
     """
     unsafe_magnet = (
-        f"{MAGNET}&tr=http%3A%2F%2F192.168.1.1%2Fannounce"
-        "&ws=http%3A%2F%2Flocalhost%2Ffile"
+        f"{MAGNET}&tr=http%3A%2F%2Ftracker.invalid%2Fannounce"
+        "&ws=http%3A%2F%2Fwebseed.invalid%2Ffile"
     )
 
     assert (

--- a/tests/test_search_probe.py
+++ b/tests/test_search_probe.py
@@ -90,9 +90,9 @@ def test_build_probe_payload_uses_real_size_and_best_seeder_count():
     assert data["availability"] == 1.5
 
 
-def test_probe_existing_magnet_reads_status_without_cleanup(monkeypatch):
+def test_probe_existing_magnet_skips_without_leaking_status(monkeypatch):
     """
-    磁力任务已存在时只读取状态，不应删除用户已有任务。
+    磁力任务已存在时不应返回下载器中的任务详情。
     """
     server = MagicMock()
     server.get_torrents.return_value = (
@@ -112,10 +112,8 @@ def test_probe_existing_magnet_reads_status_without_cleanup(monkeypatch):
 
     result = search_endpoint._probe_magnet(MAGNET, downloader="qb", timeout=5)
 
-    assert result["success"]
-    assert result["data"]["existing"]
-    assert result["data"]["size"] == 2048
-    assert result["data"]["seeders"] == 5
+    assert not result["success"]
+    assert "data" not in result
     server.add_torrent.assert_not_called()
     server.delete_torrents.assert_not_called()
 
@@ -140,6 +138,7 @@ def test_probe_new_magnet_adds_tagged_task_and_cleans_files(monkeypatch):
                     "name": "new",
                     "total_size": 8192,
                     "tags": f"MOVIEPILOT,{probe_tag}",
+                    "category": search_endpoint._PROBE_CATEGORY,
                     "num_seeds": 1,
                     "num_complete": 2,
                 }
@@ -167,6 +166,7 @@ def test_probe_new_magnet_adds_tagged_task_and_cleans_files(monkeypatch):
     assert add_kwargs["dl_limit"] == search_endpoint._PROBE_SPEED_LIMIT
     assert add_kwargs["up_limit"] == search_endpoint._PROBE_SPEED_LIMIT
     assert add_kwargs["stop_condition"] == "MetadataReceived"
+    assert add_kwargs["category"] == search_endpoint._PROBE_CATEGORY
     assert add_kwargs["tag"][0].startswith(f"{search_endpoint._PROBE_TAG_PREFIX}_")
     server.delete_torrents.assert_called_once_with(delete_file=False, ids=INFO_HASH)
 
@@ -207,6 +207,7 @@ def test_probe_timeout_returns_partial_tracker_state_and_cleans(monkeypatch):
                     "total_size": -1,
                     "size": 0,
                     "tags": f"MOVIEPILOT,{probe_tag}",
+                    "category": search_endpoint._PROBE_CATEGORY,
                     "num_seeds": 0,
                     "num_complete": 6,
                     "num_leechs": 1,
@@ -254,6 +255,7 @@ def test_probe_add_without_hash_finds_tagged_task_and_cleans(monkeypatch):
                         "name": "new",
                         "total_size": 4096,
                         "tags": "MOVIEPILOT,MP_PROBE_test",
+                        "category": search_endpoint._PROBE_CATEGORY,
                     }
                 ],
                 False,
@@ -266,6 +268,7 @@ def test_probe_add_without_hash_finds_tagged_task_and_cleans(monkeypatch):
                         "name": "new",
                         "total_size": 4096,
                         "tags": f"MOVIEPILOT,{tags}",
+                        "category": search_endpoint._PROBE_CATEGORY,
                     }
                 ],
                 False,
@@ -327,6 +330,43 @@ def test_probe_cleanup_skips_task_without_unique_probe_tag(monkeypatch):
         ),
         ([], False),
     ]
+    server.add_torrent.return_value = (True, [INFO_HASH])
+    module = _FakeQbittorrentModule(server)
+    monkeypatch.setattr(search_endpoint, "QbittorrentModule", lambda: module)
+
+    result = search_endpoint._probe_magnet(MAGNET, downloader=None, timeout=5)
+
+    assert result["success"]
+    assert result["data"]["cleanup"] is False
+    server.delete_torrents.assert_not_called()
+
+
+def test_probe_cleanup_skips_task_without_probe_category(monkeypatch):
+    """
+    即使任务带有本次唯一标签，缺少探测专用分类时也不应删除。
+    """
+    server = MagicMock()
+    first_hash_query = True
+
+    def get_torrents(ids=None, tags=None):
+        nonlocal first_hash_query
+        if ids == INFO_HASH and first_hash_query:
+            first_hash_query = False
+            return ([], False)
+        probe_tag = server.add_torrent.call_args.kwargs["tag"][0]
+        return (
+            [
+                {
+                    "hash": INFO_HASH,
+                    "name": "new",
+                    "total_size": 4096,
+                    "tags": f"MOVIEPILOT,{probe_tag}",
+                }
+            ],
+            False,
+        )
+
+    server.get_torrents.side_effect = get_torrents
     server.add_torrent.return_value = (True, [INFO_HASH])
     module = _FakeQbittorrentModule(server)
     monkeypatch.setattr(search_endpoint, "QbittorrentModule", lambda: module)

--- a/tests/test_search_probe.py
+++ b/tests/test_search_probe.py
@@ -1,6 +1,9 @@
 import base64
 from unittest.mock import MagicMock
 
+import pytest
+
+from app import schemas
 import app.api.endpoints.search as search_endpoint
 
 
@@ -90,9 +93,9 @@ def test_build_probe_payload_uses_real_size_and_best_seeder_count():
     assert data["availability"] == 1.5
 
 
-def test_probe_existing_magnet_skips_without_leaking_status(monkeypatch):
+def test_probe_existing_magnet_reads_status_without_cleanup(monkeypatch):
     """
-    磁力任务已存在时不应返回下载器中的任务详情。
+    磁力任务已存在时只读取状态，不应删除用户已有任务。
     """
     server = MagicMock()
     server.get_torrents.return_value = (
@@ -112,8 +115,10 @@ def test_probe_existing_magnet_skips_without_leaking_status(monkeypatch):
 
     result = search_endpoint._probe_magnet(MAGNET, downloader="qb", timeout=5)
 
-    assert not result["success"]
-    assert "data" not in result
+    assert result["success"]
+    assert result["data"]["existing"]
+    assert result["data"]["size"] == 2048
+    assert result["data"]["seeders"] == 5
     server.add_torrent.assert_not_called()
     server.delete_torrents.assert_not_called()
 
@@ -390,3 +395,17 @@ def test_probe_cleanup_skips_task_without_probe_category(monkeypatch):
     assert result["success"]
     assert result["data"]["cleanup"] is False
     server.delete_torrents.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_probe_endpoint_requires_superuser():
+    """
+    磁力探测会操作下载器，应限制为管理员 token。
+    """
+    response = await search_endpoint.probe_search_torrent(
+        payload={"magnet": MAGNET},
+        token=schemas.TokenPayload(super_user=False),
+    )
+
+    assert not response.success
+    assert response.message == "用户权限不足"

--- a/tests/test_search_probe.py
+++ b/tests/test_search_probe.py
@@ -36,6 +36,22 @@ def test_extract_btih_supports_hex_and_base32():
     assert search_endpoint._extract_btih("https://example.com/demo.torrent") is None
 
 
+def test_sanitize_probe_magnet_keeps_only_btih():
+    """
+    探测添加到下载器前应移除 tracker/webseed 等外部连接参数。
+    """
+    unsafe_magnet = (
+        f"{MAGNET}&tr=http%3A%2F%2F192.168.1.1%2Fannounce"
+        "&ws=http%3A%2F%2Flocalhost%2Ffile"
+    )
+
+    assert (
+        search_endpoint._sanitize_probe_magnet(unsafe_magnet)
+        == f"magnet:?xt=urn:btih:{INFO_HASH}"
+    )
+    assert search_endpoint._sanitize_probe_magnet("magnet:?dn=demo") is None
+
+
 def test_parse_probe_timeout_uses_safe_bounds():
     """
     探测超时时间应被限制在较小区间内，避免接口长期占用后端线程。
@@ -146,13 +162,27 @@ def test_probe_new_magnet_adds_tagged_task_and_cleans_files(monkeypatch):
     assert result["data"]["size"] == 8192
 
     add_kwargs = server.add_torrent.call_args.kwargs
-    assert add_kwargs["content"] == MAGNET
+    assert add_kwargs["content"] == f"magnet:?xt=urn:btih:{INFO_HASH}"
     assert add_kwargs["is_paused"] is False
     assert add_kwargs["dl_limit"] == search_endpoint._PROBE_SPEED_LIMIT
     assert add_kwargs["up_limit"] == search_endpoint._PROBE_SPEED_LIMIT
     assert add_kwargs["stop_condition"] == "MetadataReceived"
     assert add_kwargs["tag"][0].startswith(f"{search_endpoint._PROBE_TAG_PREFIX}_")
     server.delete_torrents.assert_called_once_with(delete_file=True, ids=INFO_HASH)
+
+
+def test_probe_rejects_magnet_without_btih(monkeypatch):
+    """
+    无法识别 info hash 时不应把任务交给下载器，避免误清理已有任务。
+    """
+    module = MagicMock()
+    monkeypatch.setattr(search_endpoint, "QbittorrentModule", lambda: module)
+
+    result = search_endpoint._probe_magnet("magnet:?dn=demo", downloader=None, timeout=5)
+
+    assert not result["success"]
+    assert result["message"] == "无法解析 magnet 链接中的 btih"
+    module.init_module.assert_not_called()
 
 
 def test_probe_timeout_returns_partial_tracker_state_and_cleans(monkeypatch):

--- a/tests/test_search_probe.py
+++ b/tests/test_search_probe.py
@@ -185,6 +185,20 @@ def test_probe_rejects_magnet_without_btih(monkeypatch):
     module.init_module.assert_not_called()
 
 
+def test_probe_rejects_non_string_magnet(monkeypatch):
+    """
+    非字符串输入应返回受控失败，不应触发下载器初始化。
+    """
+    module = MagicMock()
+    monkeypatch.setattr(search_endpoint, "QbittorrentModule", lambda: module)
+
+    result = search_endpoint._probe_magnet(123, downloader=None, timeout=5)
+
+    assert not result["success"]
+    assert result["message"] == "只支持 magnet 链接探测"
+    module.init_module.assert_not_called()
+
+
 def test_probe_timeout_returns_partial_tracker_state_and_cleans(monkeypatch):
     """
     超时时即使没有 metadata，也应返回 tracker 健康度并清理临时任务。


### PR DESCRIPTION
## 变更
- 新增 `/api/v1/search/probe`，用于探测搜索结果中的磁力链接。
- 通过 qBittorrent 临时任务读取大小、做种数、下载者、可用性和元数据状态。
- 只允许管理员调用，并通过唯一标签、专用分类和 `delete_file=False` 保护既有任务。

## 边界
本次仅包含搜索结果磁力探测接口和测试，不包含用户私有站点配置、Cookie、下载器路径或本地资源包内容。

## 验证
- `pytest tests/test_search_probe.py tests/test_subtitle_search.py tests/test_subtitle_signed_download.py`（33 passed）
- `pylint app/api/endpoints/search.py`（10.00/10）
- `git diff --check upstream/v2..HEAD`