### PR TITLE
新增蓝光原盘转封装配置

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -389,6 +389,8 @@ class ConfigModel(BaseModel):
     TRANSFER_THREADS: int = 1
     # 蓝光原盘目录自动转封装为单个MKV文件，默认关闭
     BLURAY_REMUX_ENABLED: bool = False
+    # 蓝光原盘转封装超时时间（秒）
+    BLURAY_REMUX_TIMEOUT: int = 6 * 60 * 60
     # 电影重命名格式
     MOVIE_RENAME_FORMAT: str = (
         "{{title}}{% if year %} ({{year}}){% endif %}"

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -387,6 +387,8 @@ class ConfigModel(BaseModel):
     # ==================== 整理配置 ====================
     # 文件整理线程数
     TRANSFER_THREADS: int = 1
+    # 蓝光原盘目录自动转封装为单个MKV文件，默认关闭
+    BLURAY_REMUX_ENABLED: bool = False
     # 电影重命名格式
     MOVIE_RENAME_FORMAT: str = (
         "{{title}}{% if year %} ({{year}}){% endif %}"

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -293,7 +293,6 @@ class TransHandler:
     def __get_bluray_remux_sources(
             cls,
             bluray_root: Path,
-            allow_largest_fallback: bool = True,
     ) -> Tuple[List[_BlurayRemuxSource], int]:
         """
         获取蓝光原盘转封装源文件列表。
@@ -347,9 +346,9 @@ class TransHandler:
             )
             return [], 0
 
-        if len(stream_files) > 1 and not allow_largest_fallback:
+        if len(stream_files) > 1:
             logger.warn(
-                f"蓝光原盘 {bluray_root} 缺少播放列表，移动模式跳过最大分片回退"
+                f"蓝光原盘 {bluray_root} 缺少播放列表，跳过多分片最大文件回退"
             )
             return [], 0
 
@@ -700,10 +699,7 @@ class TransHandler:
                     need_notify=need_notify,
                 )
 
-        source_files, source_size = self.__get_bluray_remux_sources(
-            bluray_root,
-            allow_largest_fallback=transfer_type == "copy",
-        )
+        source_files, source_size = self.__get_bluray_remux_sources(bluray_root)
         if not source_files:
             return TransferInfo(
                 success=False,

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -65,6 +65,16 @@ class TransHandler:
             return False
 
     @staticmethod
+    def __is_same_path(path: Path, other: Path) -> bool:
+        """
+        判断两个路径是否指向同一位置。
+        """
+        try:
+            return path.resolve() == other.resolve()
+        except OSError:
+            return False
+
+    @staticmethod
     def __normalize_disc_folder_name(value: Optional[str]) -> Optional[str]:
         """
         从 Disc/Disk/DVD/CD 标识中提取盘号并统一为 Disc N。
@@ -278,7 +288,7 @@ class TransHandler:
         """
         转义 ffconcat 文件中的路径。
         """
-        value = path.as_posix().replace("\\", "/")
+        value = path.as_posix()
         if "\n" in value or "\r" in value:
             raise ValueError("蓝光分片路径包含换行控制字符")
         return value.replace("'", "'\\''")
@@ -479,6 +489,17 @@ class TransHandler:
         bluray_root = self.__get_local_bluray_root(Path(fileitem.path))
         if not bluray_root:
             return None
+        if transfer_type == "move" and not self.__is_same_path(
+            Path(fileitem.path), bluray_root
+        ):
+            return TransferInfo(
+                success=False,
+                message="蓝光原盘转封装移动模式不支持从子目录入口整理",
+                fileitem=fileitem,
+                fail_list=[fileitem.path],
+                transfer_type=transfer_type,
+                need_notify=need_notify,
+            )
         if mediainfo.type == MediaType.TV:
             logger.warn("电视剧蓝光原盘可能包含多集或全集播放列表，保持目录整理")
             return None

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -191,16 +191,17 @@ class TransHandler:
             stream_names = []
             for _ in range(playitem_count):
                 if pos + 13 > len(data):
-                    break
+                    return []
                 item_length = int.from_bytes(data[pos:pos + 2], "big")
                 item_end = pos + 2 + item_length
                 if item_length < 9 or item_end > len(data):
-                    break
+                    return []
                 clip_name = data[pos + 2:pos + 7].decode(
                     "ascii", errors="ignore"
                 ).strip("\x00 ")
-                if clip_name:
-                    stream_names.append(f"{clip_name}.m2ts")
+                if not clip_name:
+                    return []
+                stream_names.append(f"{clip_name}.m2ts")
                 pos = item_end
             return stream_names
         except Exception as err:
@@ -280,7 +281,7 @@ class TransHandler:
         value = path.as_posix().replace("\\", "/")
         if "\n" in value or "\r" in value:
             raise ValueError("蓝光分片路径包含换行控制字符")
-        return value.replace("'", "\\'")
+        return value.replace("'", "'\\''")
 
     @classmethod
     def __run_bluray_remux(

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -199,7 +199,12 @@ class TransHandler:
         best_files = []
         best_size = 0
         if playlist_dir.is_dir():
-            for mpls_file in sorted(playlist_dir.glob("*.mpls")):
+            playlist_files = [
+                item
+                for item in playlist_dir.iterdir()
+                if item.is_file() and item.suffix.lower() == ".mpls"
+            ]
+            for mpls_file in sorted(playlist_files):
                 names = cls.__parse_mpls_stream_names(mpls_file)
                 files = [
                     stream_map.get(name.upper())
@@ -314,8 +319,6 @@ class TransHandler:
                 return False, f"ffmpeg 转封装失败：{errmsg or completed.returncode}"
             if not tmp_file.exists():
                 return False, "ffmpeg 转封装完成但未生成目标文件"
-            if target_file.exists() or target_file.is_symlink():
-                target_file.unlink()
             tmp_file.replace(target_file)
             return True, ""
         except Exception as err:
@@ -392,17 +395,14 @@ class TransHandler:
         if overwrite_event and overwrite_event.event_data:
             overwrite_event_data = overwrite_event.event_data
             if overwrite_event_data.overwrite is True:
-                target_oper.delete(target_item)
                 return True, ""
             if overwrite_event_data.overwrite is False:
                 return False, overwrite_event_data.reason or "插件决定不覆盖已有文件"
 
         if overwrite_mode in ["always", "latest"]:
-            target_oper.delete(target_item)
             return True, ""
         if overwrite_mode == "size":
             if (target_item.size or 0) < source_size:
-                target_oper.delete(target_item)
                 return True, ""
             return False, "媒体库存在同名文件，且质量更好"
         if overwrite_mode == "never":

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -524,9 +524,7 @@ class TransHandler:
             rename_format=rename_format,
             need_rename=need_rename,
         )
-        if transfer_type == "move" and self.__is_path_relative_to(
-            target_file, bluray_root
-        ):
+        if self.__is_path_relative_to(target_file, bluray_root):
             return TransferInfo(
                 success=False,
                 message="蓝光原盘转封装目标不能位于源目录内",

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -3,6 +3,7 @@ import shutil
 import subprocess
 import threading
 import uuid
+import weakref
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, List, Tuple
@@ -37,7 +38,6 @@ _BLURAY_MPLS_MAX_DURATION_SECONDS = 12 * 60 * 60
 _BLURAY_MPLS_TIME_BASE = 45000
 _BLURAY_PLAYITEM_IN_TIME_OFFSET = 14
 _BLURAY_PLAYITEM_OUT_TIME_OFFSET = 18
-_BLURAY_REMUX_LOCK_CACHE_LIMIT = 1024
 _BLURAY_REMUX_MIN_TIMEOUT = 60
 
 
@@ -63,7 +63,7 @@ class TransHandler:
     文件转移整理类
     """
 
-    _bluray_remux_locks = {}
+    _bluray_remux_locks = weakref.WeakValueDictionary()
     _bluray_remux_locks_guard = threading.Lock()
 
     def __init__(self):
@@ -76,18 +76,11 @@ class TransHandler:
         """
         lock_key = target_file.resolve().as_posix()
         with cls._bluray_remux_locks_guard:
-            if lock_key not in cls._bluray_remux_locks:
-                cls._bluray_remux_locks[lock_key] = threading.Lock()
-            while len(cls._bluray_remux_locks) > _BLURAY_REMUX_LOCK_CACHE_LIMIT:
-                removed = False
-                for stale_key, stale_lock in list(cls._bluray_remux_locks.items()):
-                    if stale_key != lock_key and not stale_lock.locked():
-                        cls._bluray_remux_locks.pop(stale_key, None)
-                        removed = True
-                        break
-                if not removed:
-                    break
-            return cls._bluray_remux_locks[lock_key]
+            target_lock = cls._bluray_remux_locks.get(lock_key)
+            if target_lock is None:
+                target_lock = threading.Lock()
+                cls._bluray_remux_locks[lock_key] = target_lock
+            return target_lock
 
     @staticmethod
     def __is_path_relative_to(path: Path, parent: Path) -> bool:
@@ -786,12 +779,6 @@ class TransHandler:
             target_item = self.__build_local_fileitem(target_file)
 
         if transfer_type == "move" and not source_oper.delete(fileitem):
-            if not allow_target_replace and (target_file.exists() or target_file.is_symlink()):
-                try:
-                    target_file.unlink()
-                    target_item = None
-                except OSError as err:
-                    logger.error(f"回滚蓝光原盘转封装目标文件失败：{target_file} - {err}")
             return TransferInfo(
                 success=False,
                 message="转封装成功但删除源目录失败",

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -196,6 +196,7 @@ class TransHandler:
 
         stream_map = {item.name.upper(): item for item in stream_files}
         playlist_dir = bluray_root / "BDMV" / "PLAYLIST"
+        playlist_files = []
         best_files = []
         best_size = 0
         if playlist_dir.is_dir():
@@ -218,6 +219,12 @@ class TransHandler:
                     best_size = total_size
         if best_files:
             return best_files, best_size
+
+        if playlist_files:
+            logger.warn(
+                f"蓝光原盘 {bluray_root} 存在播放列表但无法匹配可转封装分片，跳过转封装"
+            )
+            return [], 0
 
         largest_file = max(stream_files, key=lambda item: item.stat().st_size)
         return [largest_file], largest_file.stat().st_size
@@ -442,8 +449,8 @@ class TransHandler:
         bluray_root = self.__get_local_bluray_root(Path(fileitem.path))
         if not bluray_root:
             return None
-        if mediainfo.type == MediaType.TV and in_meta.begin_episode is None:
-            logger.warn("电视剧蓝光原盘未识别到集数，保持目录整理")
+        if mediainfo.type == MediaType.TV:
+            logger.warn("电视剧蓝光原盘可能包含多集或全集播放列表，保持目录整理")
             return None
 
         target_file = self.__get_bluray_remux_target_file(

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -33,6 +33,8 @@ from app.utils.system import SystemUtils
 
 _BLURAY_MPLS_MAX_SIZE = 1024 * 1024
 _BLURAY_MPLS_TIME_BASE = 45000
+_BLURAY_PLAYITEM_IN_TIME_OFFSET = 14
+_BLURAY_PLAYITEM_OUT_TIME_OFFSET = 18
 
 
 @dataclass(frozen=True)
@@ -224,19 +226,34 @@ class TransHandler:
             pos += 4
             stream_items = []
             for _ in range(playitem_count):
-                if pos + 21 > len(data):
+                if pos + _BLURAY_PLAYITEM_OUT_TIME_OFFSET + 4 > len(data):
                     return []
                 item_length = int.from_bytes(data[pos:pos + 2], "big")
                 item_end = pos + 2 + item_length
-                if item_length < 19 or item_end > len(data):
+                if (
+                        item_length < _BLURAY_PLAYITEM_OUT_TIME_OFFSET + 4 - 2
+                        or item_end > len(data)
+                ):
                     return []
                 clip_name = data[pos + 2:pos + 7].decode(
                     "ascii", errors="ignore"
                 ).strip("\x00 ")
                 if not clip_name:
                     return []
-                in_time = int.from_bytes(data[pos + 13:pos + 17], "big")
-                out_time = int.from_bytes(data[pos + 17:pos + 21], "big")
+                in_time = int.from_bytes(
+                    data[
+                        pos + _BLURAY_PLAYITEM_IN_TIME_OFFSET:
+                        pos + _BLURAY_PLAYITEM_IN_TIME_OFFSET + 4
+                    ],
+                    "big",
+                )
+                out_time = int.from_bytes(
+                    data[
+                        pos + _BLURAY_PLAYITEM_OUT_TIME_OFFSET:
+                        pos + _BLURAY_PLAYITEM_OUT_TIME_OFFSET + 4
+                    ],
+                    "big",
+                )
                 if out_time <= in_time:
                     return []
                 stream_items.append((f"{clip_name}.m2ts", in_time, out_time))
@@ -359,6 +376,7 @@ class TransHandler:
             source_files: List[_BlurayRemuxSource],
             target_file: Path,
             allow_target_replace: bool,
+            recheck_target_size: Optional[int],
     ) -> Tuple[bool, str]:
         """
         使用 ffmpeg 将蓝光原盘分片转封装为单个 MKV。
@@ -442,6 +460,11 @@ class TransHandler:
                     and (target_file.exists() or target_file.is_symlink())
             ):
                 return False, f"{target_file} 在转封装期间被创建，取消覆盖"
+            if (
+                    recheck_target_size is not None
+                    and tmp_file.stat().st_size <= recheck_target_size
+            ):
+                return False, "媒体库存在同名文件，且质量更好"
             tmp_file.replace(target_file)
             return True, ""
         except Exception as err:
@@ -492,13 +515,13 @@ class TransHandler:
             transfer_type: str,
             overwrite_mode: Optional[str],
             source_size: int,
-    ) -> Tuple[bool, str]:
+    ) -> Tuple[bool, str, bool]:
         """
         检查蓝光转封装目标文件覆盖策略。
         """
         target_item = target_oper.get_item(target_file)
         if not target_item:
-            return True, ""
+            return True, "", False
 
         logger.info(
             f"目的文件系统中已经存在同名文件 {target_file}，当前整理覆盖模式设置为 {overwrite_mode}"
@@ -518,19 +541,19 @@ class TransHandler:
         if overwrite_event and overwrite_event.event_data:
             overwrite_event_data = overwrite_event.event_data
             if overwrite_event_data.overwrite is True:
-                return True, ""
+                return True, "", False
             if overwrite_event_data.overwrite is False:
-                return False, overwrite_event_data.reason or "插件决定不覆盖已有文件"
+                return False, overwrite_event_data.reason or "插件决定不覆盖已有文件", False
 
         if overwrite_mode in ["always", "latest"]:
-            return True, ""
+            return True, "", False
         if overwrite_mode == "size":
             if (target_item.size or 0) < source_size:
-                return True, ""
-            return False, "媒体库存在同名文件，且质量更好"
+                return True, "", True
+            return False, "媒体库存在同名文件，且质量更好", False
         if overwrite_mode == "never":
-            return False, "媒体库存在同名文件，当前覆盖模式为不覆盖"
-        return False, f"{target_file} 已存在"
+            return False, "媒体库存在同名文件，当前覆盖模式为不覆盖", False
+        return False, f"{target_file} 已存在", False
 
     def __transfer_bluray_remux(
             self,
@@ -659,12 +682,20 @@ class TransHandler:
             )
         target_lock = self.__get_bluray_remux_target_lock(target_file)
         with target_lock:
+            target_item = target_oper.get_item(target_file)
+            target_size = target_item.size if target_item else None
+            if target_size is None and target_file.is_file():
+                target_size = target_file.stat().st_size
             allow_target_replace = bool(
                 target_file.exists()
                 or target_file.is_symlink()
-                or target_oper.get_item(target_file)
+                or target_item
             )
-            can_overwrite, errmsg = self.__check_bluray_remux_overwrite(
+            (
+                can_overwrite,
+                errmsg,
+                recheck_output_size,
+            ) = self.__check_bluray_remux_overwrite(
                 fileitem=fileitem,
                 target_oper=target_oper,
                 target_file=target_file,
@@ -689,6 +720,7 @@ class TransHandler:
                 source_files,
                 target_file,
                 allow_target_replace=allow_target_replace,
+                recheck_target_size=target_size if recheck_output_size else None,
             )
             if not state:
                 logger.error(f"蓝光原盘 {fileitem.path} 转封装失败：{errmsg}")

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -32,6 +32,8 @@ from app.schemas.types import MediaType, ChainEventType
 from app.utils.system import SystemUtils
 
 _BLURAY_MPLS_MAX_SIZE = 1024 * 1024
+_BLURAY_MPLS_MAX_PLAYITEMS = 200
+_BLURAY_MPLS_MAX_DURATION_SECONDS = 12 * 60 * 60
 _BLURAY_MPLS_TIME_BASE = 45000
 _BLURAY_PLAYITEM_IN_TIME_OFFSET = 14
 _BLURAY_PLAYITEM_OUT_TIME_OFFSET = 18
@@ -223,8 +225,15 @@ class TransHandler:
                 return []
             pos = playlist_start + 6
             playitem_count = int.from_bytes(data[pos:pos + 2], "big")
+            if (
+                    playitem_count <= 0
+                    or playitem_count > _BLURAY_MPLS_MAX_PLAYITEMS
+            ):
+                return []
             pos += 4
             stream_items = []
+            seen_items = set()
+            total_duration = 0
             for _ in range(playitem_count):
                 if pos + _BLURAY_PLAYITEM_OUT_TIME_OFFSET + 4 > len(data):
                     return []
@@ -255,6 +264,16 @@ class TransHandler:
                     "big",
                 )
                 if out_time <= in_time:
+                    return []
+                item_key = (clip_name.upper(), in_time, out_time)
+                if item_key in seen_items:
+                    return []
+                seen_items.add(item_key)
+                total_duration += out_time - in_time
+                if (
+                        total_duration
+                        > _BLURAY_MPLS_MAX_DURATION_SECONDS * _BLURAY_MPLS_TIME_BASE
+                ):
                     return []
                 stream_items.append((f"{clip_name}.m2ts", in_time, out_time))
                 pos = item_end
@@ -455,6 +474,8 @@ class TransHandler:
                 return False, f"ffmpeg 转封装失败：{errmsg or completed.returncode}"
             if not tmp_file.exists():
                 return False, "ffmpeg 转封装完成但未生成目标文件"
+            if tmp_file.stat().st_size <= 0:
+                return False, "ffmpeg 转封装完成但输出文件为空"
             if (
                     not allow_target_replace
                     and (target_file.exists() or target_file.is_symlink())
@@ -520,6 +541,18 @@ class TransHandler:
         检查蓝光转封装目标文件覆盖策略。
         """
         target_item = target_oper.get_item(target_file)
+        if not target_item and (target_file.exists() or target_file.is_symlink()):
+            if target_file.is_file():
+                target_item = self.__build_local_fileitem(target_file)
+            else:
+                target_item = FileItem(
+                    storage=target_storage,
+                    path=target_file.as_posix(),
+                    name=target_file.name,
+                    basename=target_file.stem,
+                    type="file",
+                    size=0,
+                )
         if not target_item:
             return True, "", False
 

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -88,7 +88,9 @@ class TransHandler:
         判断 path 是否位于 parent 内部，兼容目标文件尚未创建的场景。
         """
         try:
-            path.resolve().relative_to(parent.resolve())
+            parent_path = parent.resolve()
+            candidate_path = path.parent.resolve() / path.name
+            candidate_path.relative_to(parent_path)
             return True
         except (OSError, ValueError):
             return False

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -358,6 +358,7 @@ class TransHandler:
             cls,
             source_files: List[_BlurayRemuxSource],
             target_file: Path,
+            allow_target_replace: bool,
     ) -> Tuple[bool, str]:
         """
         使用 ffmpeg 将蓝光原盘分片转封装为单个 MKV。
@@ -436,6 +437,11 @@ class TransHandler:
                 return False, f"ffmpeg 转封装失败：{errmsg or completed.returncode}"
             if not tmp_file.exists():
                 return False, "ffmpeg 转封装完成但未生成目标文件"
+            if (
+                    not allow_target_replace
+                    and (target_file.exists() or target_file.is_symlink())
+            ):
+                return False, f"{target_file} 在转封装期间被创建，取消覆盖"
             tmp_file.replace(target_file)
             return True, ""
         except Exception as err:
@@ -653,6 +659,11 @@ class TransHandler:
             )
         target_lock = self.__get_bluray_remux_target_lock(target_file)
         with target_lock:
+            allow_target_replace = bool(
+                target_file.exists()
+                or target_file.is_symlink()
+                or target_oper.get_item(target_file)
+            )
             can_overwrite, errmsg = self.__check_bluray_remux_overwrite(
                 fileitem=fileitem,
                 target_oper=target_oper,
@@ -674,7 +685,11 @@ class TransHandler:
                 )
 
             logger.info(f"正在转封装蓝光原盘：{bluray_root} 到 {target_file}")
-            state, errmsg = self.__run_bluray_remux(source_files, target_file)
+            state, errmsg = self.__run_bluray_remux(
+                source_files,
+                target_file,
+                allow_target_replace=allow_target_replace,
+            )
             if not state:
                 logger.error(f"蓝光原盘 {fileitem.path} 转封装失败：{errmsg}")
                 return TransferInfo(

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -3,6 +3,7 @@ import shutil
 import subprocess
 import threading
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, List, Tuple
 
@@ -31,6 +32,24 @@ from app.schemas.types import MediaType, ChainEventType
 from app.utils.system import SystemUtils
 
 _BLURAY_MPLS_MAX_SIZE = 1024 * 1024
+_BLURAY_MPLS_TIME_BASE = 45000
+
+
+@dataclass(frozen=True)
+class _BlurayRemuxSource:
+    """
+    蓝光转封装源分片。
+    """
+    path: Path
+    in_time: int = 0
+    out_time: int = 0
+
+    @property
+    def need_clip(self) -> bool:
+        """
+        是否需要按 MPLS 时间戳裁剪。
+        """
+        return self.in_time > 0 or self.out_time > 0
 
 
 class TransHandler:
@@ -186,9 +205,9 @@ class TransHandler:
         return None
 
     @staticmethod
-    def __parse_mpls_stream_names(mpls_file: Path) -> List[str]:
+    def __parse_mpls_stream_items(mpls_file: Path) -> List[Tuple[str, int, int]]:
         """
-        从 MPLS 播放列表中提取 m2ts 分片名。
+        从 MPLS 播放列表中提取 m2ts 分片名和裁剪时间。
         """
         try:
             if mpls_file.stat().st_size > _BLURAY_MPLS_MAX_SIZE:
@@ -203,28 +222,43 @@ class TransHandler:
             pos = playlist_start + 6
             playitem_count = int.from_bytes(data[pos:pos + 2], "big")
             pos += 4
-            stream_names = []
+            stream_items = []
             for _ in range(playitem_count):
-                if pos + 13 > len(data):
+                if pos + 21 > len(data):
                     return []
                 item_length = int.from_bytes(data[pos:pos + 2], "big")
                 item_end = pos + 2 + item_length
-                if item_length < 9 or item_end > len(data):
+                if item_length < 19 or item_end > len(data):
                     return []
                 clip_name = data[pos + 2:pos + 7].decode(
                     "ascii", errors="ignore"
                 ).strip("\x00 ")
                 if not clip_name:
                     return []
-                stream_names.append(f"{clip_name}.m2ts")
+                in_time = int.from_bytes(data[pos + 13:pos + 17], "big")
+                out_time = int.from_bytes(data[pos + 17:pos + 21], "big")
+                if out_time <= in_time:
+                    return []
+                stream_items.append((f"{clip_name}.m2ts", in_time, out_time))
                 pos = item_end
-            return stream_names
+            return stream_items
         except Exception as err:
             logger.debug(f"解析蓝光播放列表 {mpls_file} 失败：{err}")
             return []
 
     @classmethod
-    def __get_bluray_remux_sources(cls, bluray_root: Path) -> Tuple[List[Path], int]:
+    def __parse_mpls_stream_names(cls, mpls_file: Path) -> List[str]:
+        """
+        从 MPLS 播放列表中提取 m2ts 分片名。
+        """
+        return [item[0] for item in cls.__parse_mpls_stream_items(mpls_file)]
+
+    @classmethod
+    def __get_bluray_remux_sources(
+            cls,
+            bluray_root: Path,
+            allow_largest_fallback: bool = True,
+    ) -> Tuple[List[_BlurayRemuxSource], int]:
         """
         获取蓝光原盘转封装源文件列表。
         """
@@ -254,16 +288,19 @@ class TransHandler:
                 if item.is_file() and item.suffix.lower() == ".mpls"
             ]
             for mpls_file in sorted(playlist_files):
-                names = cls.__parse_mpls_stream_names(mpls_file)
+                stream_items = cls.__parse_mpls_stream_items(mpls_file)
                 files = [
                     stream_map.get(name.upper())
-                    for name in names
+                    for name, _in_time, _out_time in stream_items
                 ]
                 if not files or any(item is None for item in files):
                     continue
                 total_size = sum(item.stat().st_size for item in files)
                 if total_size > best_size:
-                    best_files = files
+                    best_files = [
+                        _BlurayRemuxSource(file, in_time, out_time)
+                        for file, (_name, in_time, out_time) in zip(files, stream_items)
+                    ]
                     best_size = total_size
         if best_files:
             return best_files, best_size
@@ -274,8 +311,14 @@ class TransHandler:
             )
             return [], 0
 
+        if len(stream_files) > 1 and not allow_largest_fallback:
+            logger.warn(
+                f"蓝光原盘 {bluray_root} 缺少播放列表，移动模式跳过最大分片回退"
+            )
+            return [], 0
+
         largest_file = max(stream_files, key=lambda item: item.stat().st_size)
-        return [largest_file], largest_file.stat().st_size
+        return [_BlurayRemuxSource(largest_file)], largest_file.stat().st_size
 
     @staticmethod
     def __build_local_fileitem(path: Path) -> FileItem:
@@ -303,10 +346,17 @@ class TransHandler:
             raise ValueError("蓝光分片路径包含换行控制字符")
         return value.replace("'", "'\\''")
 
+    @staticmethod
+    def __format_bluray_time(value: int) -> str:
+        """
+        将 MPLS 时间戳转换为 ffconcat 秒数。
+        """
+        return f"{value / _BLURAY_MPLS_TIME_BASE:.6f}".rstrip("0").rstrip(".")
+
     @classmethod
     def __run_bluray_remux(
             cls,
-            source_files: List[Path],
+            source_files: List[_BlurayRemuxSource],
             target_file: Path,
     ) -> Tuple[bool, str]:
         """
@@ -325,7 +375,7 @@ class TransHandler:
             f".{target_file.stem}.{temp_suffix}.ffconcat"
         )
         try:
-            if len(source_files) == 1:
+            if len(source_files) == 1 and not source_files[0].need_clip:
                 command = [
                     ffmpeg,
                     "-hide_banner",
@@ -333,7 +383,7 @@ class TransHandler:
                     "error",
                     "-y",
                     "-i",
-                    source_files[0].as_posix(),
+                    source_files[0].path.as_posix(),
                     "-map",
                     "0",
                     "-c",
@@ -342,13 +392,21 @@ class TransHandler:
                     tmp_file.as_posix(),
                 ]
             else:
-                concat_file.write_text(
-                    "ffconcat version 1.0\n"
-                    + "\n".join(
-                        f"file '{cls.__escape_ffconcat_path(item)}'"
-                        for item in source_files
+                concat_lines = ["ffconcat version 1.0"]
+                for item in source_files:
+                    concat_lines.append(
+                        f"file '{cls.__escape_ffconcat_path(item.path)}'"
                     )
-                    + "\n",
+                    if item.in_time > 0:
+                        concat_lines.append(
+                            f"inpoint {cls.__format_bluray_time(item.in_time)}"
+                        )
+                    if item.out_time > 0:
+                        concat_lines.append(
+                            f"outpoint {cls.__format_bluray_time(item.out_time)}"
+                        )
+                concat_file.write_text(
+                    "\n".join(concat_lines) + "\n",
                     encoding="utf-8",
                 )
                 command = [
@@ -580,7 +638,10 @@ class TransHandler:
                     need_notify=need_notify,
                 )
 
-        source_files, source_size = self.__get_bluray_remux_sources(bluray_root)
+        source_files, source_size = self.__get_bluray_remux_sources(
+            bluray_root,
+            allow_largest_fallback=transfer_type == "copy",
+        )
         if not source_files:
             return TransferInfo(
                 success=False,

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -30,6 +30,8 @@ from app.schemas import (
 from app.schemas.types import MediaType, ChainEventType
 from app.utils.system import SystemUtils
 
+_BLURAY_MPLS_MAX_SIZE = 1024 * 1024
+
 
 class TransHandler:
     """
@@ -189,6 +191,9 @@ class TransHandler:
         从 MPLS 播放列表中提取 m2ts 分片名。
         """
         try:
+            if mpls_file.stat().st_size > _BLURAY_MPLS_MAX_SIZE:
+                logger.warn(f"蓝光播放列表 {mpls_file} 过大，跳过解析")
+                return []
             data = mpls_file.read_bytes()
             if len(data) < 16:
                 return []
@@ -227,7 +232,12 @@ class TransHandler:
         stream_files = [
             item
             for item in stream_dir.iterdir()
-            if item.is_file() and item.suffix.lower() == ".m2ts"
+            if (
+                not item.is_symlink()
+                and item.is_file()
+                and item.suffix.lower() == ".m2ts"
+                and cls.__is_path_relative_to(item, bluray_root)
+            )
         ] if stream_dir.is_dir() else []
         if not stream_files:
             return [], 0
@@ -373,10 +383,12 @@ class TransHandler:
         except Exception as err:
             return False, f"蓝光原盘转封装失败：{err}"
         finally:
-            if tmp_file.exists():
-                tmp_file.unlink()
-            if concat_file.exists():
-                concat_file.unlink()
+            for cleanup_file in [tmp_file, concat_file]:
+                try:
+                    if cleanup_file.exists():
+                        cleanup_file.unlink()
+                except OSError as err:
+                    logger.warning(f"清理蓝光转封装临时文件失败：{cleanup_file} - {err}")
 
     def __get_bluray_remux_target_file(
             self,

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -1,6 +1,8 @@
 import re
 import shutil
 import subprocess
+import threading
+import uuid
 from pathlib import Path
 from typing import Optional, List, Tuple
 
@@ -34,8 +36,22 @@ class TransHandler:
     文件转移整理类
     """
 
+    _bluray_remux_locks = {}
+    _bluray_remux_locks_guard = threading.Lock()
+
     def __init__(self):
         pass
+
+    @classmethod
+    def __get_bluray_remux_target_lock(cls, target_file: Path) -> threading.Lock:
+        """
+        获取蓝光转封装目标文件锁，避免并发任务共享临时文件或相互覆盖。
+        """
+        lock_key = target_file.resolve().as_posix()
+        with cls._bluray_remux_locks_guard:
+            if lock_key not in cls._bluray_remux_locks:
+                cls._bluray_remux_locks[lock_key] = threading.Lock()
+            return cls._bluray_remux_locks[lock_key]
 
     @staticmethod
     def __normalize_disc_folder_name(value: Optional[str]) -> Optional[str]:
@@ -250,7 +266,10 @@ class TransHandler:
         """
         转义 ffconcat 文件中的路径。
         """
-        return path.as_posix().replace("\\", "/").replace("'", "\\'")
+        value = path.as_posix().replace("\\", "/")
+        if "\n" in value or "\r" in value:
+            raise ValueError("蓝光分片路径包含换行控制字符")
+        return value.replace("'", "\\'")
 
     @classmethod
     def __run_bluray_remux(
@@ -266,13 +285,14 @@ class TransHandler:
             return False, "未找到 ffmpeg，无法进行蓝光原盘转封装"
 
         target_file.parent.mkdir(parents=True, exist_ok=True)
+        temp_suffix = uuid.uuid4().hex
         tmp_file = target_file.with_name(
-            f".{target_file.stem}.tmp{target_file.suffix}"
+            f".{target_file.stem}.{temp_suffix}.tmp{target_file.suffix}"
         )
-        concat_file = target_file.with_name(f".{target_file.stem}.ffconcat")
+        concat_file = target_file.with_name(
+            f".{target_file.stem}.{temp_suffix}.ffconcat"
+        )
         try:
-            if tmp_file.exists():
-                tmp_file.unlink()
             if len(source_files) == 1:
                 command = [
                     ffmpeg,
@@ -380,8 +400,6 @@ class TransHandler:
         """
         target_item = target_oper.get_item(target_file)
         if not target_item:
-            if overwrite_mode == "latest":
-                self.__delete_version_files(target_oper, target_file)
             return True, ""
 
         logger.info(
@@ -518,38 +536,43 @@ class TransHandler:
                 transfer_type=transfer_type,
                 need_notify=need_notify,
             )
-        can_overwrite, errmsg = self.__check_bluray_remux_overwrite(
-            fileitem=fileitem,
-            target_oper=target_oper,
-            target_file=target_file,
-            target_storage=target_storage,
-            transfer_type=transfer_type,
-            overwrite_mode=overwrite_mode,
-            source_size=source_size,
-        )
-        if not can_overwrite:
-            return TransferInfo(
-                success=False,
-                message=errmsg,
+        target_lock = self.__get_bluray_remux_target_lock(target_file)
+        with target_lock:
+            can_overwrite, errmsg = self.__check_bluray_remux_overwrite(
                 fileitem=fileitem,
-                target_diritem=target_diritem,
-                fail_list=[fileitem.path],
+                target_oper=target_oper,
+                target_file=target_file,
+                target_storage=target_storage,
                 transfer_type=transfer_type,
-                need_notify=need_notify,
+                overwrite_mode=overwrite_mode,
+                source_size=source_size,
             )
+            if not can_overwrite:
+                return TransferInfo(
+                    success=False,
+                    message=errmsg,
+                    fileitem=fileitem,
+                    target_diritem=target_diritem,
+                    fail_list=[fileitem.path],
+                    transfer_type=transfer_type,
+                    need_notify=need_notify,
+                )
 
-        logger.info(f"正在转封装蓝光原盘：{bluray_root} 到 {target_file}")
-        state, errmsg = self.__run_bluray_remux(source_files, target_file)
-        if not state:
-            logger.error(f"蓝光原盘 {fileitem.path} 转封装失败：{errmsg}")
-            return TransferInfo(
-                success=False,
-                message=errmsg,
-                fileitem=fileitem,
-                fail_list=[fileitem.path],
-                transfer_type=transfer_type,
-                need_notify=need_notify,
-            )
+            logger.info(f"正在转封装蓝光原盘：{bluray_root} 到 {target_file}")
+            state, errmsg = self.__run_bluray_remux(source_files, target_file)
+            if not state:
+                logger.error(f"蓝光原盘 {fileitem.path} 转封装失败：{errmsg}")
+                return TransferInfo(
+                    success=False,
+                    message=errmsg,
+                    fileitem=fileitem,
+                    fail_list=[fileitem.path],
+                    transfer_type=transfer_type,
+                    need_notify=need_notify,
+                )
+            if overwrite_mode == "latest":
+                self.__delete_version_files(target_oper, target_file)
+
         if transfer_type == "move" and not source_oper.delete(fileitem):
             return TransferInfo(
                 success=False,

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -1,4 +1,6 @@
 import re
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Optional, List, Tuple
 
@@ -125,6 +127,449 @@ class TransHandler:
             type=item_type,
             extension=path.suffix.lstrip(".") if item_type == "file" else None,
             size=size if item_type == "file" else None,
+        )
+
+    @staticmethod
+    def __get_local_bluray_root(path: Path) -> Optional[Path]:
+        """
+        获取本地蓝光原盘根目录。
+        """
+        if (path / "BDMV" / "STREAM").is_dir():
+            return path
+        if path.name.upper() == "BDMV" and (path / "STREAM").is_dir():
+            return path.parent
+        if (
+            path.name.upper() == "STREAM"
+            and path.parent.name.upper() == "BDMV"
+            and path.is_dir()
+        ):
+            return path.parent.parent
+        return None
+
+    @staticmethod
+    def __parse_mpls_stream_names(mpls_file: Path) -> List[str]:
+        """
+        从 MPLS 播放列表中提取 m2ts 分片名。
+        """
+        try:
+            data = mpls_file.read_bytes()
+            if len(data) < 16:
+                return []
+            playlist_start = int.from_bytes(data[8:12], "big")
+            if playlist_start <= 0 or playlist_start + 10 > len(data):
+                return []
+            pos = playlist_start + 6
+            playitem_count = int.from_bytes(data[pos:pos + 2], "big")
+            pos += 4
+            stream_names = []
+            for _ in range(playitem_count):
+                if pos + 13 > len(data):
+                    break
+                item_length = int.from_bytes(data[pos:pos + 2], "big")
+                item_end = pos + 2 + item_length
+                if item_length < 9 or item_end > len(data):
+                    break
+                clip_name = data[pos + 2:pos + 7].decode(
+                    "ascii", errors="ignore"
+                ).strip("\x00 ")
+                if clip_name:
+                    stream_names.append(f"{clip_name}.m2ts")
+                pos = item_end
+            return stream_names
+        except Exception as err:
+            logger.debug(f"解析蓝光播放列表 {mpls_file} 失败：{err}")
+            return []
+
+    @classmethod
+    def __get_bluray_remux_sources(cls, bluray_root: Path) -> Tuple[List[Path], int]:
+        """
+        获取蓝光原盘转封装源文件列表。
+        """
+        stream_dir = bluray_root / "BDMV" / "STREAM"
+        stream_files = [
+            item
+            for item in stream_dir.iterdir()
+            if item.is_file() and item.suffix.lower() == ".m2ts"
+        ] if stream_dir.is_dir() else []
+        if not stream_files:
+            return [], 0
+
+        stream_map = {item.name.upper(): item for item in stream_files}
+        playlist_dir = bluray_root / "BDMV" / "PLAYLIST"
+        best_files = []
+        best_size = 0
+        if playlist_dir.is_dir():
+            for mpls_file in sorted(playlist_dir.glob("*.mpls")):
+                names = cls.__parse_mpls_stream_names(mpls_file)
+                files = [
+                    stream_map.get(name.upper())
+                    for name in names
+                ]
+                if not files or any(item is None for item in files):
+                    continue
+                total_size = sum(item.stat().st_size for item in files)
+                if total_size > best_size:
+                    best_files = files
+                    best_size = total_size
+        if best_files:
+            return best_files, best_size
+
+        largest_file = max(stream_files, key=lambda item: item.stat().st_size)
+        return [largest_file], largest_file.stat().st_size
+
+    @staticmethod
+    def __build_local_fileitem(path: Path) -> FileItem:
+        """
+        根据本地文件路径构造文件项。
+        """
+        return FileItem(
+            storage="local",
+            path=path.as_posix(),
+            name=path.name,
+            basename=path.stem,
+            type="file",
+            size=path.stat().st_size,
+            extension=path.suffix.lstrip("."),
+            modify_time=path.stat().st_mtime,
+        )
+
+    @staticmethod
+    def __escape_ffconcat_path(path: Path) -> str:
+        """
+        转义 ffconcat 文件中的路径。
+        """
+        return path.as_posix().replace("\\", "/").replace("'", "\\'")
+
+    @classmethod
+    def __run_bluray_remux(
+            cls,
+            source_files: List[Path],
+            target_file: Path,
+    ) -> Tuple[bool, str]:
+        """
+        使用 ffmpeg 将蓝光原盘分片转封装为单个 MKV。
+        """
+        ffmpeg = shutil.which("ffmpeg")
+        if not ffmpeg:
+            return False, "未找到 ffmpeg，无法进行蓝光原盘转封装"
+
+        target_file.parent.mkdir(parents=True, exist_ok=True)
+        tmp_file = target_file.with_name(
+            f".{target_file.stem}.tmp{target_file.suffix}"
+        )
+        concat_file = target_file.with_name(f".{target_file.stem}.ffconcat")
+        try:
+            if tmp_file.exists():
+                tmp_file.unlink()
+            if len(source_files) == 1:
+                command = [
+                    ffmpeg,
+                    "-hide_banner",
+                    "-loglevel",
+                    "error",
+                    "-y",
+                    "-i",
+                    source_files[0].as_posix(),
+                    "-map",
+                    "0",
+                    "-c",
+                    "copy",
+                    "-dn",
+                    tmp_file.as_posix(),
+                ]
+            else:
+                concat_file.write_text(
+                    "ffconcat version 1.0\n"
+                    + "\n".join(
+                        f"file '{cls.__escape_ffconcat_path(item)}'"
+                        for item in source_files
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+                command = [
+                    ffmpeg,
+                    "-hide_banner",
+                    "-loglevel",
+                    "error",
+                    "-y",
+                    "-f",
+                    "concat",
+                    "-safe",
+                    "0",
+                    "-i",
+                    concat_file.as_posix(),
+                    "-map",
+                    "0",
+                    "-c",
+                    "copy",
+                    "-dn",
+                    tmp_file.as_posix(),
+                ]
+            completed = subprocess.run(
+                command, capture_output=True, text=True, check=False
+            )
+            if completed.returncode != 0:
+                errmsg = (completed.stderr or completed.stdout or "").strip()
+                return False, f"ffmpeg 转封装失败：{errmsg or completed.returncode}"
+            if not tmp_file.exists():
+                return False, "ffmpeg 转封装完成但未生成目标文件"
+            if target_file.exists() or target_file.is_symlink():
+                target_file.unlink()
+            tmp_file.replace(target_file)
+            return True, ""
+        except Exception as err:
+            return False, f"蓝光原盘转封装失败：{err}"
+        finally:
+            if tmp_file.exists():
+                tmp_file.unlink()
+            if concat_file.exists():
+                concat_file.unlink()
+
+    def __get_bluray_remux_target_file(
+            self,
+            fileitem: FileItem,
+            in_meta: MetaBase,
+            mediainfo: MediaInfo,
+            target_path: Path,
+            rename_format: str,
+            need_rename: bool,
+    ) -> Path:
+        """
+        获取蓝光原盘转封装目标文件路径。
+        """
+        if need_rename:
+            target_file = self.get_rename_path(
+                path=target_path,
+                template_string=rename_format,
+                rename_dict=self.get_naming_dict(
+                    meta=in_meta,
+                    mediainfo=mediainfo,
+                    file_ext=".mkv",
+                ),
+                source_path=fileitem.path,
+                source_item=fileitem,
+            )
+            if target_file.suffix.lower() != ".mkv":
+                target_file = target_file.parent / f"{target_file.name}.mkv"
+            return target_file
+        return target_path / f"{fileitem.name}.mkv"
+
+    def __check_bluray_remux_overwrite(
+            self,
+            fileitem: FileItem,
+            target_oper: StorageBase,
+            target_file: Path,
+            target_storage: str,
+            transfer_type: str,
+            overwrite_mode: Optional[str],
+            source_size: int,
+    ) -> Tuple[bool, str]:
+        """
+        检查蓝光转封装目标文件覆盖策略。
+        """
+        target_item = target_oper.get_item(target_file)
+        if not target_item:
+            if overwrite_mode == "latest":
+                self.__delete_version_files(target_oper, target_file)
+            return True, ""
+
+        logger.info(
+            f"目的文件系统中已经存在同名文件 {target_file}，当前整理覆盖模式设置为 {overwrite_mode}"
+        )
+        overwrite_event_data = TransferOverwriteCheckEventData(
+            fileitem=fileitem,
+            target_item=target_item,
+            target_storage=target_storage,
+            target_path=target_file,
+            overwrite_mode=overwrite_mode or "",
+            transfer_type=transfer_type,
+        )
+        overwrite_event = eventmanager.send_event(
+            ChainEventType.TransferOverwriteCheck,
+            overwrite_event_data,
+        )
+        if overwrite_event and overwrite_event.event_data:
+            overwrite_event_data = overwrite_event.event_data
+            if overwrite_event_data.overwrite is True:
+                target_oper.delete(target_item)
+                return True, ""
+            if overwrite_event_data.overwrite is False:
+                return False, overwrite_event_data.reason or "插件决定不覆盖已有文件"
+
+        if overwrite_mode in ["always", "latest"]:
+            target_oper.delete(target_item)
+            return True, ""
+        if overwrite_mode == "size":
+            if (target_item.size or 0) < source_size:
+                target_oper.delete(target_item)
+                return True, ""
+            return False, "媒体库存在同名文件，且质量更好"
+        if overwrite_mode == "never":
+            return False, "媒体库存在同名文件，当前覆盖模式为不覆盖"
+        return False, f"{target_file} 已存在"
+
+    def __transfer_bluray_remux(
+            self,
+            fileitem: FileItem,
+            in_meta: MetaBase,
+            mediainfo: MediaInfo,
+            target_storage: str,
+            target_path: Path,
+            transfer_type: str,
+            source_oper: StorageBase,
+            target_oper: StorageBase,
+            rename_format: str,
+            overwrite_mode: Optional[str],
+            need_scrape: bool,
+            need_rename: bool,
+            need_notify: bool,
+    ) -> Optional[TransferInfo]:
+        """
+        在配置开启时将本地蓝光原盘目录转封装为单个 MKV。
+        """
+        if not settings.BLURAY_REMUX_ENABLED:
+            return None
+        if (fileitem.storage or "local") != "local" or target_storage != "local":
+            logger.warn("蓝光原盘转封装仅支持本地源到本地目标，保持目录整理")
+            return None
+        if transfer_type not in ["copy", "move"]:
+            logger.warn(
+                f"蓝光原盘转封装不支持 {transfer_type} 整理方式，保持目录整理"
+            )
+            return None
+
+        bluray_root = self.__get_local_bluray_root(Path(fileitem.path))
+        if not bluray_root:
+            return None
+        if mediainfo.type == MediaType.TV and in_meta.begin_episode is None:
+            logger.warn("电视剧蓝光原盘未识别到集数，保持目录整理")
+            return None
+
+        target_file = self.__get_bluray_remux_target_file(
+            fileitem=fileitem,
+            in_meta=in_meta,
+            mediainfo=mediainfo,
+            target_path=target_path,
+            rename_format=rename_format,
+            need_rename=need_rename,
+        )
+        if need_rename:
+            folder_path = DirectoryHelper.get_media_root_path(
+                rename_format, rename_path=target_file
+            )
+        else:
+            folder_path = target_file.parent
+        if not folder_path:
+            return TransferInfo(
+                success=False,
+                message="重命名格式无效",
+                fileitem=fileitem,
+                transfer_type=transfer_type,
+                need_notify=need_notify,
+            )
+        target_diritem = target_oper.get_folder(folder_path)
+        if not target_diritem:
+            return TransferInfo(
+                success=False,
+                message=f"目标目录 {folder_path} 获取失败",
+                fileitem=fileitem,
+                fail_list=[fileitem.path],
+                transfer_type=transfer_type,
+                need_notify=need_notify,
+            )
+
+        event_data = TransferInterceptEventData(
+            fileitem=fileitem,
+            meta=in_meta,
+            mediainfo=mediainfo,
+            target_storage=target_storage,
+            target_path=target_file,
+            transfer_type=transfer_type,
+            options={"bluray_remux": True},
+        )
+        event = eventmanager.send_event(ChainEventType.TransferIntercept, event_data)
+        if event and event.event_data:
+            event_data = event.event_data
+            if event_data.cancel:
+                return TransferInfo(
+                    success=False,
+                    message=event_data.reason,
+                    fileitem=fileitem,
+                    fail_list=[fileitem.path],
+                    transfer_type=transfer_type,
+                    need_notify=need_notify,
+                )
+
+        source_files, source_size = self.__get_bluray_remux_sources(bluray_root)
+        if not source_files:
+            return TransferInfo(
+                success=False,
+                message=f"蓝光原盘 {bluray_root} 未找到可转封装的视频分片",
+                fileitem=fileitem,
+                fail_list=[fileitem.path],
+                transfer_type=transfer_type,
+                need_notify=need_notify,
+            )
+        can_overwrite, errmsg = self.__check_bluray_remux_overwrite(
+            fileitem=fileitem,
+            target_oper=target_oper,
+            target_file=target_file,
+            target_storage=target_storage,
+            transfer_type=transfer_type,
+            overwrite_mode=overwrite_mode,
+            source_size=source_size,
+        )
+        if not can_overwrite:
+            return TransferInfo(
+                success=False,
+                message=errmsg,
+                fileitem=fileitem,
+                target_diritem=target_diritem,
+                fail_list=[fileitem.path],
+                transfer_type=transfer_type,
+                need_notify=need_notify,
+            )
+
+        logger.info(f"正在转封装蓝光原盘：{bluray_root} 到 {target_file}")
+        state, errmsg = self.__run_bluray_remux(source_files, target_file)
+        if not state:
+            logger.error(f"蓝光原盘 {fileitem.path} 转封装失败：{errmsg}")
+            return TransferInfo(
+                success=False,
+                message=errmsg,
+                fileitem=fileitem,
+                fail_list=[fileitem.path],
+                transfer_type=transfer_type,
+                need_notify=need_notify,
+            )
+        if transfer_type == "move" and not source_oper.delete(fileitem):
+            return TransferInfo(
+                success=False,
+                message="转封装成功但删除源目录失败",
+                fileitem=fileitem,
+                target_diritem=target_diritem,
+                fail_list=[fileitem.path],
+                transfer_type=transfer_type,
+                need_notify=need_notify,
+            )
+
+        target_item = target_oper.get_item(target_file)
+        if not target_item:
+            target_item = self.__build_local_fileitem(target_file)
+        logger.info(f"蓝光原盘 {fileitem.path} 转封装整理成功")
+        return TransferInfo(
+            success=True,
+            fileitem=fileitem,
+            target_item=target_item,
+            target_diritem=target_diritem,
+            need_scrape=need_scrape,
+            need_notify=need_notify,
+            transfer_type=transfer_type,
+            file_list=[fileitem.path],
+            file_list_new=[target_item.path],
+            file_count=1,
+            total_size=target_item.size or 0,
         )
 
     def transfer_media(
@@ -257,6 +702,24 @@ class TransHandler:
                     fileitem.size = sum(
                         file.size for file in source_oper.list(stream_fileitem) or []
                     )
+                # 可选：将本地蓝光原盘转封装为单个 MKV 文件
+                bluray_remux_result = self.__transfer_bluray_remux(
+                    fileitem=fileitem,
+                    in_meta=in_meta,
+                    mediainfo=mediainfo,
+                    target_storage=target_storage,
+                    target_path=target_path,
+                    transfer_type=transfer_type,
+                    source_oper=source_oper,
+                    target_oper=target_oper,
+                    rename_format=rename_format,
+                    overwrite_mode=overwrite_mode,
+                    need_scrape=need_scrape,
+                    need_rename=need_rename,
+                    need_notify=need_notify,
+                )
+                if bluray_remux_result:
+                    return bluray_remux_result
                 # 整理目录
                 new_diritem, errmsg = self.__transfer_dir(
                     fileitem=fileitem,

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -54,6 +54,17 @@ class TransHandler:
             return cls._bluray_remux_locks[lock_key]
 
     @staticmethod
+    def __is_path_relative_to(path: Path, parent: Path) -> bool:
+        """
+        判断 path 是否位于 parent 内部，兼容目标文件尚未创建的场景。
+        """
+        try:
+            path.resolve().relative_to(parent.resolve())
+            return True
+        except (OSError, ValueError):
+            return False
+
+    @staticmethod
     def __normalize_disc_folder_name(value: Optional[str]) -> Optional[str]:
         """
         从 Disc/Disk/DVD/CD 标识中提取盘号并统一为 Disc N。
@@ -479,6 +490,17 @@ class TransHandler:
             rename_format=rename_format,
             need_rename=need_rename,
         )
+        if transfer_type == "move" and self.__is_path_relative_to(
+            target_file, bluray_root
+        ):
+            return TransferInfo(
+                success=False,
+                message="蓝光原盘转封装目标不能位于源目录内",
+                fileitem=fileitem,
+                fail_list=[fileitem.path],
+                transfer_type=transfer_type,
+                need_notify=need_notify,
+            )
         if need_rename:
             folder_path = DirectoryHelper.get_media_root_path(
                 rename_format, rename_path=target_file

--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -37,6 +37,8 @@ _BLURAY_MPLS_MAX_DURATION_SECONDS = 12 * 60 * 60
 _BLURAY_MPLS_TIME_BASE = 45000
 _BLURAY_PLAYITEM_IN_TIME_OFFSET = 14
 _BLURAY_PLAYITEM_OUT_TIME_OFFSET = 18
+_BLURAY_REMUX_LOCK_CACHE_LIMIT = 1024
+_BLURAY_REMUX_MIN_TIMEOUT = 60
 
 
 @dataclass(frozen=True)
@@ -76,6 +78,15 @@ class TransHandler:
         with cls._bluray_remux_locks_guard:
             if lock_key not in cls._bluray_remux_locks:
                 cls._bluray_remux_locks[lock_key] = threading.Lock()
+            while len(cls._bluray_remux_locks) > _BLURAY_REMUX_LOCK_CACHE_LIMIT:
+                removed = False
+                for stale_key, stale_lock in list(cls._bluray_remux_locks.items()):
+                    if stale_key != lock_key and not stale_lock.locked():
+                        cls._bluray_remux_locks.pop(stale_key, None)
+                        removed = True
+                        break
+                if not removed:
+                    break
             return cls._bluray_remux_locks[lock_key]
 
     @staticmethod
@@ -465,8 +476,12 @@ class TransHandler:
                     "-dn",
                     tmp_file.as_posix(),
                 ]
+            timeout = max(
+                _BLURAY_REMUX_MIN_TIMEOUT,
+                int(settings.BLURAY_REMUX_TIMEOUT or _BLURAY_REMUX_MIN_TIMEOUT),
+            )
             completed = subprocess.run(
-                command, capture_output=True, text=True, check=False
+                command, capture_output=True, text=True, check=False, timeout=timeout
             )
             if completed.returncode != 0:
                 errmsg = (completed.stderr or completed.stdout or "").strip()
@@ -487,6 +502,8 @@ class TransHandler:
                 return False, "媒体库存在同名文件，且质量更好"
             tmp_file.replace(target_file)
             return True, ""
+        except subprocess.TimeoutExpired:
+            return False, f"ffmpeg 转封装超过 {timeout} 秒"
         except Exception as err:
             return False, f"蓝光原盘转封装失败：{err}"
         finally:
@@ -764,18 +781,28 @@ class TransHandler:
             if overwrite_mode == "latest":
                 self.__delete_version_files(target_oper, target_file)
 
+        target_item = target_oper.get_item(target_file)
+        if not target_item and target_file.exists():
+            target_item = self.__build_local_fileitem(target_file)
+
         if transfer_type == "move" and not source_oper.delete(fileitem):
+            if not allow_target_replace and (target_file.exists() or target_file.is_symlink()):
+                try:
+                    target_file.unlink()
+                    target_item = None
+                except OSError as err:
+                    logger.error(f"回滚蓝光原盘转封装目标文件失败：{target_file} - {err}")
             return TransferInfo(
                 success=False,
                 message="转封装成功但删除源目录失败",
                 fileitem=fileitem,
+                target_item=target_item,
                 target_diritem=target_diritem,
                 fail_list=[fileitem.path],
                 transfer_type=transfer_type,
                 need_notify=need_notify,
             )
 
-        target_item = target_oper.get_item(target_file)
         if not target_item:
             target_item = self.__build_local_fileitem(target_file)
         logger.info(f"蓝光原盘 {fileitem.path} 转封装整理成功")

--- a/tests/test_bluray.py
+++ b/tests/test_bluray.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
+import shutil
 import subprocess
 from pathlib import Path, PurePosixPath
 from tempfile import TemporaryDirectory
@@ -260,6 +261,19 @@ class BluRayRemuxTest(TestCase):
         path.write_bytes(b"MPLS0200" + (16).to_bytes(4, "big") + b"\x00" * 4 + playlist)
 
     @staticmethod
+    def __set_first_mpls_times(path: Path, in_time: int, out_time: int):
+        data = bytearray(path.read_bytes())
+        playlist_start = int.from_bytes(data[8:12], "big")
+        first_playitem_pos = playlist_start + 10
+        data[first_playitem_pos + 13:first_playitem_pos + 17] = in_time.to_bytes(
+            4, "big"
+        )
+        data[first_playitem_pos + 17:first_playitem_pos + 21] = out_time.to_bytes(
+            4, "big"
+        )
+        path.write_bytes(data)
+
+    @staticmethod
     def __create_bluray_dir(
             root: Path,
             playlist_name: str = "00000.mpls",
@@ -359,6 +373,47 @@ class BluRayRemuxTest(TestCase):
             command = mock_run.call_args.args[0]
             self.assertIn("concat", command)
             self.assertIn("-safe", command)
+
+    def test_bluray_remux_writes_playlist_clip_points(self):
+        concat_files = []
+
+        def run_ffmpeg(command, *_args, **_kwargs):
+            concat_files.append(Path(command[command.index("-i") + 1]).read_text())
+            output_path = Path(command[-1])
+            output_path.write_bytes(b"mkv")
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_root = root / "BluRay Movie Source"
+            source_item = self.__create_bluray_dir(source_root)
+            self.__set_first_mpls_times(
+                source_root / "BDMV" / "PLAYLIST" / "00000.mpls",
+                in_time=45000,
+                out_time=90000,
+            )
+
+            with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
+                "app.modules.filemanager.transhandler.shutil.which",
+                return_value="ffmpeg",
+            ), patch(
+                "app.modules.filemanager.transhandler.subprocess.run",
+                side_effect=run_ffmpeg,
+            ):
+                result = TransHandler().transfer_media(
+                    fileitem=source_item,
+                    in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
+                    mediainfo=self.__movie_info(),
+                    target_storage="local",
+                    target_path=root / "media",
+                    transfer_type="copy",
+                    source_oper=LocalStorage(),
+                    target_oper=LocalStorage(),
+                )
+
+            self.assertTrue(result.success)
+            self.assertIn("inpoint 1", concat_files[0])
+            self.assertIn("outpoint 2", concat_files[0])
 
     def test_bluray_remux_accepts_uppercase_playlist_suffix(self):
         def run_ffmpeg(command, *_args, **_kwargs):
@@ -524,6 +579,17 @@ class BluRayRemuxTest(TestCase):
                 [],
             )
 
+    def test_bluray_remux_rejects_invalid_playlist_time_range(self):
+        with TemporaryDirectory() as temp_dir:
+            mpls_file = Path(temp_dir) / "00000.mpls"
+            self.__write_mpls(mpls_file, ["00000.m2ts"])
+            self.__set_first_mpls_times(mpls_file, in_time=90000, out_time=45000)
+
+            self.assertEqual(
+                TransHandler._TransHandler__parse_mpls_stream_names(mpls_file),
+                [],
+            )
+
     def test_bluray_remux_rejects_large_playlist_parse(self):
         with TemporaryDirectory() as temp_dir:
             mpls_file = Path(temp_dir) / "00000.mpls"
@@ -584,6 +650,32 @@ class BluRayRemuxTest(TestCase):
                 self.assertTrue(source_root.exists())
                 self.assertFalse((source_root / f"{source_item.name}.mkv").exists())
                 self.assertFalse(mock_run.called)
+
+    def test_bluray_remux_move_rejects_multi_stream_largest_file_fallback(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_root = root / "BluRay Movie Source"
+            source_item = self.__create_bluray_dir(source_root)
+            shutil.rmtree(source_root / "BDMV" / "PLAYLIST")
+
+            with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
+                "app.modules.filemanager.transhandler.subprocess.run"
+            ) as mock_run:
+                result = TransHandler().transfer_media(
+                    fileitem=source_item,
+                    in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
+                    mediainfo=self.__movie_info(),
+                    target_storage="local",
+                    target_path=root / "media",
+                    transfer_type="move",
+                    source_oper=LocalStorage(),
+                    target_oper=LocalStorage(),
+                    need_rename=False,
+                )
+
+            self.assertFalse(result.success)
+            self.assertTrue(source_root.exists())
+            self.assertFalse(mock_run.called)
 
     def test_bluray_remux_move_rejects_child_directory_entry(self):
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_bluray.py
+++ b/tests/test_bluray.py
@@ -316,6 +316,15 @@ class BluRayRemuxTest(TestCase):
         mediainfo.year = "2024"
         return mediainfo
 
+    def __assert_ffmpeg_not_called(self, mock_run):
+        for run_call in mock_run.call_args_list:
+            command = run_call.args[0] if run_call.args else run_call.kwargs.get("args")
+            if isinstance(command, (list, tuple)) and command:
+                executable = Path(str(command[0])).name.lower()
+            else:
+                executable = str(command or "").strip().split(" ", 1)[0].strip("'\"").lower()
+            self.assertNotIn(executable, {"ffmpeg", "ffmpeg.exe"})
+
     def test_bluray_remux_disabled_keeps_directory_transfer(self):
         with TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -338,7 +347,7 @@ class BluRayRemuxTest(TestCase):
 
             self.assertTrue(result.success)
             self.assertEqual(result.target_item.type, "dir")
-            self.assertFalse(mock_run.called)
+            self.__assert_ffmpeg_not_called(mock_run)
 
     def test_bluray_remux_enabled_uses_playlist_concat(self):
         def run_ffmpeg(command, *_args, **_kwargs):
@@ -483,7 +492,7 @@ class BluRayRemuxTest(TestCase):
 
             self.assertFalse(result.success)
             self.assertTrue(source_root.exists())
-            self.assertFalse(mock_run.called)
+            self.__assert_ffmpeg_not_called(mock_run)
 
     def test_tv_bluray_remux_keeps_directory_transfer(self):
         with TemporaryDirectory() as temp_dir:
@@ -507,7 +516,7 @@ class BluRayRemuxTest(TestCase):
 
             self.assertTrue(result.success)
             self.assertEqual(result.target_item.type, "dir")
-            self.assertFalse(mock_run.called)
+            self.__assert_ffmpeg_not_called(mock_run)
 
     def test_bluray_remux_failure_keeps_latest_version_files(self):
         def run_ffmpeg(command, *_args, **_kwargs):
@@ -672,7 +681,7 @@ class BluRayRemuxTest(TestCase):
                 self.assertFalse(result.success)
                 self.assertTrue(source_root.exists())
                 self.assertFalse((source_root / f"{source_item.name}.mkv").exists())
-                self.assertFalse(mock_run.called)
+                self.__assert_ffmpeg_not_called(mock_run)
 
     def test_bluray_remux_rejects_multi_stream_largest_file_fallback(self):
         for transfer_type in ["copy", "move"]:
@@ -699,7 +708,7 @@ class BluRayRemuxTest(TestCase):
 
                 self.assertFalse(result.success)
                 self.assertTrue(source_root.exists())
-                self.assertFalse(mock_run.called)
+                self.__assert_ffmpeg_not_called(mock_run)
 
     def test_bluray_remux_move_rejects_child_directory_entry(self):
         with TemporaryDirectory() as temp_dir:
@@ -732,7 +741,7 @@ class BluRayRemuxTest(TestCase):
 
             self.assertFalse(result.success)
             self.assertTrue(source_root.exists())
-            self.assertFalse(mock_run.called)
+            self.__assert_ffmpeg_not_called(mock_run)
 
     def test_bluray_remux_failure_keeps_existing_target_file(self):
         def run_ffmpeg(command, *_args, **_kwargs):
@@ -919,7 +928,7 @@ class BluRayRemuxTest(TestCase):
 
             self.assertFalse(result.success)
             self.assertTrue(target_file.is_symlink())
-            self.assertFalse(mock_run.called)
+            self.__assert_ffmpeg_not_called(mock_run)
 
     def test_bluray_remux_timeout_returns_failure(self):
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_bluray.py
+++ b/tests/test_bluray.py
@@ -495,6 +495,31 @@ class BluRayRemuxTest(TestCase):
                 Path("BluRay\nMovie Source") / "BDMV" / "STREAM" / "00000.m2ts"
             )
 
+    def test_bluray_remux_move_rejects_target_inside_source(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_root = root / "BluRay Movie Source"
+            source_item = self.__create_bluray_dir(source_root)
+
+            with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
+                "app.modules.filemanager.transhandler.subprocess.run"
+            ) as mock_run:
+                result = TransHandler().transfer_media(
+                    fileitem=source_item,
+                    in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
+                    mediainfo=self.__movie_info(),
+                    target_storage="local",
+                    target_path=source_root,
+                    transfer_type="move",
+                    source_oper=LocalStorage(),
+                    target_oper=LocalStorage(),
+                    need_rename=False,
+                )
+
+            self.assertFalse(result.success)
+            self.assertTrue(source_root.exists())
+            self.assertFalse(mock_run.called)
+
     def test_bluray_remux_failure_keeps_existing_target_file(self):
         def run_ffmpeg(command, *_args, **_kwargs):
             return subprocess.CompletedProcess(command, 1, "", "failed")

--- a/tests/test_bluray.py
+++ b/tests/test_bluray.py
@@ -451,6 +451,50 @@ class BluRayRemuxTest(TestCase):
             self.assertEqual(result.target_item.type, "dir")
             self.assertFalse(mock_run.called)
 
+    def test_bluray_remux_failure_keeps_latest_version_files(self):
+        def run_ffmpeg(command, *_args, **_kwargs):
+            return subprocess.CompletedProcess(command, 1, "", "failed")
+
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_item = self.__create_bluray_dir(root / "BluRay Movie Source")
+            old_file = (
+                root
+                / "media"
+                / "BluRay Movie (2024)"
+                / "BluRay Movie (2024).old.mkv"
+            )
+            old_file.parent.mkdir(parents=True)
+            old_file.write_bytes(b"old")
+
+            with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
+                "app.modules.filemanager.transhandler.shutil.which",
+                return_value="ffmpeg",
+            ), patch(
+                "app.modules.filemanager.transhandler.subprocess.run",
+                side_effect=run_ffmpeg,
+            ):
+                result = TransHandler().transfer_media(
+                    fileitem=source_item,
+                    in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
+                    mediainfo=self.__movie_info(),
+                    target_storage="local",
+                    target_path=root / "media",
+                    transfer_type="copy",
+                    source_oper=LocalStorage(),
+                    target_oper=LocalStorage(),
+                    overwrite_mode="latest",
+                )
+
+            self.assertFalse(result.success)
+            self.assertTrue(old_file.exists())
+
+    def test_bluray_remux_rejects_newline_in_concat_path(self):
+        with self.assertRaises(ValueError):
+            TransHandler._TransHandler__escape_ffconcat_path(
+                Path("BluRay\nMovie Source") / "BDMV" / "STREAM" / "00000.m2ts"
+            )
+
     def test_bluray_remux_failure_keeps_existing_target_file(self):
         def run_ffmpeg(command, *_args, **_kwargs):
             return subprocess.CompletedProcess(command, 1, "", "failed")

--- a/tests/test_bluray.py
+++ b/tests/test_bluray.py
@@ -918,3 +918,93 @@ class BluRayRemuxTest(TestCase):
             self.assertFalse(result.success)
             self.assertTrue(target_file.is_symlink())
             self.assertFalse(mock_run.called)
+
+    def test_bluray_remux_timeout_returns_failure(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_item = self.__create_bluray_dir(root / "BluRay Movie Source")
+
+            def run_ffmpeg(command, *_args, **kwargs):
+                raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+            with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch.object(
+                settings, "BLURAY_REMUX_TIMEOUT", 1
+            ), patch(
+                "app.modules.filemanager.transhandler.shutil.which",
+                return_value="ffmpeg",
+            ), patch(
+                "app.modules.filemanager.transhandler.subprocess.run",
+                side_effect=run_ffmpeg,
+            ):
+                result = TransHandler().transfer_media(
+                    fileitem=source_item,
+                    in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
+                    mediainfo=self.__movie_info(),
+                    target_storage="local",
+                    target_path=root / "media",
+                    transfer_type="copy",
+                    source_oper=LocalStorage(),
+                    target_oper=LocalStorage(),
+                )
+
+            self.assertFalse(result.success)
+            self.assertIn("ffmpeg 转封装超过 60 秒", result.message)
+
+    def test_bluray_remux_target_lock_cache_is_bounded(self):
+        old_locks = TransHandler._bluray_remux_locks
+        try:
+            TransHandler._bluray_remux_locks = {}
+            with TemporaryDirectory() as temp_dir:
+                root = Path(temp_dir)
+                for index in range(1100):
+                    TransHandler._TransHandler__get_bluray_remux_target_lock(
+                        root / f"target-{index}.mkv"
+                    )
+
+            self.assertLessEqual(len(TransHandler._bluray_remux_locks), 1024)
+        finally:
+            TransHandler._bluray_remux_locks = old_locks
+
+    def test_bluray_remux_move_delete_failure_rolls_back_new_target(self):
+        class DeleteFailingLocalStorage(LocalStorage):
+            def delete(self, fileitem):
+                return False
+
+        def run_ffmpeg(command, *_args, **_kwargs):
+            output_path = Path(command[-1])
+            output_path.write_bytes(b"mkv")
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_root = root / "BluRay Movie Source"
+            source_item = self.__create_bluray_dir(source_root)
+            target_file = (
+                root
+                / "media"
+                / "BluRay Movie (2024)"
+                / "BluRay Movie (2024).mkv"
+            )
+
+            with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
+                "app.modules.filemanager.transhandler.shutil.which",
+                return_value="ffmpeg",
+            ), patch(
+                "app.modules.filemanager.transhandler.subprocess.run",
+                side_effect=run_ffmpeg,
+            ):
+                result = TransHandler().transfer_media(
+                    fileitem=source_item,
+                    in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
+                    mediainfo=self.__movie_info(),
+                    target_storage="local",
+                    target_path=root / "media",
+                    transfer_type="move",
+                    source_oper=DeleteFailingLocalStorage(),
+                    target_oper=LocalStorage(),
+                    need_rename=False,
+                )
+
+            self.assertFalse(result.success)
+            self.assertTrue(source_root.exists())
+            self.assertFalse(target_file.exists())

--- a/tests/test_bluray.py
+++ b/tests/test_bluray.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
+import gc
 import shutil
 import subprocess
+import weakref
 from pathlib import Path, PurePosixPath
 from tempfile import TemporaryDirectory
 from typing import Optional
@@ -950,22 +952,31 @@ class BluRayRemuxTest(TestCase):
             self.assertFalse(result.success)
             self.assertIn("ffmpeg 转封装超过 60 秒", result.message)
 
-    def test_bluray_remux_target_lock_cache_is_bounded(self):
+    def test_bluray_remux_target_locks_reuse_live_lock_without_cache_growth(self):
         old_locks = TransHandler._bluray_remux_locks
         try:
-            TransHandler._bluray_remux_locks = {}
+            TransHandler._bluray_remux_locks = weakref.WeakValueDictionary()
             with TemporaryDirectory() as temp_dir:
                 root = Path(temp_dir)
+                target = root / "target.mkv"
+                target_lock = TransHandler._TransHandler__get_bluray_remux_target_lock(
+                    target
+                )
+                self.assertIs(
+                    target_lock,
+                    TransHandler._TransHandler__get_bluray_remux_target_lock(target),
+                )
                 for index in range(1100):
                     TransHandler._TransHandler__get_bluray_remux_target_lock(
                         root / f"target-{index}.mkv"
                     )
+                gc.collect()
 
-            self.assertLessEqual(len(TransHandler._bluray_remux_locks), 1024)
+                self.assertEqual(1, len(TransHandler._bluray_remux_locks))
         finally:
             TransHandler._bluray_remux_locks = old_locks
 
-    def test_bluray_remux_move_delete_failure_rolls_back_new_target(self):
+    def test_bluray_remux_move_delete_failure_keeps_new_target(self):
         class DeleteFailingLocalStorage(LocalStorage):
             def delete(self, fileitem):
                 return False
@@ -979,12 +990,7 @@ class BluRayRemuxTest(TestCase):
             root = Path(temp_dir)
             source_root = root / "BluRay Movie Source"
             source_item = self.__create_bluray_dir(source_root)
-            target_file = (
-                root
-                / "media"
-                / "BluRay Movie (2024)"
-                / "BluRay Movie (2024).mkv"
-            )
+            target_file = root / "media" / f"{source_item.name}.mkv"
 
             with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
                 "app.modules.filemanager.transhandler.shutil.which",
@@ -1007,4 +1013,5 @@ class BluRayRemuxTest(TestCase):
 
             self.assertFalse(result.success)
             self.assertTrue(source_root.exists())
-            self.assertFalse(target_file.exists())
+            self.assertTrue(target_file.exists())
+            self.assertEqual(target_file, Path(result.target_item.path))

--- a/tests/test_bluray.py
+++ b/tests/test_bluray.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 import subprocess
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from tempfile import TemporaryDirectory
 from typing import Optional
 from unittest import TestCase
@@ -502,6 +502,13 @@ class BluRayRemuxTest(TestCase):
 
         self.assertIn("Schindler'\\''s List", escaped)
 
+    def test_bluray_remux_keeps_literal_backslash_in_concat_path(self):
+        escaped = TransHandler._TransHandler__escape_ffconcat_path(
+            PurePosixPath("Back\\slash/BDMV/STREAM/00000.m2ts")
+        )
+
+        self.assertIn("Back\\slash", escaped)
+
     def test_bluray_remux_rejects_partial_playlist_parse(self):
         with TemporaryDirectory() as temp_dir:
             mpls_file = Path(temp_dir) / "00000.mpls"
@@ -532,6 +539,39 @@ class BluRayRemuxTest(TestCase):
                     mediainfo=self.__movie_info(),
                     target_storage="local",
                     target_path=source_root,
+                    transfer_type="move",
+                    source_oper=LocalStorage(),
+                    target_oper=LocalStorage(),
+                    need_rename=False,
+                )
+
+            self.assertFalse(result.success)
+            self.assertTrue(source_root.exists())
+            self.assertFalse(mock_run.called)
+
+    def test_bluray_remux_move_rejects_child_directory_entry(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_root = root / "BluRay Movie Source"
+            self.__create_bluray_dir(source_root)
+            bdmv_item = schemas.FileItem(
+                storage="local",
+                type="dir",
+                path=(source_root / "BDMV").as_posix(),
+                name="BDMV",
+                basename="BDMV",
+                size=0,
+            )
+
+            with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
+                "app.modules.filemanager.transhandler.subprocess.run"
+            ) as mock_run:
+                result = TransHandler().transfer_media(
+                    fileitem=bdmv_item,
+                    in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
+                    mediainfo=self.__movie_info(),
+                    target_storage="local",
+                    target_path=root / "media",
                     transfer_type="move",
                     source_oper=LocalStorage(),
                     target_oper=LocalStorage(),

--- a/tests/test_bluray.py
+++ b/tests/test_bluray.py
@@ -558,30 +558,32 @@ class BluRayRemuxTest(TestCase):
             self.assertEqual(source_files, [])
             self.assertEqual(source_size, 0)
 
-    def test_bluray_remux_move_rejects_target_inside_source(self):
-        with TemporaryDirectory() as temp_dir:
-            root = Path(temp_dir)
-            source_root = root / "BluRay Movie Source"
-            source_item = self.__create_bluray_dir(source_root)
+    def test_bluray_remux_rejects_target_inside_source(self):
+        for transfer_type in ["copy", "move"]:
+            with self.subTest(transfer_type=transfer_type), TemporaryDirectory() as temp_dir:
+                root = Path(temp_dir)
+                source_root = root / "BluRay Movie Source"
+                source_item = self.__create_bluray_dir(source_root)
 
-            with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
-                "app.modules.filemanager.transhandler.subprocess.run"
-            ) as mock_run:
-                result = TransHandler().transfer_media(
-                    fileitem=source_item,
-                    in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
-                    mediainfo=self.__movie_info(),
-                    target_storage="local",
-                    target_path=source_root,
-                    transfer_type="move",
-                    source_oper=LocalStorage(),
-                    target_oper=LocalStorage(),
-                    need_rename=False,
-                )
+                with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
+                    "app.modules.filemanager.transhandler.subprocess.run"
+                ) as mock_run:
+                    result = TransHandler().transfer_media(
+                        fileitem=source_item,
+                        in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
+                        mediainfo=self.__movie_info(),
+                        target_storage="local",
+                        target_path=source_root,
+                        transfer_type=transfer_type,
+                        source_oper=LocalStorage(),
+                        target_oper=LocalStorage(),
+                        need_rename=False,
+                    )
 
-            self.assertFalse(result.success)
-            self.assertTrue(source_root.exists())
-            self.assertFalse(mock_run.called)
+                self.assertFalse(result.success)
+                self.assertTrue(source_root.exists())
+                self.assertFalse((source_root / f"{source_item.name}.mkv").exists())
+                self.assertFalse(mock_run.called)
 
     def test_bluray_remux_move_rejects_child_directory_entry(self):
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_bluray.py
+++ b/tests/test_bluray.py
@@ -291,6 +291,14 @@ class BluRayRemuxTest(TestCase):
         mediainfo.year = "2024"
         return mediainfo
 
+    @staticmethod
+    def __tv_info() -> MediaInfo:
+        mediainfo = MediaInfo()
+        mediainfo.type = MediaType.TV
+        mediainfo.title = "BluRay Show"
+        mediainfo.year = "2024"
+        return mediainfo
+
     def test_bluray_remux_disabled_keeps_directory_transfer(self):
         with TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -386,6 +394,62 @@ class BluRayRemuxTest(TestCase):
             self.assertTrue(result.success)
             command = mock_run.call_args.args[0]
             self.assertIn("concat", command)
+
+    def test_bluray_remux_rejects_unmatched_playlist(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_root = root / "BluRay Movie Source"
+            source_item = self.__create_bluray_dir(source_root)
+            self.__write_mpls(
+                source_root / "BDMV" / "PLAYLIST" / "00000.mpls",
+                ["99999.m2ts"],
+            )
+
+            with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
+                "app.modules.filemanager.transhandler.shutil.which",
+                return_value="ffmpeg",
+            ), patch(
+                "app.modules.filemanager.transhandler.subprocess.run"
+            ) as mock_run:
+                result = TransHandler().transfer_media(
+                    fileitem=source_item,
+                    in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
+                    mediainfo=self.__movie_info(),
+                    target_storage="local",
+                    target_path=root / "media",
+                    transfer_type="move",
+                    source_oper=LocalStorage(),
+                    target_oper=LocalStorage(),
+                    need_rename=False,
+                )
+
+            self.assertFalse(result.success)
+            self.assertTrue(source_root.exists())
+            self.assertFalse(mock_run.called)
+
+    def test_tv_bluray_remux_keeps_directory_transfer(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_item = self.__create_bluray_dir(root / "BluRay Show S01E01")
+
+            with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
+                "app.modules.filemanager.transhandler.subprocess.run"
+            ) as mock_run:
+                result = TransHandler().transfer_media(
+                    fileitem=source_item,
+                    in_meta=MetaInfoPath(Path("BluRay Show S01E01")),
+                    mediainfo=self.__tv_info(),
+                    target_storage="local",
+                    target_path=root / "media",
+                    transfer_type="copy",
+                    source_oper=LocalStorage(),
+                    target_oper=LocalStorage(),
+                    need_rename=False,
+                )
+
+            self.assertTrue(result.success)
+            self.assertEqual(result.target_item.type, "dir")
+            self.assertFalse(mock_run.called)
 
     def test_bluray_remux_failure_keeps_existing_target_file(self):
         def run_ffmpeg(command, *_args, **_kwargs):

--- a/tests/test_bluray.py
+++ b/tests/test_bluray.py
@@ -672,31 +672,32 @@ class BluRayRemuxTest(TestCase):
                 self.assertFalse((source_root / f"{source_item.name}.mkv").exists())
                 self.assertFalse(mock_run.called)
 
-    def test_bluray_remux_move_rejects_multi_stream_largest_file_fallback(self):
-        with TemporaryDirectory() as temp_dir:
-            root = Path(temp_dir)
-            source_root = root / "BluRay Movie Source"
-            source_item = self.__create_bluray_dir(source_root)
-            shutil.rmtree(source_root / "BDMV" / "PLAYLIST")
+    def test_bluray_remux_rejects_multi_stream_largest_file_fallback(self):
+        for transfer_type in ["copy", "move"]:
+            with self.subTest(transfer_type=transfer_type), TemporaryDirectory() as temp_dir:
+                root = Path(temp_dir)
+                source_root = root / "BluRay Movie Source"
+                source_item = self.__create_bluray_dir(source_root)
+                shutil.rmtree(source_root / "BDMV" / "PLAYLIST")
 
-            with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
-                "app.modules.filemanager.transhandler.subprocess.run"
-            ) as mock_run:
-                result = TransHandler().transfer_media(
-                    fileitem=source_item,
-                    in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
-                    mediainfo=self.__movie_info(),
-                    target_storage="local",
-                    target_path=root / "media",
-                    transfer_type="move",
-                    source_oper=LocalStorage(),
-                    target_oper=LocalStorage(),
-                    need_rename=False,
-                )
+                with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
+                    "app.modules.filemanager.transhandler.subprocess.run"
+                ) as mock_run:
+                    result = TransHandler().transfer_media(
+                        fileitem=source_item,
+                        in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
+                        mediainfo=self.__movie_info(),
+                        target_storage="local",
+                        target_path=root / "media",
+                        transfer_type=transfer_type,
+                        source_oper=LocalStorage(),
+                        target_oper=LocalStorage(),
+                        need_rename=False,
+                    )
 
-            self.assertFalse(result.success)
-            self.assertTrue(source_root.exists())
-            self.assertFalse(mock_run.called)
+                self.assertFalse(result.success)
+                self.assertTrue(source_root.exists())
+                self.assertFalse(mock_run.called)
 
     def test_bluray_remux_move_rejects_child_directory_entry(self):
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_bluray.py
+++ b/tests/test_bluray.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
+import subprocess
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Optional
 from unittest import TestCase
 from unittest.mock import patch
@@ -9,12 +11,15 @@ from app import schemas
 from app.chain.media import MediaChain
 from app.chain.storage import StorageChain
 from app.chain.transfer import TransferChain
+from app.core.config import settings
 from app.core.context import MediaInfo
 from app.core.event import Event
 from app.core.metainfo import MetaInfoPath
 from app.db.models.transferhistory import TransferHistory
 from app.log import logger
-from app.schemas.types import EventType
+from app.modules.filemanager.storages.local import LocalStorage
+from app.modules.filemanager.transhandler import TransHandler
+from app.schemas.types import EventType, MediaType
 from tests.cases.files import bluray_files
 
 
@@ -225,3 +230,121 @@ class BluRayTest(TestCase):
             "app.chain.media.MediaChain.metadata_nfo", return_value=None
         ) as mock:
             self._test_scrape_metadata(mock_metadata_nfo=mock)
+
+
+class BluRayRemuxTest(TestCase):
+    @staticmethod
+    def __write_mpls(path: Path, stream_names: list[str]):
+        """
+        写入只包含基础 PlayItem 的最小 MPLS 测试文件。
+        """
+        items = b""
+        for stream_name in stream_names:
+            clip_name = Path(stream_name).stem.encode("ascii")[:5].ljust(5, b"\x00")
+            body = (
+                clip_name
+                + b"M2TS"
+                + b"\x00"
+                + b"\x01"
+                + (0).to_bytes(4, "big")
+                + (90000).to_bytes(4, "big")
+            )
+            items += len(body).to_bytes(2, "big") + body
+        playlist = (
+            len(items).to_bytes(4, "big")
+            + b"\x00\x00"
+            + len(stream_names).to_bytes(2, "big")
+            + (0).to_bytes(2, "big")
+            + items
+        )
+        path.write_bytes(b"MPLS0200" + (16).to_bytes(4, "big") + b"\x00" * 4 + playlist)
+
+    @staticmethod
+    def __create_bluray_dir(root: Path) -> schemas.FileItem:
+        stream_dir = root / "BDMV" / "STREAM"
+        playlist_dir = root / "BDMV" / "PLAYLIST"
+        stream_dir.mkdir(parents=True)
+        playlist_dir.mkdir(parents=True)
+        (stream_dir / "00000.m2ts").write_bytes(b"0" * 10)
+        (stream_dir / "00001.m2ts").write_bytes(b"1" * 20)
+        BluRayRemuxTest.__write_mpls(
+            playlist_dir / "00000.mpls",
+            ["00000.m2ts", "00001.m2ts"],
+        )
+        return schemas.FileItem(
+            storage="local",
+            type="dir",
+            path=root.as_posix(),
+            name=root.name,
+            basename=root.stem,
+            size=0,
+        )
+
+    @staticmethod
+    def __movie_info() -> MediaInfo:
+        mediainfo = MediaInfo()
+        mediainfo.type = MediaType.MOVIE
+        mediainfo.title = "BluRay Movie"
+        mediainfo.year = "2024"
+        return mediainfo
+
+    def test_bluray_remux_disabled_keeps_directory_transfer(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_item = self.__create_bluray_dir(root / "BluRay Movie Source")
+            target_path = root / "media"
+
+            with patch.object(settings, "BLURAY_REMUX_ENABLED", False), patch(
+                "app.modules.filemanager.transhandler.subprocess.run"
+            ) as mock_run:
+                result = TransHandler().transfer_media(
+                    fileitem=source_item,
+                    in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
+                    mediainfo=self.__movie_info(),
+                    target_storage="local",
+                    target_path=target_path,
+                    transfer_type="copy",
+                    source_oper=LocalStorage(),
+                    target_oper=LocalStorage(),
+                )
+
+            self.assertTrue(result.success)
+            self.assertEqual(result.target_item.type, "dir")
+            self.assertFalse(mock_run.called)
+
+    def test_bluray_remux_enabled_uses_playlist_concat(self):
+        def run_ffmpeg(command, *_args, **_kwargs):
+            output_path = Path(command[-1])
+            output_path.write_bytes(b"mkv")
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_item = self.__create_bluray_dir(root / "BluRay Movie Source")
+            target_path = root / "media"
+
+            with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
+                "app.modules.filemanager.transhandler.shutil.which",
+                return_value="ffmpeg",
+            ), patch(
+                "app.modules.filemanager.transhandler.subprocess.run",
+                side_effect=run_ffmpeg,
+            ) as mock_run:
+                result = TransHandler().transfer_media(
+                    fileitem=source_item,
+                    in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
+                    mediainfo=self.__movie_info(),
+                    target_storage="local",
+                    target_path=target_path,
+                    transfer_type="copy",
+                    source_oper=LocalStorage(),
+                    target_oper=LocalStorage(),
+                )
+
+            target_file = target_path / "BluRay Movie (2024)" / "BluRay Movie (2024).mkv"
+            self.assertTrue(result.success)
+            self.assertEqual(result.target_item.path, target_file.as_posix())
+            self.assertTrue(target_file.exists())
+            command = mock_run.call_args.args[0]
+            self.assertIn("concat", command)
+            self.assertIn("-safe", command)

--- a/tests/test_bluray.py
+++ b/tests/test_bluray.py
@@ -260,7 +260,10 @@ class BluRayRemuxTest(TestCase):
         path.write_bytes(b"MPLS0200" + (16).to_bytes(4, "big") + b"\x00" * 4 + playlist)
 
     @staticmethod
-    def __create_bluray_dir(root: Path) -> schemas.FileItem:
+    def __create_bluray_dir(
+            root: Path,
+            playlist_name: str = "00000.mpls",
+    ) -> schemas.FileItem:
         stream_dir = root / "BDMV" / "STREAM"
         playlist_dir = root / "BDMV" / "PLAYLIST"
         stream_dir.mkdir(parents=True)
@@ -268,7 +271,7 @@ class BluRayRemuxTest(TestCase):
         (stream_dir / "00000.m2ts").write_bytes(b"0" * 10)
         (stream_dir / "00001.m2ts").write_bytes(b"1" * 20)
         BluRayRemuxTest.__write_mpls(
-            playlist_dir / "00000.mpls",
+            playlist_dir / playlist_name,
             ["00000.m2ts", "00001.m2ts"],
         )
         return schemas.FileItem(
@@ -348,3 +351,76 @@ class BluRayRemuxTest(TestCase):
             command = mock_run.call_args.args[0]
             self.assertIn("concat", command)
             self.assertIn("-safe", command)
+
+    def test_bluray_remux_accepts_uppercase_playlist_suffix(self):
+        def run_ffmpeg(command, *_args, **_kwargs):
+            output_path = Path(command[-1])
+            output_path.write_bytes(b"mkv")
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_item = self.__create_bluray_dir(
+                root / "BluRay Movie Source",
+                playlist_name="00000.MPLS",
+            )
+
+            with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
+                "app.modules.filemanager.transhandler.shutil.which",
+                return_value="ffmpeg",
+            ), patch(
+                "app.modules.filemanager.transhandler.subprocess.run",
+                side_effect=run_ffmpeg,
+            ) as mock_run:
+                result = TransHandler().transfer_media(
+                    fileitem=source_item,
+                    in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
+                    mediainfo=self.__movie_info(),
+                    target_storage="local",
+                    target_path=root / "media",
+                    transfer_type="copy",
+                    source_oper=LocalStorage(),
+                    target_oper=LocalStorage(),
+                )
+
+            self.assertTrue(result.success)
+            command = mock_run.call_args.args[0]
+            self.assertIn("concat", command)
+
+    def test_bluray_remux_failure_keeps_existing_target_file(self):
+        def run_ffmpeg(command, *_args, **_kwargs):
+            return subprocess.CompletedProcess(command, 1, "", "failed")
+
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_item = self.__create_bluray_dir(root / "BluRay Movie Source")
+            target_file = (
+                root
+                / "media"
+                / "BluRay Movie (2024)"
+                / "BluRay Movie (2024).mkv"
+            )
+            target_file.parent.mkdir(parents=True)
+            target_file.write_bytes(b"old")
+
+            with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
+                "app.modules.filemanager.transhandler.shutil.which",
+                return_value="ffmpeg",
+            ), patch(
+                "app.modules.filemanager.transhandler.subprocess.run",
+                side_effect=run_ffmpeg,
+            ):
+                result = TransHandler().transfer_media(
+                    fileitem=source_item,
+                    in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
+                    mediainfo=self.__movie_info(),
+                    target_storage="local",
+                    target_path=root / "media",
+                    transfer_type="copy",
+                    source_oper=LocalStorage(),
+                    target_oper=LocalStorage(),
+                    overwrite_mode="always",
+                )
+
+            self.assertFalse(result.success)
+            self.assertEqual(target_file.read_bytes(), b"old")

--- a/tests/test_bluray.py
+++ b/tests/test_bluray.py
@@ -246,6 +246,7 @@ class BluRayRemuxTest(TestCase):
                 clip_name
                 + b"M2TS"
                 + b"\x00"
+                + b"\x00"
                 + b"\x01"
                 + (0).to_bytes(4, "big")
                 + (90000).to_bytes(4, "big")
@@ -265,10 +266,10 @@ class BluRayRemuxTest(TestCase):
         data = bytearray(path.read_bytes())
         playlist_start = int.from_bytes(data[8:12], "big")
         first_playitem_pos = playlist_start + 10
-        data[first_playitem_pos + 13:first_playitem_pos + 17] = in_time.to_bytes(
+        data[first_playitem_pos + 14:first_playitem_pos + 18] = in_time.to_bytes(
             4, "big"
         )
-        data[first_playitem_pos + 17:first_playitem_pos + 21] = out_time.to_bytes(
+        data[first_playitem_pos + 18:first_playitem_pos + 22] = out_time.to_bytes(
             4, "big"
         )
         path.write_bytes(data)
@@ -785,3 +786,43 @@ class BluRayRemuxTest(TestCase):
 
             self.assertFalse(result.success)
             self.assertEqual(target_file.read_bytes(), b"external")
+
+    def test_bluray_remux_size_overwrite_uses_output_size_before_replace(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_item = self.__create_bluray_dir(root / "BluRay Movie Source")
+            target_file = (
+                root
+                / "media"
+                / "BluRay Movie (2024)"
+                / "BluRay Movie (2024).mkv"
+            )
+            target_file.parent.mkdir(parents=True)
+            target_file.write_bytes(b"larger-old")
+
+            def run_ffmpeg(command, *_args, **_kwargs):
+                output_path = Path(command[-1])
+                output_path.write_bytes(b"mkv")
+                return subprocess.CompletedProcess(command, 0, "", "")
+
+            with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
+                "app.modules.filemanager.transhandler.shutil.which",
+                return_value="ffmpeg",
+            ), patch(
+                "app.modules.filemanager.transhandler.subprocess.run",
+                side_effect=run_ffmpeg,
+            ):
+                result = TransHandler().transfer_media(
+                    fileitem=source_item,
+                    in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
+                    mediainfo=self.__movie_info(),
+                    target_storage="local",
+                    target_path=root / "media",
+                    transfer_type="copy",
+                    source_oper=LocalStorage(),
+                    target_oper=LocalStorage(),
+                    overwrite_mode="size",
+                )
+
+            self.assertFalse(result.success)
+            self.assertEqual(target_file.read_bytes(), b"larger-old")

--- a/tests/test_bluray.py
+++ b/tests/test_bluray.py
@@ -683,6 +683,37 @@ class BluRayRemuxTest(TestCase):
                 self.assertFalse((source_root / f"{source_item.name}.mkv").exists())
                 self.__assert_ffmpeg_not_called(mock_run)
 
+    def test_bluray_remux_rejects_leaf_symlink_target_inside_source(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_root = root / "BluRay Movie Source"
+            source_item = self.__create_bluray_dir(source_root)
+            target_file = source_root / f"{source_item.name}.mkv"
+            try:
+                target_file.symlink_to(root / "outside.mkv")
+            except OSError as err:
+                self.skipTest(f"当前文件系统不支持创建符号链接：{err}")
+
+            with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
+                "app.modules.filemanager.transhandler.subprocess.run"
+            ) as mock_run:
+                result = TransHandler().transfer_media(
+                    fileitem=source_item,
+                    in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
+                    mediainfo=self.__movie_info(),
+                    target_storage="local",
+                    target_path=source_root,
+                    transfer_type="move",
+                    source_oper=LocalStorage(),
+                    target_oper=LocalStorage(),
+                    need_rename=False,
+                )
+
+            self.assertFalse(result.success)
+            self.assertIn("目标不能位于源目录内", result.message)
+            self.assertTrue(target_file.is_symlink())
+            self.__assert_ffmpeg_not_called(mock_run)
+
     def test_bluray_remux_rejects_multi_stream_largest_file_fallback(self):
         for transfer_type in ["copy", "move"]:
             with self.subTest(transfer_type=transfer_type), TemporaryDirectory() as temp_dir:

--- a/tests/test_bluray.py
+++ b/tests/test_bluray.py
@@ -524,6 +524,40 @@ class BluRayRemuxTest(TestCase):
                 [],
             )
 
+    def test_bluray_remux_rejects_large_playlist_parse(self):
+        with TemporaryDirectory() as temp_dir:
+            mpls_file = Path(temp_dir) / "00000.mpls"
+            mpls_file.write_bytes(b"0" * (1024 * 1024 + 1))
+
+            self.assertEqual(
+                TransHandler._TransHandler__parse_mpls_stream_names(mpls_file),
+                [],
+            )
+
+    def test_bluray_remux_ignores_stream_symlink(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_root = root / "BluRay Movie Source"
+            self.__create_bluray_dir(source_root)
+            outside_file = root / "outside.m2ts"
+            outside_file.write_bytes(b"x" * 50)
+            symlink_file = source_root / "BDMV" / "STREAM" / "00002.m2ts"
+            try:
+                symlink_file.symlink_to(outside_file)
+            except OSError as err:
+                self.skipTest(f"当前文件系统不支持创建符号链接：{err}")
+            self.__write_mpls(
+                source_root / "BDMV" / "PLAYLIST" / "00000.mpls",
+                ["00002.m2ts"],
+            )
+
+            source_files, source_size = TransHandler._TransHandler__get_bluray_remux_sources(
+                source_root
+            )
+
+            self.assertEqual(source_files, [])
+            self.assertEqual(source_size, 0)
+
     def test_bluray_remux_move_rejects_target_inside_source(self):
         with TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/tests/test_bluray.py
+++ b/tests/test_bluray.py
@@ -591,6 +591,26 @@ class BluRayRemuxTest(TestCase):
                 [],
             )
 
+    def test_bluray_remux_rejects_duplicate_playlist_items(self):
+        with TemporaryDirectory() as temp_dir:
+            mpls_file = Path(temp_dir) / "00000.mpls"
+            self.__write_mpls(mpls_file, ["00000.m2ts", "00000.m2ts"])
+
+            self.assertEqual(
+                TransHandler._TransHandler__parse_mpls_stream_names(mpls_file),
+                [],
+            )
+
+    def test_bluray_remux_rejects_excessive_playlist_items(self):
+        with TemporaryDirectory() as temp_dir:
+            mpls_file = Path(temp_dir) / "00000.mpls"
+            self.__write_mpls(mpls_file, ["00000.m2ts"] * 201)
+
+            self.assertEqual(
+                TransHandler._TransHandler__parse_mpls_stream_names(mpls_file),
+                [],
+            )
+
     def test_bluray_remux_rejects_large_playlist_parse(self):
         with TemporaryDirectory() as temp_dir:
             mpls_file = Path(temp_dir) / "00000.mpls"
@@ -787,6 +807,43 @@ class BluRayRemuxTest(TestCase):
             self.assertFalse(result.success)
             self.assertEqual(target_file.read_bytes(), b"external")
 
+    def test_bluray_remux_rejects_empty_output(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_item = self.__create_bluray_dir(root / "BluRay Movie Source")
+            target_file = (
+                root
+                / "media"
+                / "BluRay Movie (2024)"
+                / "BluRay Movie (2024).mkv"
+            )
+
+            def run_ffmpeg(command, *_args, **_kwargs):
+                output_path = Path(command[-1])
+                output_path.write_bytes(b"")
+                return subprocess.CompletedProcess(command, 0, "", "")
+
+            with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
+                "app.modules.filemanager.transhandler.shutil.which",
+                return_value="ffmpeg",
+            ), patch(
+                "app.modules.filemanager.transhandler.subprocess.run",
+                side_effect=run_ffmpeg,
+            ):
+                result = TransHandler().transfer_media(
+                    fileitem=source_item,
+                    in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
+                    mediainfo=self.__movie_info(),
+                    target_storage="local",
+                    target_path=root / "media",
+                    transfer_type="copy",
+                    source_oper=LocalStorage(),
+                    target_oper=LocalStorage(),
+                )
+
+            self.assertFalse(result.success)
+            self.assertFalse(target_file.exists())
+
     def test_bluray_remux_size_overwrite_uses_output_size_before_replace(self):
         with TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -826,3 +883,37 @@ class BluRayRemuxTest(TestCase):
 
             self.assertFalse(result.success)
             self.assertEqual(target_file.read_bytes(), b"larger-old")
+
+    def test_bluray_remux_rejects_broken_symlink_target_by_default(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_item = self.__create_bluray_dir(root / "BluRay Movie Source")
+            target_file = (
+                root
+                / "media"
+                / "BluRay Movie (2024)"
+                / "BluRay Movie (2024).mkv"
+            )
+            target_file.parent.mkdir(parents=True)
+            try:
+                target_file.symlink_to(root / "missing.mkv")
+            except OSError as err:
+                self.skipTest(f"当前文件系统不支持创建符号链接：{err}")
+
+            with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
+                "app.modules.filemanager.transhandler.subprocess.run"
+            ) as mock_run:
+                result = TransHandler().transfer_media(
+                    fileitem=source_item,
+                    in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
+                    mediainfo=self.__movie_info(),
+                    target_storage="local",
+                    target_path=root / "media",
+                    transfer_type="copy",
+                    source_oper=LocalStorage(),
+                    target_oper=LocalStorage(),
+                )
+
+            self.assertFalse(result.success)
+            self.assertTrue(target_file.is_symlink())
+            self.assertFalse(mock_run.called)

--- a/tests/test_bluray.py
+++ b/tests/test_bluray.py
@@ -495,6 +495,28 @@ class BluRayRemuxTest(TestCase):
                 Path("BluRay\nMovie Source") / "BDMV" / "STREAM" / "00000.m2ts"
             )
 
+    def test_bluray_remux_escapes_quote_in_concat_path(self):
+        escaped = TransHandler._TransHandler__escape_ffconcat_path(
+            Path("Schindler's List") / "BDMV" / "STREAM" / "00000.m2ts"
+        )
+
+        self.assertIn("Schindler'\\''s List", escaped)
+
+    def test_bluray_remux_rejects_partial_playlist_parse(self):
+        with TemporaryDirectory() as temp_dir:
+            mpls_file = Path(temp_dir) / "00000.mpls"
+            self.__write_mpls(mpls_file, ["00000.m2ts"])
+            data = bytearray(mpls_file.read_bytes())
+            playlist_start = int.from_bytes(data[8:12], "big")
+            playitem_count_pos = playlist_start + 6
+            data[playitem_count_pos:playitem_count_pos + 2] = (2).to_bytes(2, "big")
+            mpls_file.write_bytes(data)
+
+            self.assertEqual(
+                TransHandler._TransHandler__parse_mpls_stream_names(mpls_file),
+                [],
+            )
+
     def test_bluray_remux_move_rejects_target_inside_source(self):
         with TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/tests/test_bluray.py
+++ b/tests/test_bluray.py
@@ -747,3 +747,41 @@ class BluRayRemuxTest(TestCase):
 
             self.assertFalse(result.success)
             self.assertEqual(target_file.read_bytes(), b"old")
+
+    def test_bluray_remux_rechecks_target_before_replace(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_item = self.__create_bluray_dir(root / "BluRay Movie Source")
+            target_file = (
+                root
+                / "media"
+                / "BluRay Movie (2024)"
+                / "BluRay Movie (2024).mkv"
+            )
+
+            def run_ffmpeg(command, *_args, **_kwargs):
+                target_file.write_bytes(b"external")
+                output_path = Path(command[-1])
+                output_path.write_bytes(b"mkv")
+                return subprocess.CompletedProcess(command, 0, "", "")
+
+            with patch.object(settings, "BLURAY_REMUX_ENABLED", True), patch(
+                "app.modules.filemanager.transhandler.shutil.which",
+                return_value="ffmpeg",
+            ), patch(
+                "app.modules.filemanager.transhandler.subprocess.run",
+                side_effect=run_ffmpeg,
+            ):
+                result = TransHandler().transfer_media(
+                    fileitem=source_item,
+                    in_meta=MetaInfoPath(Path("BluRay Movie (2024)")),
+                    mediainfo=self.__movie_info(),
+                    target_storage="local",
+                    target_path=root / "media",
+                    transfer_type="copy",
+                    source_oper=LocalStorage(),
+                    target_oper=LocalStorage(),
+                )
+
+            self.assertFalse(result.success)
+            self.assertEqual(target_file.read_bytes(), b"external")


### PR DESCRIPTION
## 变更
- 新增 `BLURAY_REMUX_ENABLED`，默认关闭；新增 `BLURAY_REMUX_TIMEOUT` 控制 ffmpeg 转封装超时。
- 开启后，本地电影蓝光原盘可按 MPLS 播放列表安全转封装为单个 MKV。
- 对播放列表解析、目标覆盖、临时文件、路径边界、并发锁和失败清理增加保护；多分片缺少可用播放列表时拒绝转封装。

## 边界
本次仅包含蓝光原盘转封装配置、整理逻辑和测试，不包含用户私有媒体库路径、下载器路径或本地资源包内容。

## 验证
- `pytest tests/test_bluray.py tests/test_transfer_preview.py`（32 passed, 3 skipped）
- `pylint app/modules/filemanager/transhandler.py tests/test_bluray.py`（10.00/10）
- `git diff --check upstream/v2..HEAD`