### PR TITLE
增强单种多季整理识别

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -165,6 +165,23 @@ _EPISODE_SINGLE_RE_LIST = (
     re.compile(rf"第\s*({_CN_NUMBER_RE})\s*[集话話幕]", re.IGNORECASE),
     re.compile(r"(?:^|[^A-Za-z0-9])EP?\s*0*([0-9]{1,4})(?![A-Za-z0-9])", re.IGNORECASE),
 )
+_SEASON_ENUM_SEPARATOR_RE = r"(?:[+&/\u3001,\uff0c]|\u548c)"
+_SEASON_ENUM_RE_LIST = (
+    re.compile(
+        r"(?:^|[^A-Za-z0-9])("
+        r"(?:(?:TV)?S(?:eason)?\s*0*[1-9]\d?\s*"
+        rf"{_SEASON_ENUM_SEPARATOR_RE}\s*)+"
+        r"(?:TV)?S(?:eason)?\s*0*[1-9]\d?"
+        r")(?![A-Za-z0-9])",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"(\u7b2c?\s*{_CN_NUMBER_RE}"
+        rf"(?:\s*{_SEASON_ENUM_SEPARATOR_RE}\s*{_CN_NUMBER_RE})+"
+        rf"\s*[\u5b63\u671f\u90e8])",
+        re.IGNORECASE,
+    ),
+)
 
 
 @dataclass
@@ -2651,6 +2668,16 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                 seasons.update(
                     season for season in (begin, finish) if season is not None
                 )
+        for pattern in _SEASON_ENUM_RE_LIST:
+            for match in pattern.finditer(merged_text):
+                seasons.update(
+                    season
+                    for season in (
+                        cls._cn_number_to_int(season_text)
+                        for season_text in re.findall(_CN_NUMBER_RE, match.group(1))
+                    )
+                    if season is not None
+                )
         return tuple(sorted(seasons))
 
     @classmethod
@@ -2878,9 +2905,17 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             return []
         seasons = getattr(mediainfo, "seasons", None) or {}
         episodes = seasons.get(season_num) or seasons.get(str(season_num)) or []
-        if isinstance(episodes, list):
-            return [int(ep) for ep in episodes if str(ep).isdigit()]
-        return []
+        if not isinstance(episodes, list):
+            return []
+        episode_numbers = []
+        for episode in episodes:
+            if isinstance(episode, dict):
+                episode_num = episode.get("episode_number")
+            else:
+                episode_num = getattr(episode, "episode_number", episode)
+            if str(episode_num).isdigit():
+                episode_numbers.append(int(episode_num))
+        return episode_numbers
 
     @classmethod
     def _map_absolute_episode(
@@ -2923,6 +2958,22 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                 or not meta.begin_episode
         ):
             return False
+        explicit_season = (
+            cls._nearest_path_season_marker(source_path) if source_path else None
+        )
+        if explicit_season is not None:
+            explicit_episode_list = cls._season_episode_list(
+                mediainfo, explicit_season
+            )
+            if (
+                    meta.begin_episode in explicit_episode_list
+                    and (
+                        not meta.end_episode
+                        or meta.end_episode in explicit_episode_list
+                    )
+            ):
+                return False
+
         mapped_begin = cls._map_absolute_episode(
             meta.begin_episode, source_seasons, mediainfo
         )
@@ -2930,9 +2981,6 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             return False
 
         mapped_season, mapped_episode = mapped_begin
-        explicit_season = (
-            cls._nearest_path_season_marker(source_path) if source_path else None
-        )
         if explicit_season is not None and mapped_season != explicit_season:
             return False
         if (

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -125,17 +125,20 @@ _CN_NUMBER_MAP = {
     "十": 10,
 }
 _CN_NUMBER_RE = r"[0-9一二两三四五六七八九十]{1,3}"
+_SEASON_RANGE_TRAILING_RE = r"(?!\s*(?:Episodes?|EP(?:isodes?)?|[集话話幕]))"
 _SEASON_RANGE_RE_LIST = (
     re.compile(
         r"(?:^|[^A-Za-z0-9])(?:TV)?S(?:eason)?\s*0*([1-9]\d?)\s*"
         r"(?:[-~+&/、,，]|至|到|和|\bto\b)\s*"
-        r"(?:(?:TV)?S(?:eason)?\s*)?0*([1-9]\d?)(?![A-Za-z0-9])",
+        r"(?:(?:TV)?S(?:eason)?\s*)?0*([1-9]\d?)"
+        rf"(?![A-Za-z0-9]){_SEASON_RANGE_TRAILING_RE}",
         re.IGNORECASE,
     ),
     re.compile(
         r"(?:^|[^A-Za-z0-9])Season\s*0*([1-9]\d?)\s*"
         r"(?:[-~+&/、,，]|至|到|和|\bto\b)\s*"
-        r"(?:Season\s*)?0*([1-9]\d?)(?![A-Za-z0-9])",
+        r"(?:Season\s*)?0*([1-9]\d?)"
+        rf"(?![A-Za-z0-9]){_SEASON_RANGE_TRAILING_RE}",
         re.IGNORECASE,
     ),
     re.compile(
@@ -2718,13 +2721,23 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
 
     @classmethod
     def _nearest_path_season_marker(
-            cls, source_path: Union[str, Path, PurePosixPath]
+            cls,
+            source_path: Union[str, Path, PurePosixPath],
+            source_root: Optional[PurePosixPath] = None,
     ) -> Optional[int]:
         """
         从近到远查找路径中的明确单季标记。
         """
         path = cls._normalize_posix_path(source_path)
-        for part in reversed(path.parts):
+        parts = path.parts
+        if source_root:
+            try:
+                parts = path.relative_to(
+                    cls._normalize_posix_path(source_root)
+                ).parts
+            except ValueError:
+                pass
+        for part in reversed(parts):
             season = cls._extract_single_season_marker(part)
             if season is not None:
                 return season
@@ -2824,7 +2837,6 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         source_seasons = cls._parse_multi_season_numbers(
             getattr(download_history, "seasons", None),
             getattr(download_history, "torrent_name", None),
-            getattr(download_history, "torrent_description", None),
             history_name,
             source_name,
             source_root_name,
@@ -2878,7 +2890,9 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         """
         根据路径和多季上下文推断当前文件所属季。
         """
-        explicit_season = cls._nearest_path_season_marker(source_path)
+        explicit_season = cls._nearest_path_season_marker(
+            source_path, context.source_root if context else None
+        )
         if explicit_season is not None:
             return explicit_season
         if not context:
@@ -2902,7 +2916,9 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             return False
         if getattr(meta, "begin_episode", None) is None:
             return False
-        explicit_season = cls._nearest_path_season_marker(source_path)
+        explicit_season = cls._nearest_path_season_marker(
+            source_path, context.source_root if context else None
+        )
         season_num = (
             explicit_season
             if explicit_season is not None
@@ -3011,7 +3027,11 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         ):
             return False
         explicit_season = (
-            cls._nearest_path_season_marker(source_path) if source_path else None
+            cls._extract_single_season_marker(
+                cls._normalize_posix_path(source_path).name
+            )
+            if source_path
+            else None
         )
         current_season = (
             explicit_season
@@ -3175,6 +3195,25 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         matched_episode_format_template = False
         multi_season_context: Optional[_MultiSeasonTransferContext] = None
 
+        def _apply_multi_season_adjustments(
+                current_meta: Optional[MetaBase], source_path: Path
+        ) -> Optional[MetaBase]:
+            """
+            应用多季上下文，并在已有媒体集数信息时提前修正绝对集数。
+            """
+            if not current_meta or season is not None:
+                return current_meta
+            self._apply_multi_season_context(
+                current_meta, source_path, multi_season_context
+            )
+            self._remap_absolute_episode(
+                current_meta,
+                self._task_source_seasons(multi_season_context, season),
+                mediainfo,
+                source_path,
+            )
+            return current_meta
+
         def _build_file_meta(
                 source_path: Path,
                 custom_word_list: Optional[List[str]] = None,
@@ -3192,11 +3231,7 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                 # 这里避免再次偏移集数，导致手动整理的集数偏移翻倍。
                 return built_meta
             built_meta = _apply_meta_overrides(built_meta, source_path)
-            if season is None:
-                self._apply_multi_season_context(
-                    built_meta, source_path, multi_season_context
-                )
-            return built_meta
+            return _apply_multi_season_adjustments(built_meta, source_path)
 
         def _build_path_meta(
                 source_path: Path,
@@ -3211,11 +3246,7 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             if not path_meta:
                 return None
             path_meta = _apply_meta_overrides(path_meta, source_path)
-            if season is None:
-                self._apply_multi_season_context(
-                    path_meta, source_path, multi_season_context
-                )
-            return path_meta
+            return _apply_multi_season_adjustments(path_meta, source_path)
 
         def _apply_meta_overrides(
                 current_meta: MetaBase, source_path: Path

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -129,21 +129,24 @@ _SEASON_RANGE_RE_LIST = (
     re.compile(
         r"(?:^|[^A-Za-z0-9])(?:TV)?S(?:eason)?\s*0*([1-9]\d?)\s*"
         r"(?:[-~+&/、,，]|至|到|和|\bto\b)\s*"
-        r"S(?:eason)?\s*0*([1-9]\d?)(?![A-Za-z0-9])",
+        r"(?:(?:TV)?S(?:eason)?\s*)?0*([1-9]\d?)(?![A-Za-z0-9])",
         re.IGNORECASE,
     ),
     re.compile(
         r"(?:^|[^A-Za-z0-9])Season\s*0*([1-9]\d?)\s*"
-        r"(?:[-~+&/、,，]|至|到|和|\bto\b)\s*0*([1-9]\d?)(?![A-Za-z0-9])",
+        r"(?:[-~+&/、,，]|至|到|和|\bto\b)\s*"
+        r"(?:Season\s*)?0*([1-9]\d?)(?![A-Za-z0-9])",
         re.IGNORECASE,
     ),
     re.compile(
-        rf"第\s*({_CN_NUMBER_RE})\s*(?:[-~+&/、,，]|至|到|和)\s*"
+        rf"第\s*({_CN_NUMBER_RE})\s*[季期部]?\s*"
+        rf"(?:[-~+&/、,，]|至|到|和)\s*第?\s*"
         rf"({_CN_NUMBER_RE})\s*[季期部]",
         re.IGNORECASE,
     ),
     re.compile(
-        rf"({_CN_NUMBER_RE})\s*(?:[-~+&/、,，]|至|到|和)\s*"
+        rf"({_CN_NUMBER_RE})\s*[季期部]?\s*"
+        rf"(?:[-~+&/、,，]|至|到|和)\s*第?\s*"
         rf"({_CN_NUMBER_RE})\s*[季期部]",
         re.IGNORECASE,
     ),

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -2639,9 +2639,18 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         seasons: set[int] = set()
         merged_text = "\n".join(str(text or "") for text in texts)
         for pattern in _SEASON_RANGE_RE_LIST:
-            for match in pattern.findall(merged_text):
-                start, end = match[:2] if isinstance(match, tuple) else (None, None)
-                seasons.update(cls._season_range_to_numbers(start, end))
+            for match in pattern.finditer(merged_text):
+                start, end = match.group(1), match.group(2)
+                separator = merged_text[match.end(1):match.start(2)]
+                if re.search(r"[-~]|至|到|\bto\b", separator, re.IGNORECASE):
+                    seasons.update(cls._season_range_to_numbers(start, end))
+                    continue
+
+                begin = cls._cn_number_to_int(start)
+                finish = cls._cn_number_to_int(end)
+                seasons.update(
+                    season for season in (begin, finish) if season is not None
+                )
         return tuple(sorted(seasons))
 
     @classmethod
@@ -2753,7 +2762,19 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             source_path,
         )
         source_root = cls._normalize_posix_path(history_path or source_path)
-        if source_root.suffix:
+        source_root_is_file = (
+                getattr(source_fileitem, "type", None) == "file"
+                and source_path is not None
+                and source_root == cls._normalize_posix_path(source_path)
+        )
+        if not source_root_is_file:
+            source_root_is_file = any(
+                item
+                and item.type == "file"
+                and cls._normalize_posix_path(item.path) == source_root
+                for item, _ in file_items or []
+            )
+        if source_root_is_file:
             source_root = source_root.parent
 
         top_dirs: set[str] = set()
@@ -3163,7 +3184,9 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             """
             downloadhis = DownloadHistoryOper()
             if download_hash:
-                return downloadhis.get_by_hash(download_hash)
+                download_history = downloadhis.get_by_hash(download_hash)
+                if download_history:
+                    return download_history
 
             if fileitem and fileitem.path:
                 source_path = Path(fileitem.path).as_posix()
@@ -3178,7 +3201,7 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                     downloadhis=downloadhis,
                     file_path=Path(candidate_item.path),
                     bluray_dir=candidate_bluray_dir,
-                    download_hash=download_hash,
+                    download_hash=None,
                 )
                 if download_history:
                     return download_history

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -3046,6 +3046,11 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                 or not meta.begin_episode
         ):
             return False
+        if (
+                meta.end_episode is not None
+                and meta.end_episode < meta.begin_episode
+        ):
+            return False
         explicit_season = (
             cls._extract_single_season_marker(
                 cls._normalize_posix_path(source_path).name
@@ -3053,15 +3058,28 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             if source_path
             else None
         )
-        current_season = (
-            explicit_season
-            if explicit_season is not None
-            else meta.begin_season
-        )
+        if explicit_season is not None:
+            new_total_episode = (
+                (meta.end_episode - meta.begin_episode) + 1
+                if meta.end_episode is not None
+                else 1
+            )
+            changed = (
+                    meta.begin_season != explicit_season
+                    or meta.end_season is not None
+                    or meta.total_season != 1
+                    or meta.total_episode != new_total_episode
+            )
+            meta.begin_season = explicit_season
+            meta.end_season = None
+            meta.total_season = 1
+            meta.total_episode = new_total_episode
+            return changed
+
+        current_season = meta.begin_season
         source_season_numbers = {int(season) for season in source_seasons}
         if current_season is not None and (
-                explicit_season is not None
-                or current_season in source_season_numbers
+                current_season in source_season_numbers
         ):
             current_episode_list = cls._season_episode_list(
                 mediainfo, current_season
@@ -3097,8 +3115,6 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             return False
 
         mapped_season, mapped_episode = mapped_begin
-        if explicit_season is not None and mapped_season != explicit_season:
-            return False
         if (
                 meta.begin_season
                 and meta.begin_season != 1
@@ -3382,7 +3398,9 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                     continue
                 download_history = self._resolve_download_history(
                     downloadhis=downloadhis,
-                    file_path=Path(candidate_item.path),
+                    file_path=Path(
+                        self._normalize_posix_path(candidate_item.path).as_posix()
+                    ),
                     bluray_dir=candidate_bluray_dir,
                     download_hash=None,
                 )

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -125,7 +125,7 @@ _CN_NUMBER_MAP = {
     "十": 10,
 }
 _CN_NUMBER_RE = r"[0-9一二两三四五六七八九十]{1,3}"
-_SEASON_RANGE_TRAILING_RE = r"(?!\s*(?:Episodes?|EP(?:isodes?)?|[集话話幕]))"
+_SEASON_RANGE_TRAILING_RE = r"(?![\s._\-\[\]()（）]*(?:Episodes?|EP(?:isodes?)?|[集话話幕]))"
 _SEASON_RANGE_RE_LIST = (
     re.compile(
         r"(?:^|[^A-Za-z0-9])(?:TV)?S(?:eason)?\s*0*([1-9]\d?)\s*"
@@ -3116,7 +3116,7 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
 
         mapped_season, mapped_episode = mapped_begin
         if (
-                meta.begin_season
+                meta.begin_season is not None
                 and meta.begin_season != 1
                 and mapped_season != meta.begin_season
         ):

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -2708,15 +2708,24 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         if not text:
             return None
         text = str(text)
-        if cls._parse_multi_season_numbers(text):
-            return None
+        range_spans = [
+            match.span()
+            for pattern in _SEASON_RANGE_RE_LIST + _SEASON_ENUM_RE_LIST
+            for match in pattern.finditer(text)
+        ]
+        candidates = []
         for pattern in _SEASON_SINGLE_RE_LIST:
-            match = pattern.search(text)
-            if not match:
-                continue
-            season = cls._cn_number_to_int(match.group(1))
-            if season is not None:
-                return season
+            for match in pattern.finditer(text):
+                if any(
+                        start <= match.start(1) < end
+                        for start, end in range_spans
+                ):
+                    continue
+                season = cls._cn_number_to_int(match.group(1))
+                if season is not None:
+                    candidates.append((match.start(1), season))
+        if candidates:
+            return max(candidates, key=lambda candidate: candidate[0])[1]
         return None
 
     @classmethod
@@ -2843,6 +2852,7 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         )
 
         top_dirs: set[str] = set()
+        explicit_top_dir_seasons: set[int] = set()
         for item, _ in file_items or []:
             if not item or item.type != "file":
                 continue
@@ -2851,15 +2861,25 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             first_dir = cls._relative_first_dir(source_root, item.path)
             if not first_dir:
                 continue
-            if cls._extract_single_season_marker(first_dir) is not None:
+            explicit_season = cls._extract_single_season_marker(first_dir)
+            if explicit_season is not None:
+                explicit_top_dir_seasons.add(explicit_season)
                 continue
             top_dirs.add(first_dir)
 
         top_dir_seasons: Dict[str, int] = {}
-        if len(source_seasons) > 1 and len(top_dirs) == len(source_seasons):
+        remaining_source_seasons = tuple(
+            season
+            for season in source_seasons
+            if season not in explicit_top_dir_seasons
+        )
+        if (
+                len(source_seasons) > 1
+                and len(top_dirs) == len(remaining_source_seasons)
+        ):
             for dirname, season_num in zip(
                     sorted(top_dirs, key=cls._natural_sort_key),
-                    source_seasons,
+                    remaining_source_seasons,
             ):
                 top_dir_seasons[dirname] = season_num
 

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -2875,11 +2875,19 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         if not meta or not context or len(context.source_seasons) <= 1:
             return False
         explicit_season = cls._nearest_path_season_marker(source_path)
-        season_num = explicit_season or cls._infer_context_season(source_path, context)
+        season_num = (
+            explicit_season
+            if explicit_season is not None
+            else cls._infer_context_season(source_path, context)
+        )
         if season_num is None:
             return False
         changed = False
-        if meta.begin_season != season_num or meta.end_season is not None:
+        if (
+                meta.begin_season != season_num
+                or meta.end_season is not None
+                or meta.total_season != 1
+        ):
             meta.begin_season = season_num
             meta.end_season = None
             meta.total_season = 1
@@ -2891,17 +2899,19 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             )
             if local_episode:
                 begin_episode, end_episode = local_episode
+                total_episode = (
+                    (end_episode - begin_episode) + 1
+                    if end_episode
+                    else 1
+                )
                 if (
                         meta.begin_episode != begin_episode
                         or meta.end_episode != end_episode
+                        or meta.total_episode != total_episode
                 ):
                     meta.begin_episode = begin_episode
                     meta.end_episode = end_episode
-                    meta.total_episode = (
-                        (end_episode - begin_episode) + 1
-                        if end_episode
-                        else 1
-                    )
+                    meta.total_episode = total_episode
                     changed = True
 
         return changed
@@ -2913,7 +2923,7 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         """
         获取指定季的剧集列表。
         """
-        if not mediainfo or not season_num:
+        if not mediainfo or season_num is None:
             return []
         seasons = getattr(mediainfo, "seasons", None) or {}
         if not isinstance(seasons, dict):
@@ -2929,7 +2939,7 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                 episode_num = getattr(episode, "episode_number", episode)
             if str(episode_num).isdigit():
                 episode_numbers.append(int(episode_num))
-        return episode_numbers
+        return sorted(episode_numbers)
 
     @classmethod
     def _map_absolute_episode(

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -2831,6 +2831,18 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             top_dir_seasons=top_dir_seasons,
         )
 
+    @staticmethod
+    def _task_source_seasons(
+            context: Optional[_MultiSeasonTransferContext],
+            season: Optional[int],
+    ) -> List[int]:
+        """
+        获取整理任务需要继承的源多季信息。
+        """
+        if not context or season is not None:
+            return []
+        return list(context.source_seasons)
+
     @classmethod
     def _infer_context_season(
             cls,
@@ -2904,6 +2916,8 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         if not mediainfo or not season_num:
             return []
         seasons = getattr(mediainfo, "seasons", None) or {}
+        if not isinstance(seasons, dict):
+            return []
         episodes = seasons.get(season_num) or seasons.get(str(season_num)) or []
         if not isinstance(episodes, list):
             return []
@@ -2998,18 +3012,26 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             if not mapped_end or mapped_end[0] != mapped_season:
                 return False
 
+        new_end_episode = mapped_end[1] if mapped_end else None
+        new_total_episode = (
+            (new_end_episode - mapped_episode) + 1
+            if new_end_episode is not None
+            else 1
+        )
         changed = (
                 meta.begin_season != mapped_season
+                or meta.end_season is not None
+                or meta.total_season != 1
                 or meta.begin_episode != mapped_episode
-                or (mapped_end and meta.end_episode != mapped_end[1])
+                or meta.end_episode != new_end_episode
+                or meta.total_episode != new_total_episode
         )
         meta.begin_season = mapped_season
         meta.end_season = None
         meta.total_season = 1
         meta.begin_episode = mapped_episode
-        if mapped_end:
-            meta.end_episode = mapped_end[1]
-            meta.total_episode = (meta.end_episode - meta.begin_episode) + 1
+        meta.end_episode = new_end_episode
+        meta.total_episode = new_total_episode
         return changed
 
     def do_transfer(
@@ -3617,9 +3639,9 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                     downloader=_downloader,
                     download_hash=_download_hash,
                     download_history=download_history,
-                    source_seasons=list(multi_season_context.source_seasons)
-                    if multi_season_context
-                    else [],
+                    source_seasons=self._task_source_seasons(
+                        multi_season_context, season
+                    ),
                     transfer_batch_id=transfer_batch_id,
                     manual=manual,
                     background=background,

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -2631,8 +2631,16 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             return _CN_NUMBER_MAP[text]
         if "十" in text:
             left, _, right = text.partition("十")
-            tens = _CN_NUMBER_MAP.get(left, 1) if left else 1
-            ones = _CN_NUMBER_MAP.get(right, 0) if right else 0
+            if left:
+                tens = int(left) if left.isdigit() else _CN_NUMBER_MAP.get(left)
+            else:
+                tens = 1
+            if right:
+                ones = int(right) if right.isdigit() else _CN_NUMBER_MAP.get(right)
+            else:
+                ones = 0
+            if tens is None or ones is None:
+                return None
             return tens * 10 + ones
         return None
 
@@ -2790,13 +2798,6 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         """
         history_path = getattr(download_history, "path", None)
         source_path = getattr(source_fileitem, "path", None)
-        source_seasons = cls._parse_multi_season_numbers(
-            getattr(download_history, "seasons", None),
-            getattr(download_history, "torrent_name", None),
-            getattr(download_history, "torrent_description", None),
-            history_path,
-            source_path,
-        )
         source_root = cls._normalize_posix_path(history_path or source_path)
         source_root_is_file = (
                 getattr(source_fileitem, "type", None) == "file"
@@ -2812,6 +2813,22 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             )
         if source_root_is_file:
             source_root = source_root.parent
+
+        history_name = (
+            cls._normalize_posix_path(history_path).name if history_path else None
+        )
+        source_name = (
+            cls._normalize_posix_path(source_path).name if source_path else None
+        )
+        source_root_name = source_root.name or None
+        source_seasons = cls._parse_multi_season_numbers(
+            getattr(download_history, "seasons", None),
+            getattr(download_history, "torrent_name", None),
+            getattr(download_history, "torrent_description", None),
+            history_name,
+            source_name,
+            source_root_name,
+        )
 
         top_dirs: set[str] = set()
         for item, _ in file_items or []:

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -2985,18 +2985,42 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         explicit_season = (
             cls._nearest_path_season_marker(source_path) if source_path else None
         )
-        if explicit_season is not None:
-            explicit_episode_list = cls._season_episode_list(
-                mediainfo, explicit_season
+        current_season = (
+            explicit_season
+            if explicit_season is not None
+            else meta.begin_season
+        )
+        source_season_numbers = {int(season) for season in source_seasons}
+        if current_season is not None and (
+                explicit_season is not None
+                or current_season in source_season_numbers
+        ):
+            current_episode_list = cls._season_episode_list(
+                mediainfo, current_season
             )
             if (
-                    meta.begin_episode in explicit_episode_list
+                    meta.begin_episode in current_episode_list
                     and (
-                        not meta.end_episode
-                        or meta.end_episode in explicit_episode_list
+                        meta.end_episode is None
+                        or meta.end_episode in current_episode_list
                     )
             ):
-                return False
+                new_total_episode = (
+                    (meta.end_episode - meta.begin_episode) + 1
+                    if meta.end_episode is not None
+                    else 1
+                )
+                changed = (
+                        meta.begin_season != current_season
+                        or meta.end_season is not None
+                        or meta.total_season != 1
+                        or meta.total_episode != new_total_episode
+                )
+                meta.begin_season = current_season
+                meta.end_season = None
+                meta.total_season = 1
+                meta.total_episode = new_total_episode
+                return changed
 
         mapped_begin = cls._map_absolute_episode(
             meta.begin_episode, source_seasons, mediainfo
@@ -3269,7 +3293,7 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                     return download_history
 
             if fileitem and fileitem.path:
-                source_path = Path(fileitem.path).as_posix()
+                source_path = self._normalize_posix_path(fileitem.path).as_posix()
                 download_history = downloadhis.get_by_path(source_path)
                 if download_history:
                     return download_history

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -179,6 +179,12 @@ _SEASON_ENUM_RE_LIST = (
         re.IGNORECASE,
     ),
     re.compile(
+        rf"(\u7b2c?\s*{_CN_NUMBER_RE}\s*[\u5b63\u671f\u90e8]"
+        rf"(?:\s*{_SEASON_ENUM_SEPARATOR_RE}\s*\u7b2c?\s*"
+        rf"{_CN_NUMBER_RE}\s*[\u5b63\u671f\u90e8])+)",
+        re.IGNORECASE,
+    ),
+    re.compile(
         rf"(\u7b2c?\s*{_CN_NUMBER_RE}"
         rf"(?:\s*{_SEASON_ENUM_SEPARATOR_RE}\s*{_CN_NUMBER_RE})+"
         rf"\s*[\u5b63\u671f\u90e8])",
@@ -2876,6 +2882,8 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         将多季包上下文中的季号应用到文件元数据。
         """
         if not meta or not context or len(context.source_seasons) <= 1:
+            return False
+        if getattr(meta, "begin_episode", None) is None:
             return False
         explicit_season = cls._nearest_path_season_marker(source_path)
         season_num = (

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -5,7 +5,8 @@ import threading
 import traceback
 import uuid
 from copy import deepcopy
-from pathlib import Path
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
 from typing import List, Optional, Tuple, Union, Dict, Callable, Any
 
 from app import schemas
@@ -107,6 +108,77 @@ SUBTITLE_STEM_TAGS = {
     "繁中",
     "繁体",
 }
+
+
+_CN_NUMBER_MAP = {
+    "零": 0,
+    "一": 1,
+    "二": 2,
+    "两": 2,
+    "三": 3,
+    "四": 4,
+    "五": 5,
+    "六": 6,
+    "七": 7,
+    "八": 8,
+    "九": 9,
+    "十": 10,
+}
+_CN_NUMBER_RE = r"[0-9一二两三四五六七八九十]{1,3}"
+_SEASON_RANGE_RE_LIST = (
+    re.compile(
+        r"(?:^|[^A-Za-z0-9])(?:TV)?S(?:eason)?\s*0*([1-9]\d?)\s*"
+        r"(?:[-~+&/、,，]|至|到|和|\bto\b)\s*"
+        r"S(?:eason)?\s*0*([1-9]\d?)(?![A-Za-z0-9])",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"(?:^|[^A-Za-z0-9])Season\s*0*([1-9]\d?)\s*"
+        r"(?:[-~+&/、,，]|至|到|和|\bto\b)\s*0*([1-9]\d?)(?![A-Za-z0-9])",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"第\s*({_CN_NUMBER_RE})\s*(?:[-~+&/、,，]|至|到|和)\s*"
+        rf"({_CN_NUMBER_RE})\s*[季期部]",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"({_CN_NUMBER_RE})\s*(?:[-~+&/、,，]|至|到|和)\s*"
+        rf"({_CN_NUMBER_RE})\s*[季期部]",
+        re.IGNORECASE,
+    ),
+)
+_SEASON_SINGLE_RE_LIST = (
+    re.compile(r"(?:^|[^A-Za-z0-9])S0*([0-9]{1,2})(?=E\d{1,4}|[^A-Za-z0-9]|$)", re.IGNORECASE),
+    re.compile(r"(?:^|[^A-Za-z0-9])Season\s*0*([0-9]{1,2})(?![A-Za-z0-9])", re.IGNORECASE),
+    re.compile(rf"第\s*({_CN_NUMBER_RE})\s*[季期部]", re.IGNORECASE),
+)
+_EPISODE_RANGE_RE_LIST = (
+    re.compile(
+        rf"第\s*({_CN_NUMBER_RE})\s*"
+        rf"(?:[-~+&/、,，]|至|到|和)\s*"
+        rf"({_CN_NUMBER_RE})\s*[集话話幕]",
+        re.IGNORECASE,
+    ),
+)
+_EPISODE_SINGLE_RE_LIST = (
+    re.compile(rf"第\s*({_CN_NUMBER_RE})\s*[集话話幕]", re.IGNORECASE),
+    re.compile(r"(?:^|[^A-Za-z0-9])EP?\s*0*([0-9]{1,4})(?![A-Za-z0-9])", re.IGNORECASE),
+)
+
+
+@dataclass
+class _MultiSeasonTransferContext:
+    """
+    多季包整理上下文。
+    """
+    source_root: Optional[PurePosixPath] = None
+    source_seasons: Tuple[int, ...] = ()
+    top_dir_seasons: Dict[str, int] = None
+
+    def __post_init__(self):
+        if self.top_dir_seasons is None:
+            self.top_dir_seasons = {}
 
 
 class JobManager:
@@ -1656,6 +1728,17 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                     mediainfo.title = transfer_history.title
                     mediainfo_changed = True
 
+            if self._remap_absolute_episode(
+                    task.meta,
+                    task.source_seasons,
+                    mediainfo,
+                    Path(task.fileitem.path),
+            ):
+                mediainfo_changed = True
+                logger.info(
+                    f"{task.fileitem.name} 多季包集数已修正为 {task.meta.season_episode}"
+                )
+
             if mediainfo_changed:
                 # 更新任务信息
                 task.mediainfo = mediainfo
@@ -2508,6 +2591,358 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             else None
         )
 
+    @staticmethod
+    def _cn_number_to_int(value: Optional[Union[int, str]]) -> Optional[int]:
+        """
+        将简单中文数字转换为整数。
+        """
+        if value is None:
+            return None
+        text = str(value).strip()
+        if text.isdigit():
+            return int(text)
+        if text in _CN_NUMBER_MAP:
+            return _CN_NUMBER_MAP[text]
+        if "十" in text:
+            left, _, right = text.partition("十")
+            tens = _CN_NUMBER_MAP.get(left, 1) if left else 1
+            ones = _CN_NUMBER_MAP.get(right, 0) if right else 0
+            return tens * 10 + ones
+        return None
+
+    @staticmethod
+    def _normalize_posix_path(path: Union[str, Path, PurePosixPath]) -> PurePosixPath:
+        """
+        统一按 POSIX 路径处理下载器/容器内路径。
+        """
+        return PurePosixPath(str(path or "").replace("\\", "/"))
+
+    @classmethod
+    def _season_range_to_numbers(cls, start: str, end: str) -> Tuple[int, ...]:
+        """
+        将季范围转换为升序季号。
+        """
+        begin = cls._cn_number_to_int(start)
+        finish = cls._cn_number_to_int(end)
+        if begin is None or finish is None:
+            return ()
+        low, high = sorted((begin, finish))
+        if high - low > 20:
+            return ()
+        return tuple(range(low, high + 1))
+
+    @classmethod
+    def _parse_multi_season_numbers(cls, *texts: Optional[str]) -> Tuple[int, ...]:
+        """
+        从下载历史、种子标题或源路径中解析多季范围。
+        """
+        seasons: set[int] = set()
+        merged_text = "\n".join(str(text or "") for text in texts)
+        for pattern in _SEASON_RANGE_RE_LIST:
+            for match in pattern.findall(merged_text):
+                start, end = match[:2] if isinstance(match, tuple) else (None, None)
+                seasons.update(cls._season_range_to_numbers(start, end))
+        return tuple(sorted(seasons))
+
+    @classmethod
+    def _extract_single_season_marker(cls, text: Optional[str]) -> Optional[int]:
+        """
+        从单个路径片段中提取明确的单季标记。
+        """
+        if not text:
+            return None
+        text = str(text)
+        if cls._parse_multi_season_numbers(text):
+            return None
+        for pattern in _SEASON_SINGLE_RE_LIST:
+            match = pattern.search(text)
+            if not match:
+                continue
+            season = cls._cn_number_to_int(match.group(1))
+            if season is not None:
+                return season
+        return None
+
+    @classmethod
+    def _nearest_path_season_marker(
+            cls, source_path: Union[str, Path, PurePosixPath]
+    ) -> Optional[int]:
+        """
+        从近到远查找路径中的明确单季标记。
+        """
+        path = cls._normalize_posix_path(source_path)
+        for part in reversed(path.parts):
+            season = cls._extract_single_season_marker(part)
+            if season is not None:
+                return season
+        return None
+
+    @classmethod
+    def _extract_local_episode_marker(
+            cls, text: Optional[str]
+    ) -> Optional[Tuple[int, Optional[int]]]:
+        """
+        从文件名中提取明确的本季集数标记。
+        """
+        if not text:
+            return None
+        text = str(text)
+        for pattern in _EPISODE_RANGE_RE_LIST:
+            matches = list(pattern.finditer(text))
+            if not matches:
+                continue
+            match = matches[-1]
+            begin_episode = cls._cn_number_to_int(match.group(1))
+            end_episode = cls._cn_number_to_int(match.group(2))
+            if begin_episode and end_episode and end_episode >= begin_episode:
+                return begin_episode, end_episode
+        for pattern in _EPISODE_SINGLE_RE_LIST:
+            matches = list(pattern.finditer(text))
+            if not matches:
+                continue
+            begin_episode = cls._cn_number_to_int(matches[-1].group(1))
+            if begin_episode is not None:
+                return begin_episode, None
+        return None
+
+    @staticmethod
+    def _natural_sort_key(text: str) -> Tuple:
+        """
+        自然排序键，用于将同种子下多个季目录按目录名顺序对应到季号。
+        """
+        parts = re.split(r"(\d+)", text.lower())
+        return tuple(int(part) if part.isdigit() else part for part in parts)
+
+    @classmethod
+    def _relative_first_dir(
+            cls,
+            source_root: Optional[PurePosixPath],
+            source_path: Union[str, Path, PurePosixPath],
+    ) -> Optional[str]:
+        """
+        获取文件相对种子根目录的第一层目录。
+        """
+        if not source_root:
+            return None
+        path = cls._normalize_posix_path(source_path)
+        try:
+            rel_path = path.relative_to(source_root)
+        except ValueError:
+            return None
+        if len(rel_path.parts) < 2:
+            return None
+        return rel_path.parts[0]
+
+    @classmethod
+    def _build_multi_season_context(
+            cls,
+            download_history: Optional[DownloadHistory],
+            file_items: List[Tuple[FileItem, bool]],
+            source_fileitem: Optional[FileItem] = None,
+    ) -> _MultiSeasonTransferContext:
+        """
+        构建多季包上下文，用于整理阶段继承种子/目录级季信息。
+        """
+        history_path = getattr(download_history, "path", None)
+        source_path = getattr(source_fileitem, "path", None)
+        source_seasons = cls._parse_multi_season_numbers(
+            getattr(download_history, "seasons", None),
+            getattr(download_history, "torrent_name", None),
+            getattr(download_history, "torrent_description", None),
+            history_path,
+            source_path,
+        )
+        source_root = cls._normalize_posix_path(history_path or source_path)
+        if source_root.suffix:
+            source_root = source_root.parent
+
+        top_dirs: set[str] = set()
+        for item, _ in file_items or []:
+            if not item or item.type != "file":
+                continue
+            if f".{(item.extension or '').lower()}" not in settings.RMT_MEDIAEXT:
+                continue
+            first_dir = cls._relative_first_dir(source_root, item.path)
+            if not first_dir:
+                continue
+            if cls._extract_single_season_marker(first_dir) is not None:
+                continue
+            top_dirs.add(first_dir)
+
+        top_dir_seasons: Dict[str, int] = {}
+        if len(source_seasons) > 1 and len(top_dirs) == len(source_seasons):
+            for dirname, season_num in zip(
+                    sorted(top_dirs, key=cls._natural_sort_key),
+                    source_seasons,
+            ):
+                top_dir_seasons[dirname] = season_num
+
+        return _MultiSeasonTransferContext(
+            source_root=source_root,
+            source_seasons=source_seasons,
+            top_dir_seasons=top_dir_seasons,
+        )
+
+    @classmethod
+    def _infer_context_season(
+            cls,
+            source_path: Union[str, Path, PurePosixPath],
+            context: Optional[_MultiSeasonTransferContext],
+    ) -> Optional[int]:
+        """
+        根据路径和多季上下文推断当前文件所属季。
+        """
+        explicit_season = cls._nearest_path_season_marker(source_path)
+        if explicit_season is not None:
+            return explicit_season
+        if not context:
+            return None
+        first_dir = cls._relative_first_dir(context.source_root, source_path)
+        if first_dir and first_dir in context.top_dir_seasons:
+            return context.top_dir_seasons[first_dir]
+        return None
+
+    @classmethod
+    def _apply_multi_season_context(
+            cls,
+            meta: Optional[MetaBase],
+            source_path: Union[str, Path, PurePosixPath],
+            context: Optional[_MultiSeasonTransferContext],
+    ) -> bool:
+        """
+        将多季包上下文中的季号应用到文件元数据。
+        """
+        if not meta or not context or len(context.source_seasons) <= 1:
+            return False
+        explicit_season = cls._nearest_path_season_marker(source_path)
+        season_num = explicit_season or cls._infer_context_season(source_path, context)
+        if season_num is None:
+            return False
+        changed = False
+        if meta.begin_season != season_num or meta.end_season is not None:
+            meta.begin_season = season_num
+            meta.end_season = None
+            meta.total_season = 1
+            changed = True
+
+        if explicit_season is not None:
+            local_episode = cls._extract_local_episode_marker(
+                cls._normalize_posix_path(source_path).name
+            )
+            if local_episode:
+                begin_episode, end_episode = local_episode
+                if (
+                        meta.begin_episode != begin_episode
+                        or meta.end_episode != end_episode
+                ):
+                    meta.begin_episode = begin_episode
+                    meta.end_episode = end_episode
+                    meta.total_episode = (
+                        (end_episode - begin_episode) + 1
+                        if end_episode
+                        else 1
+                    )
+                    changed = True
+
+        return changed
+
+    @staticmethod
+    def _season_episode_list(
+            mediainfo: Optional[MediaInfo], season_num: int
+    ) -> List[int]:
+        """
+        获取指定季的剧集列表。
+        """
+        if not mediainfo or not season_num:
+            return []
+        seasons = getattr(mediainfo, "seasons", None) or {}
+        episodes = seasons.get(season_num) or seasons.get(str(season_num)) or []
+        if isinstance(episodes, list):
+            return [int(ep) for ep in episodes if str(ep).isdigit()]
+        return []
+
+    @classmethod
+    def _map_absolute_episode(
+            cls,
+            episode_num: Optional[int],
+            source_seasons: Union[List[int], Tuple[int, ...]],
+            mediainfo: Optional[MediaInfo],
+    ) -> Optional[Tuple[int, int]]:
+        """
+        按媒体每季集数将全局集数映射为季内集数。
+        """
+        if not episode_num or not source_seasons or not mediainfo:
+            return None
+        offset = 0
+        for season_num in sorted({int(season) for season in source_seasons}):
+            episode_list = cls._season_episode_list(mediainfo, season_num)
+            if not episode_list:
+                return None
+            count = len(episode_list)
+            if offset < episode_num <= offset + count:
+                return season_num, episode_list[episode_num - offset - 1]
+            offset += count
+        return None
+
+    @classmethod
+    def _remap_absolute_episode(
+            cls,
+            meta: Optional[MetaBase],
+            source_seasons: Union[List[int], Tuple[int, ...]],
+            mediainfo: Optional[MediaInfo],
+            source_path: Union[str, Path, PurePosixPath] = None,
+    ) -> bool:
+        """
+        将多季包里的全局集数映射为对应季内集数。
+        """
+        if (
+                not meta
+                or not source_seasons
+                or len(source_seasons) <= 1
+                or not meta.begin_episode
+        ):
+            return False
+        mapped_begin = cls._map_absolute_episode(
+            meta.begin_episode, source_seasons, mediainfo
+        )
+        if not mapped_begin:
+            return False
+
+        mapped_season, mapped_episode = mapped_begin
+        explicit_season = (
+            cls._nearest_path_season_marker(source_path) if source_path else None
+        )
+        if explicit_season is not None and mapped_season != explicit_season:
+            return False
+        if (
+                meta.begin_season
+                and meta.begin_season != 1
+                and mapped_season != meta.begin_season
+        ):
+            return False
+
+        mapped_end = None
+        if meta.end_episode:
+            mapped_end = cls._map_absolute_episode(
+                meta.end_episode, source_seasons, mediainfo
+            )
+            if not mapped_end or mapped_end[0] != mapped_season:
+                return False
+
+        changed = (
+                meta.begin_season != mapped_season
+                or meta.begin_episode != mapped_episode
+                or (mapped_end and meta.end_episode != mapped_end[1])
+        )
+        meta.begin_season = mapped_season
+        meta.end_season = None
+        meta.total_season = 1
+        meta.begin_episode = mapped_episode
+        if mapped_end:
+            meta.end_episode = mapped_end[1]
+            meta.total_episode = (meta.end_episode - meta.begin_episode) + 1
+        return changed
+
     def do_transfer(
             self,
             fileitem: FileItem,
@@ -2585,6 +3020,7 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         # 汇总错误信息
         err_msgs: List[str] = []
         matched_episode_format_template = False
+        multi_season_context: Optional[_MultiSeasonTransferContext] = None
 
         def _build_file_meta(
                 source_path: Path,
@@ -2602,7 +3038,12 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                 # _build_path_meta 已经应用过手动季集/自定义格式覆盖；
                 # 这里避免再次偏移集数，导致手动整理的集数偏移翻倍。
                 return built_meta
-            return _apply_meta_overrides(built_meta, source_path)
+            built_meta = _apply_meta_overrides(built_meta, source_path)
+            if season is None:
+                self._apply_multi_season_context(
+                    built_meta, source_path, multi_season_context
+                )
+            return built_meta
 
         def _build_path_meta(
                 source_path: Path,
@@ -2616,7 +3057,12 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             )
             if not path_meta:
                 return None
-            return _apply_meta_overrides(path_meta, source_path)
+            path_meta = _apply_meta_overrides(path_meta, source_path)
+            if season is None:
+                self._apply_multi_season_context(
+                    path_meta, source_path, multi_season_context
+                )
+            return path_meta
 
         def _apply_meta_overrides(
                 current_meta: MetaBase, source_path: Path
@@ -2708,6 +3154,35 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                 for candidate_item, candidate_bluray_dir in candidates
                 if _is_allowed_transfer_item(candidate_item, candidate_bluray_dir)
             ]
+
+        def _resolve_multi_season_download_history(
+                items: List[Tuple[FileItem, bool]]
+        ) -> Optional[DownloadHistory]:
+            """
+            解析本轮整理对应的下载历史，用于提取整包季范围。
+            """
+            downloadhis = DownloadHistoryOper()
+            if download_hash:
+                return downloadhis.get_by_hash(download_hash)
+
+            if fileitem and fileitem.path:
+                source_path = Path(fileitem.path).as_posix()
+                download_history = downloadhis.get_by_path(source_path)
+                if download_history:
+                    return download_history
+
+            for candidate_item, candidate_bluray_dir in items or []:
+                if not candidate_item or not candidate_item.path:
+                    continue
+                download_history = self._resolve_download_history(
+                    downloadhis=downloadhis,
+                    file_path=Path(candidate_item.path),
+                    bluray_dir=candidate_bluray_dir,
+                    download_hash=download_hash,
+                )
+                if download_history:
+                    return download_history
+            return None
 
         def _build_main_meta(
                 main_fileitem: FileItem,
@@ -2941,6 +3416,11 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         try:
             candidate_file_items = _collect_candidate_file_items()
             file_items = _filter_allowed_file_items(candidate_file_items)
+            multi_season_context = self._build_multi_season_context(
+                download_history=_resolve_multi_season_download_history(file_items),
+                file_items=file_items,
+                source_fileitem=fileitem,
+            )
         except OperationInterrupted:
             return False, f"{fileitem.name} 已取消"
         finally:
@@ -3066,6 +3546,9 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                     downloader=_downloader,
                     download_hash=_download_hash,
                     download_history=download_history,
+                    source_seasons=list(multi_season_context.source_seasons)
+                    if multi_season_context
+                    else [],
                     transfer_batch_id=transfer_batch_id,
                     manual=manual,
                     background=background,

--- a/app/schemas/transfer.py
+++ b/app/schemas/transfer.py
@@ -72,6 +72,7 @@ class TransferTask(BaseModel):
     downloader: Optional[str] = None
     download_hash: Optional[str] = None
     download_history: Optional[DownloadHistory] = None
+    source_seasons: Optional[List[int]] = Field(default_factory=list)
     transfer_batch_id: Optional[str] = None
     manual: Optional[bool] = False
     background: Optional[bool] = True

--- a/tests/test_transfer_download_history_lookup.py
+++ b/tests/test_transfer_download_history_lookup.py
@@ -50,6 +50,22 @@ class TransferDownloadHistoryLookupTest(unittest.TestCase):
 
         self.assertIs(history, expected)
 
+    def test_resolve_download_history_accepts_normalized_backslash_path(self):
+        expected = SimpleNamespace(download_hash="hash1", downloader="qb")
+        oper = FakeDownloadHistoryOper(
+            histories_by_path={"C:/downloads/season-pack": expected},
+        )
+        normalized_path = TransferChain._normalize_posix_path(
+            r"C:\downloads\season-pack\Placeholder.Show.S01E01.mkv"
+        )
+
+        history = self.chain._resolve_download_history(
+            downloadhis=oper,
+            file_path=Path(normalized_path.as_posix()),
+        )
+
+        self.assertIs(history, expected)
+
     def test_resolve_download_history_falls_back_to_unique_savepath_hash(self):
         expected = SimpleNamespace(download_hash="hash1", downloader="qb")
         oper = FakeDownloadHistoryOper(

--- a/tests/test_transfer_multi_season_context.py
+++ b/tests/test_transfer_multi_season_context.py
@@ -1,0 +1,181 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from app.chain.transfer import TransferChain
+from app.core.context import MediaInfo
+from app.core.metainfo import MetaInfoPath
+from app.schemas import FileItem
+from app.schemas.types import MediaType
+
+
+def _fileitem(path: str, item_type: str = "file") -> FileItem:
+    file_path = Path(path)
+    return FileItem(
+        storage="local",
+        path=file_path.as_posix(),
+        type=item_type,
+        name=file_path.name,
+        basename=file_path.stem,
+        extension=file_path.suffix.lstrip("."),
+        size=1024,
+    )
+
+
+def _history(path: str, seasons: str, torrent_name: str = ""):
+    return SimpleNamespace(
+        path=path,
+        seasons=seasons,
+        episodes="",
+        torrent_name=torrent_name,
+        torrent_description="",
+    )
+
+
+def _mediainfo(*season_lengths: int) -> MediaInfo:
+    media = MediaInfo()
+    media.type = MediaType.TV
+    media.seasons = {
+        index: list(range(1, season_length + 1))
+        for index, season_length in enumerate(season_lengths, start=1)
+    }
+    return media
+
+
+def test_multi_season_context_maps_absolute_episode_to_second_season():
+    """
+    A two-season pack can use global episode numbers while the second top-level
+    directory has no explicit S02 marker.
+    """
+    root = "/downloads/[ReleaseGroup] Placeholder Series Alpha [Lite]"
+    first_season = (
+        f"{root}/[ReleaseGroup] Placeholder Series Alpha [1080p][Lite]/"
+        "[ReleaseGroup] Placeholder Series Alpha [02][1080p].mkv"
+    )
+    second_season = (
+        f"{root}/[ReleaseGroup] Placeholder Series Alpha Arc Two [1080p][Lite]/"
+        "[ReleaseGroup] Placeholder Series Alpha Arc Two [14][1080p].mkv"
+    )
+    context = TransferChain._build_multi_season_context(
+        download_history=_history(
+            root,
+            "S01-S02",
+            "Placeholder Series Alpha S01-S02 1080p",
+        ),
+        file_items=[(_fileitem(first_season), False), (_fileitem(second_season), False)],
+        source_fileitem=_fileitem(root, item_type="dir"),
+    )
+
+    meta = MetaInfoPath(Path(second_season))
+    TransferChain._apply_multi_season_context(meta, Path(second_season), context)
+    TransferChain._remap_absolute_episode(
+        meta, context.source_seasons, _mediainfo(12, 12), Path(second_season)
+    )
+
+    assert context.source_seasons == (1, 2)
+    assert meta.begin_season == 2
+    assert meta.begin_episode == 2
+    assert meta.season_episode == "S02 E02"
+
+
+def test_multi_season_context_maps_second_directory_with_tilde_range():
+    """
+    A S01~S02 pack should still infer the second top-level directory as season 2
+    and map absolute episode 16 to S02E04.
+    """
+    root = "/downloads/[ReleaseGroup] Placeholder Series Beta S01~S02 [Lite]"
+    first_season = (
+        f"{root}/[ReleaseGroup] Placeholder Series Beta [1080p][Lite]/"
+        "[ReleaseGroup] Placeholder Series Beta [02][1080p].mkv"
+    )
+    second_season = (
+        f"{root}/[ReleaseGroup] Placeholder Series Beta Arc Two [1080p][Lite]/"
+        "[ReleaseGroup] Placeholder Series Beta Arc Two [16][1080p].mkv"
+    )
+    context = TransferChain._build_multi_season_context(
+        download_history=_history(
+            root,
+            "S01~S02",
+            "Placeholder Series Beta S01~S02 1080p",
+        ),
+        file_items=[(_fileitem(first_season), False), (_fileitem(second_season), False)],
+        source_fileitem=_fileitem(root, item_type="dir"),
+    )
+
+    meta = MetaInfoPath(Path(second_season))
+    TransferChain._apply_multi_season_context(meta, Path(second_season), context)
+    TransferChain._remap_absolute_episode(
+        meta, context.source_seasons, _mediainfo(12, 12), Path(second_season)
+    )
+
+    assert context.source_seasons == (1, 2)
+    assert meta.begin_season == 2
+    assert meta.begin_episode == 4
+    assert meta.season_episode == "S02 E04"
+
+
+def test_multi_season_context_uses_explicit_chinese_season_marker():
+    """
+    When a file has an explicit Chinese season marker, that local marker wins
+    over the root-level multi-season range.
+    """
+    season_range = "\u7b2c1-3\u671f"
+    season_marker = "\u7b2c2\u671f"
+    episode_marker = "\u7b2c03\u8bdd"
+    root = f"/downloads/[ReleaseGroup] Placeholder Series Gamma {season_range}"
+    source = (
+        f"{root}/[ReleaseGroup] Placeholder Series Gamma {season_marker} "
+        f"{episode_marker} [1080p].mkv"
+    )
+    context = TransferChain._build_multi_season_context(
+        download_history=_history(
+            root,
+            "S01-S03",
+            "Placeholder Series Gamma S1-S3 1080p",
+        ),
+        file_items=[(_fileitem(source), False)],
+        source_fileitem=_fileitem(root, item_type="dir"),
+    )
+
+    meta = MetaInfoPath(Path(source))
+    TransferChain._apply_multi_season_context(meta, Path(source), context)
+    TransferChain._remap_absolute_episode(
+        meta, context.source_seasons, _mediainfo(12, 12, 12), Path(source)
+    )
+
+    assert meta.begin_season == 2
+    assert meta.begin_episode == 3
+    assert meta.season_episode == "S02 E03"
+
+
+def test_multi_season_context_keeps_local_episode_with_explicit_season():
+    """
+    A later season can restart local episode numbers from 01; it must not be
+    remapped through the full-pack cumulative episode table.
+    """
+    season_range = "\u7b2c1-6\u671f"
+    season_marker = "\u7b2c4\u671f"
+    episode_marker = "\u7b2c01\u8bdd"
+    root = f"/downloads/[ReleaseGroup] Placeholder Series Delta {season_range}"
+    source = (
+        f"{root}/[ReleaseGroup] Placeholder Series Delta Arc Four "
+        f"{season_marker} {episode_marker} [1080p].mkv"
+    )
+    context = TransferChain._build_multi_season_context(
+        download_history=_history(
+            root,
+            "S01-S06",
+            "Placeholder Series Delta S1-S6 1080p",
+        ),
+        file_items=[(_fileitem(source), False)],
+        source_fileitem=_fileitem(root, item_type="dir"),
+    )
+
+    meta = MetaInfoPath(Path(source))
+    TransferChain._apply_multi_season_context(meta, Path(source), context)
+    TransferChain._remap_absolute_episode(
+        meta, context.source_seasons, _mediainfo(13, 12, 12, 12, 1, 2), Path(source)
+    )
+
+    assert meta.begin_season == 4
+    assert meta.begin_episode == 1
+    assert meta.season_episode == "S04 E01"

--- a/tests/test_transfer_multi_season_context.py
+++ b/tests/test_transfer_multi_season_context.py
@@ -113,6 +113,51 @@ def test_multi_season_context_maps_second_directory_with_tilde_range():
     assert meta.season_episode == "S02 E04"
 
 
+def test_multi_season_context_keeps_dot_separated_root_directory():
+    """
+    Dot-separated release names may look like file paths; they still need to be
+    treated as torrent root directories when the source item is a directory.
+    """
+    root = "/downloads/Placeholder.Series.Epsilon.S01-S02.1080p"
+    first_season = (
+        f"{root}/Placeholder.Series.Epsilon.Part.One/"
+        "Placeholder Series Epsilon [02][1080p].mkv"
+    )
+    second_season = (
+        f"{root}/Placeholder.Series.Epsilon.Part.Two/"
+        "Placeholder Series Epsilon [14][1080p].mkv"
+    )
+    context = TransferChain._build_multi_season_context(
+        download_history=_history(
+            root,
+            "S01-S02",
+            "Placeholder Series Epsilon S01-S02 1080p",
+        ),
+        file_items=[(_fileitem(first_season), False), (_fileitem(second_season), False)],
+        source_fileitem=_fileitem(root, item_type="dir"),
+    )
+
+    meta = MetaInfoPath(Path(second_season))
+    TransferChain._apply_multi_season_context(meta, Path(second_season), context)
+    TransferChain._remap_absolute_episode(
+        meta, context.source_seasons, _mediainfo(12, 12), Path(second_season)
+    )
+
+    assert context.top_dir_seasons["Placeholder.Series.Epsilon.Part.Two"] == 2
+    assert meta.begin_season == 2
+    assert meta.begin_episode == 2
+    assert meta.season_episode == "S02 E02"
+
+
+def test_multi_season_context_does_not_expand_enumerated_seasons():
+    """
+    Enumerated seasons are not continuous ranges; S01&S03 must not imply S02.
+    """
+    assert TransferChain._parse_multi_season_numbers("Placeholder S01&S03") == (1, 3)
+    assert TransferChain._parse_multi_season_numbers("Placeholder S01,S03") == (1, 3)
+    assert TransferChain._parse_multi_season_numbers("Placeholder S01-S03") == (1, 2, 3)
+
+
 def test_multi_season_context_uses_explicit_chinese_season_marker():
     """
     When a file has an explicit Chinese season marker, that local marker wins

--- a/tests/test_transfer_multi_season_context.py
+++ b/tests/test_transfer_multi_season_context.py
@@ -304,6 +304,33 @@ def test_multi_season_context_reports_status_field_changes():
     assert meta.total_episode == 1
 
 
+def test_multi_season_context_keeps_inferred_season_local_episode():
+    """
+    Once the directory context has inferred season 2, a valid S02 local episode
+    should not be remapped as a full-pack absolute episode.
+    """
+    source = (
+        "/downloads/[ReleaseGroup] Placeholder Series Kappa/"
+        "[ReleaseGroup] Placeholder Series Kappa Arc Two [02][1080p].mkv"
+    )
+    meta = MetaInfoPath(Path(source))
+    meta.begin_season = 2
+    meta.end_season = None
+    meta.total_season = 1
+    meta.begin_episode = 2
+    meta.end_episode = None
+    meta.total_episode = 1
+
+    changed = TransferChain._remap_absolute_episode(
+        meta, (1, 2), _mediainfo(1, 12), Path(source)
+    )
+
+    assert changed is False
+    assert meta.begin_season == 2
+    assert meta.begin_episode == 2
+    assert meta.season_episode == "S02 E02"
+
+
 def test_multi_season_context_drops_source_seasons_for_explicit_task_season():
     """
     A user-provided task season should not carry source seasons that can remap it
@@ -313,6 +340,19 @@ def test_multi_season_context_drops_source_seasons_for_explicit_task_season():
 
     assert TransferChain._task_source_seasons(context, season=2) == []
     assert TransferChain._task_source_seasons(context, season=None) == [1, 2]
+
+
+def test_multi_season_context_normalizes_backslash_paths():
+    """
+    Downloader paths can contain backslashes and should use the same POSIX
+    normalization as multi-season relative path handling.
+    """
+    path = r"C:\downloads\Placeholder.Series.Lambda.S01-S02"
+
+    assert (
+        TransferChain._normalize_posix_path(path).as_posix()
+        == "C:/downloads/Placeholder.Series.Lambda.S01-S02"
+    )
 
 
 def test_multi_season_context_uses_explicit_chinese_season_marker():

--- a/tests/test_transfer_multi_season_context.py
+++ b/tests/test_transfer_multi_season_context.py
@@ -155,7 +155,52 @@ def test_multi_season_context_does_not_expand_enumerated_seasons():
     """
     assert TransferChain._parse_multi_season_numbers("Placeholder S01&S03") == (1, 3)
     assert TransferChain._parse_multi_season_numbers("Placeholder S01,S03") == (1, 3)
+    assert TransferChain._parse_multi_season_numbers("Placeholder S01&S02&S03") == (1, 2, 3)
+    assert TransferChain._parse_multi_season_numbers(
+        "Placeholder \u7b2c1\u30012\u30013\u5b63"
+    ) == (1, 2, 3)
     assert TransferChain._parse_multi_season_numbers("Placeholder S01-S03") == (1, 2, 3)
+
+
+def test_multi_season_context_accepts_episode_object_lists():
+    """
+    Season episode lists can contain TMDB-like dicts or objects.
+    """
+    media = MediaInfo()
+    media.type = MediaType.TV
+    media.seasons = {
+        1: [
+            {"episode_number": 1},
+            SimpleNamespace(episode_number="2"),
+            3,
+        ]
+    }
+
+    assert TransferChain._season_episode_list(media, 1) == [1, 2, 3]
+
+
+def test_multi_season_context_keeps_explicit_season_local_episode():
+    """
+    If a path already says S02E14 and season 2 has episode 14, keep it as
+    S02E14 instead of treating 14 as a full-pack absolute episode number.
+    """
+    source = "/downloads/[ReleaseGroup] Placeholder Series Zeta S02E14 [1080p].mkv"
+    meta = MetaInfoPath(Path(source))
+    meta.begin_season = 2
+    meta.end_season = None
+    meta.total_season = 1
+    meta.begin_episode = 14
+    meta.end_episode = None
+    meta.total_episode = 1
+
+    changed = TransferChain._remap_absolute_episode(
+        meta, (1, 2), _mediainfo(24, 24), Path(source)
+    )
+
+    assert changed is False
+    assert meta.begin_season == 2
+    assert meta.begin_episode == 14
+    assert meta.season_episode == "S02 E14"
 
 
 def test_multi_season_context_uses_explicit_chinese_season_marker():

--- a/tests/test_transfer_multi_season_context.py
+++ b/tests/test_transfer_multi_season_context.py
@@ -177,6 +177,9 @@ def test_multi_season_context_does_not_expand_enumerated_seasons():
     assert TransferChain._extract_single_season_marker(
         "Placeholder \u7b2c1\u5b63-\u7b2c3\u5b63"
     ) is None
+    assert TransferChain._extract_single_season_marker(
+        "Placeholder S01-S02 S02E03"
+    ) == 2
 
 
 def test_multi_season_context_accepts_mixed_chinese_numbers():
@@ -204,6 +207,33 @@ def test_multi_season_context_ignores_parent_directory_ranges():
 
     assert context.source_seasons == ()
     assert context.top_dir_seasons == {}
+
+
+def test_multi_season_context_maps_remaining_implicit_directories():
+    """
+    Explicit season directories should occupy their seasons while implicit
+    sibling directories map to the remaining source seasons.
+    """
+    root = "/downloads/[ReleaseGroup] Placeholder Series Xi"
+    first_season = (
+        f"{root}/Season 1/"
+        "[ReleaseGroup] Placeholder Series Xi [01][1080p].mkv"
+    )
+    second_season = (
+        f"{root}/Placeholder Series Xi Arc Two/"
+        "[ReleaseGroup] Placeholder Series Xi Arc Two [01][1080p].mkv"
+    )
+    context = TransferChain._build_multi_season_context(
+        download_history=_history(
+            root,
+            "S01-S02",
+            "Placeholder Series Xi S01-S02 1080p",
+        ),
+        file_items=[(_fileitem(first_season), False), (_fileitem(second_season), False)],
+        source_fileitem=_fileitem(root, item_type="dir"),
+    )
+
+    assert context.top_dir_seasons["Placeholder Series Xi Arc Two"] == 2
 
 
 def test_multi_season_context_ignores_parent_season_marker():

--- a/tests/test_transfer_multi_season_context.py
+++ b/tests/test_transfer_multi_season_context.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from types import SimpleNamespace
 
-from app.chain.transfer import TransferChain
+from app.chain.transfer import TransferChain, _MultiSeasonTransferContext
 from app.core.context import MediaInfo
 from app.core.metainfo import MetaInfoPath
 from app.schemas import FileItem
@@ -179,6 +179,18 @@ def test_multi_season_context_accepts_episode_object_lists():
     assert TransferChain._season_episode_list(media, 1) == [1, 2, 3]
 
 
+def test_multi_season_context_ignores_non_dict_seasons():
+    """
+    Unexpected season payloads should disable absolute remapping instead of
+    interrupting transfer.
+    """
+    media = MediaInfo()
+    media.type = MediaType.TV
+    media.seasons = [{"season_number": 1, "episode_count": 3}]
+
+    assert TransferChain._season_episode_list(media, 1) == []
+
+
 def test_multi_season_context_keeps_explicit_season_local_episode():
     """
     If a path already says S02E14 and season 2 has episode 14, keep it as
@@ -201,6 +213,44 @@ def test_multi_season_context_keeps_explicit_season_local_episode():
     assert meta.begin_season == 2
     assert meta.begin_episode == 14
     assert meta.season_episode == "S02 E14"
+
+
+def test_multi_season_context_reports_status_field_changes():
+    """
+    Queue state must be updated when remapping only normalizes season status
+    fields.
+    """
+    source = "/downloads/[ReleaseGroup] Placeholder Series Eta [02][1080p].mkv"
+    meta = MetaInfoPath(Path(source))
+    meta.begin_season = 2
+    meta.end_season = 3
+    meta.total_season = 2
+    meta.begin_episode = 2
+    meta.end_episode = None
+    meta.total_episode = 1
+
+    changed = TransferChain._remap_absolute_episode(
+        meta, (2, 3), _mediainfo(12, 12, 12), Path(source)
+    )
+
+    assert changed is True
+    assert meta.begin_season == 2
+    assert meta.end_season is None
+    assert meta.total_season == 1
+    assert meta.begin_episode == 2
+    assert meta.end_episode is None
+    assert meta.total_episode == 1
+
+
+def test_multi_season_context_drops_source_seasons_for_explicit_task_season():
+    """
+    A user-provided task season should not carry source seasons that can remap it
+    later in the queue.
+    """
+    context = _MultiSeasonTransferContext(source_seasons=(1, 2))
+
+    assert TransferChain._task_source_seasons(context, season=2) == []
+    assert TransferChain._task_source_seasons(context, season=None) == [1, 2]
 
 
 def test_multi_season_context_uses_explicit_chinese_season_marker():

--- a/tests/test_transfer_multi_season_context.py
+++ b/tests/test_transfer_multi_season_context.py
@@ -160,6 +160,18 @@ def test_multi_season_context_does_not_expand_enumerated_seasons():
         "Placeholder \u7b2c1\u30012\u30013\u5b63"
     ) == (1, 2, 3)
     assert TransferChain._parse_multi_season_numbers("Placeholder S01-S03") == (1, 2, 3)
+    assert TransferChain._parse_multi_season_numbers("Placeholder S01-02") == (1, 2)
+    assert TransferChain._parse_multi_season_numbers("Placeholder S01~02") == (1, 2)
+    assert TransferChain._parse_multi_season_numbers(
+        "Placeholder \u7b2c1\u5b63-\u7b2c3\u5b63"
+    ) == (1, 2, 3)
+    assert TransferChain._parse_multi_season_numbers(
+        "Placeholder \u7b2c1\u5b63\u3001\u7b2c3\u5b63"
+    ) == (1, 3)
+    assert TransferChain._extract_single_season_marker("Placeholder S01-02") is None
+    assert TransferChain._extract_single_season_marker(
+        "Placeholder \u7b2c1\u5b63-\u7b2c3\u5b63"
+    ) is None
 
 
 def test_multi_season_context_accepts_episode_object_lists():

--- a/tests/test_transfer_multi_season_context.py
+++ b/tests/test_transfer_multi_season_context.py
@@ -165,6 +165,8 @@ def test_multi_season_context_does_not_expand_enumerated_seasons():
     assert TransferChain._parse_multi_season_numbers("Placeholder S01-S03") == (1, 2, 3)
     assert TransferChain._parse_multi_season_numbers("Placeholder S01-02") == (1, 2)
     assert TransferChain._parse_multi_season_numbers("Placeholder S01~02") == (1, 2)
+    assert TransferChain._parse_multi_season_numbers("Season 1 - 12 Episodes") == ()
+    assert TransferChain._parse_multi_season_numbers("Placeholder S01-12 EP") == ()
     assert TransferChain._parse_multi_season_numbers(
         "Placeholder \u7b2c1\u5b63-\u7b2c3\u5b63"
     ) == (1, 2, 3)
@@ -202,6 +204,29 @@ def test_multi_season_context_ignores_parent_directory_ranges():
 
     assert context.source_seasons == ()
     assert context.top_dir_seasons == {}
+
+
+def test_multi_season_context_ignores_parent_season_marker():
+    """
+    Parent category folders outside the torrent root must not override the
+    season inferred from the torrent's own top-level directories.
+    """
+    root = "/downloads/S02/Placeholder Series Nu"
+    source = (
+        f"{root}/Placeholder Series Nu Arc One/"
+        "[ReleaseGroup] Placeholder Series Nu [01][1080p].mkv"
+    )
+    context = _MultiSeasonTransferContext(
+        source_root=TransferChain._normalize_posix_path(root),
+        source_seasons=(1, 2),
+        top_dir_seasons={"Placeholder Series Nu Arc One": 1},
+    )
+    meta = MetaInfoPath(Path(source))
+
+    TransferChain._apply_multi_season_context(meta, Path(source), context)
+
+    assert meta.begin_season == 1
+    assert meta.begin_episode == 1
 
 
 def test_multi_season_context_requires_explicit_episode():

--- a/tests/test_transfer_multi_season_context.py
+++ b/tests/test_transfer_multi_season_context.py
@@ -177,6 +177,33 @@ def test_multi_season_context_does_not_expand_enumerated_seasons():
     ) is None
 
 
+def test_multi_season_context_accepts_mixed_chinese_numbers():
+    """
+    Mixed Chinese/Arabic season numbers should be parsed instead of silently
+    becoming the wrong value.
+    """
+    assert TransferChain._cn_number_to_int("\u53412") == 12
+    assert TransferChain._cn_number_to_int("2\u5341") == 20
+    assert TransferChain._cn_number_to_int("\u5341x") is None
+
+
+def test_multi_season_context_ignores_parent_directory_ranges():
+    """
+    A generic parent folder named like a season range must not provide source
+    seasons for an unrelated child torrent root.
+    """
+    root = "/downloads/S01-S02/Placeholder Series Mu"
+    source = f"{root}/[ReleaseGroup] Placeholder Series Mu [01][1080p].mkv"
+    context = TransferChain._build_multi_season_context(
+        download_history=_history(root, "", ""),
+        file_items=[(_fileitem(source), False)],
+        source_fileitem=_fileitem(root, item_type="dir"),
+    )
+
+    assert context.source_seasons == ()
+    assert context.top_dir_seasons == {}
+
+
 def test_multi_season_context_requires_explicit_episode():
     """
     Collection-like titles can contain part ranges; without an episode marker

--- a/tests/test_transfer_multi_season_context.py
+++ b/tests/test_transfer_multi_season_context.py
@@ -395,6 +395,54 @@ def test_multi_season_context_keeps_explicit_season_local_episode():
     assert meta.season_episode == "S02 E14"
 
 
+def test_multi_season_context_keeps_explicit_season_without_episode_catalog():
+    """
+    A filename-level season marker is authoritative even when the media episode
+    catalog is incomplete.
+    """
+    source = "/downloads/[ReleaseGroup] Placeholder Series Mu S02E14 [1080p].mkv"
+    meta = MetaInfoPath(Path(source))
+    meta.begin_season = 2
+    meta.end_season = None
+    meta.total_season = 1
+    meta.begin_episode = 14
+    meta.end_episode = None
+    meta.total_episode = 1
+
+    changed = TransferChain._remap_absolute_episode(
+        meta, (1, 2), _mediainfo(13, 12), Path(source)
+    )
+
+    assert changed is False
+    assert meta.begin_season == 2
+    assert meta.begin_episode == 14
+    assert meta.season_episode == "S02 E14"
+
+
+def test_multi_season_context_rejects_reversed_episode_range():
+    """
+    Reversed episode ranges should not write invalid total_episode values.
+    """
+    source = "/downloads/[ReleaseGroup] Placeholder Series Nu [15-13][1080p].mkv"
+    meta = MetaInfoPath(Path(source))
+    meta.begin_season = 1
+    meta.end_season = None
+    meta.total_season = 1
+    meta.begin_episode = 15
+    meta.end_episode = 13
+    meta.total_episode = 1
+
+    changed = TransferChain._remap_absolute_episode(
+        meta, (1, 2), _mediainfo(12, 12), Path(source)
+    )
+
+    assert changed is False
+    assert meta.begin_season == 1
+    assert meta.begin_episode == 15
+    assert meta.end_episode == 13
+    assert meta.total_episode == 1
+
+
 def test_multi_season_context_reports_status_field_changes():
     """
     Queue state must be updated when remapping only normalizes season status

--- a/tests/test_transfer_multi_season_context.py
+++ b/tests/test_transfer_multi_season_context.py
@@ -159,6 +159,9 @@ def test_multi_season_context_does_not_expand_enumerated_seasons():
     assert TransferChain._parse_multi_season_numbers(
         "Placeholder \u7b2c1\u30012\u30013\u5b63"
     ) == (1, 2, 3)
+    assert TransferChain._parse_multi_season_numbers(
+        "Placeholder \u7b2c1\u5b63\uff0c\u7b2c2\u5b63\uff0c\u7b2c3\u5b63"
+    ) == (1, 2, 3)
     assert TransferChain._parse_multi_season_numbers("Placeholder S01-S03") == (1, 2, 3)
     assert TransferChain._parse_multi_season_numbers("Placeholder S01-02") == (1, 2)
     assert TransferChain._parse_multi_season_numbers("Placeholder S01~02") == (1, 2)
@@ -172,6 +175,27 @@ def test_multi_season_context_does_not_expand_enumerated_seasons():
     assert TransferChain._extract_single_season_marker(
         "Placeholder \u7b2c1\u5b63-\u7b2c3\u5b63"
     ) is None
+
+
+def test_multi_season_context_requires_explicit_episode():
+    """
+    Collection-like titles can contain part ranges; without an episode marker
+    they should not receive TV season context.
+    """
+    source = "/downloads/[ReleaseGroup] Placeholder Collection \u7b2c1-3\u90e8.mkv"
+    meta = MetaInfoPath(Path(source))
+    meta.begin_season = None
+    meta.end_season = None
+    meta.total_season = 1
+    meta.begin_episode = None
+    meta.end_episode = None
+    context = _MultiSeasonTransferContext(source_seasons=(1, 2, 3))
+
+    changed = TransferChain._apply_multi_season_context(meta, Path(source), context)
+
+    assert changed is False
+    assert meta.begin_season is None
+    assert meta.begin_episode is None
 
 
 def test_multi_season_context_accepts_episode_object_lists():

--- a/tests/test_transfer_multi_season_context.py
+++ b/tests/test_transfer_multi_season_context.py
@@ -179,6 +179,18 @@ def test_multi_season_context_accepts_episode_object_lists():
     assert TransferChain._season_episode_list(media, 1) == [1, 2, 3]
 
 
+def test_multi_season_context_sorts_episode_lists():
+    """
+    Absolute episode mapping should not depend on upstream episode list order.
+    """
+    media = MediaInfo()
+    media.type = MediaType.TV
+    media.seasons = {1: [3, 1, 2], 0: [1]}
+
+    assert TransferChain._season_episode_list(media, 1) == [1, 2, 3]
+    assert TransferChain._season_episode_list(media, 0) == [1]
+
+
 def test_multi_season_context_ignores_non_dict_seasons():
     """
     Unexpected season payloads should disable absolute remapping instead of
@@ -189,6 +201,56 @@ def test_multi_season_context_ignores_non_dict_seasons():
     media.seasons = [{"season_number": 1, "episode_count": 3}]
 
     assert TransferChain._season_episode_list(media, 1) == []
+
+
+def test_multi_season_context_normalizes_total_fields():
+    """
+    Applying source context should normalize stale total fields even when the
+    parsed season and episode numbers are already correct.
+    """
+    season_marker = "\u7b2c2\u5b63"
+    episode_marker = "\u7b2c03\u8bdd"
+    source = (
+        "/downloads/[ReleaseGroup] Placeholder Series Theta "
+        f"{season_marker} {episode_marker} [1080p].mkv"
+    )
+    meta = MetaInfoPath(Path(source))
+    meta.begin_season = 2
+    meta.end_season = None
+    meta.total_season = 4
+    meta.begin_episode = 3
+    meta.end_episode = None
+    meta.total_episode = 4
+    context = _MultiSeasonTransferContext(source_seasons=(1, 2))
+
+    changed = TransferChain._apply_multi_season_context(meta, Path(source), context)
+
+    assert changed is True
+    assert meta.begin_season == 2
+    assert meta.end_season is None
+    assert meta.total_season == 1
+    assert meta.begin_episode == 3
+    assert meta.end_episode is None
+    assert meta.total_episode == 1
+
+
+def test_multi_season_context_keeps_zero_season_marker():
+    """
+    S00 is a valid explicit season marker for specials and should not be treated
+    as missing context.
+    """
+    episode_marker = "\u7b2c01\u8bdd"
+    source = (
+        "/downloads/[ReleaseGroup] Placeholder Series Iota "
+        f"S00 {episode_marker} [1080p].mkv"
+    )
+    meta = MetaInfoPath(Path(source))
+    context = _MultiSeasonTransferContext(source_seasons=(1, 2))
+
+    TransferChain._apply_multi_season_context(meta, Path(source), context)
+
+    assert meta.begin_season == 0
+    assert meta.begin_episode == 1
 
 
 def test_multi_season_context_keeps_explicit_season_local_episode():

--- a/tests/test_transfer_multi_season_context.py
+++ b/tests/test_transfer_multi_season_context.py
@@ -167,6 +167,10 @@ def test_multi_season_context_does_not_expand_enumerated_seasons():
     assert TransferChain._parse_multi_season_numbers("Placeholder S01~02") == (1, 2)
     assert TransferChain._parse_multi_season_numbers("Season 1 - 12 Episodes") == ()
     assert TransferChain._parse_multi_season_numbers("Placeholder S01-12 EP") == ()
+    assert TransferChain._parse_multi_season_numbers("Placeholder S01-12.EP") == ()
+    assert TransferChain._parse_multi_season_numbers(
+        "Placeholder Season 1-12[Episodes]"
+    ) == ()
     assert TransferChain._parse_multi_season_numbers(
         "Placeholder \u7b2c1\u5b63-\u7b2c3\u5b63"
     ) == (1, 2, 3)
@@ -369,6 +373,30 @@ def test_multi_season_context_keeps_zero_season_marker():
 
     assert meta.begin_season == 0
     assert meta.begin_episode == 1
+
+
+def test_multi_season_context_preserves_zero_season_without_episode_catalog():
+    """
+    S00 can be carried by metadata even when the episode catalog lacks specials;
+    it must not be remapped through normal seasons.
+    """
+    source = "/downloads/[ReleaseGroup] Placeholder Series Omicron [02][1080p].mkv"
+    meta = MetaInfoPath(Path(source))
+    meta.begin_season = 0
+    meta.end_season = None
+    meta.total_season = 1
+    meta.begin_episode = 2
+    meta.end_episode = None
+    meta.total_episode = 1
+
+    changed = TransferChain._remap_absolute_episode(
+        meta, (0, 1), _mediainfo(12), Path(source)
+    )
+
+    assert changed is False
+    assert meta.begin_season == 0
+    assert meta.begin_episode == 2
+    assert meta.season_episode == "S00 E02"
 
 
 def test_multi_season_context_keeps_explicit_season_local_episode():


### PR DESCRIPTION
## 变更
- 增强整理流程对单个种子内多季资源的识别，支持从下载历史、种子名和源路径解析多季范围。
- 多季目录缺少明确季标记时，可按顶层目录顺序继承季号；文件名已有明确季号时优先保留文件自身季集。
- 媒体季集数可用时，将整包累计集数映射为对应季内集数，并补充边界保护，避免单季全集、S00 特别篇、倒序集数范围等场景误映射。
- 增加脱敏模拟测试覆盖多季目录、枚举/范围写法、中文季集、路径规范化、S00 和显式季号等场景。

## 边界
本次仅增强整理识别逻辑和测试，不包含用户私有媒体库路径、下载器路径、站点配置、Cookie、token 或真实媒体资源名称。

## 验证
- `pytest tests/test_transfer_multi_season_context.py tests/test_transfer_download_history_lookup.py tests/test_transfer_sync_extra_files.py tests/test_transfer_job_manager.py tests/test_transfer_history_retransfer.py tests/test_transfer_movie_collection.py`（80 passed）
- `git diff --check`
- 敏感信息扫描无命中

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 98a9f7628e58b90ca6d5f4eac610bdd16418dd22

- 增强多季包季集识别
- 支持目录继承和路径规范化
- 映射全局集数到季内
- 覆盖显式季号与边界风险

<!-- pr-agent-summary:end -->