### PR TITLE
fix: 模拟登录时页面跳转导致 page.content() 竞态失败（未知错误）

### DIFF
--- a/app/helper/cookie.py
+++ b/app/helper/cookie.py
@@ -74,7 +74,8 @@ class CookieHelper:
                 return page.content()
             except Exception as e:
                 if i >= retries - 1:
-                    raise
+                    logger.error(f"获取页面源码失败：{str(e)}")
+                    return None
                 logger.warning(f"获取页面源码失败：{str(e)}，{interval}秒后重试 ({i + 1}/{retries - 1})")
                 time.sleep(interval)
         return None
@@ -211,7 +212,10 @@ class CookieHelper:
                 if "verify" in page.url:
                     if not otp_code:
                         return None, None, "需要二次验证码"
-                    html = etree.HTML(self.get_page_content(page))
+                    html_text = self.get_page_content(page)
+                    if not html_text:
+                        return None, None, "获取网页源码失败"
+                    html = etree.HTML(html_text)
                     for xpath in self._SITE_LOGIN_XPATH.get("twostep"):
                         if html.xpath(xpath):
                             try:

--- a/app/helper/cookie.py
+++ b/app/helper/cookie.py
@@ -1,4 +1,5 @@
 import base64
+import time
 from typing import Tuple, Optional
 
 from lxml import etree
@@ -58,6 +59,27 @@ class CookieHelper:
     }
 
     @staticmethod
+    def get_page_content(page: BrowserPage, retries: int = 3, interval: float = 1.0) -> Optional[str]:
+        """
+        获取页面源码，页面跳转中（如登录前后的重定向）会导致 page.content() 抛出
+        "Unable to retrieve content because the page is navigating" 异常，等待加载完成后重试
+        :param page: 浏览器页面
+        :param retries: 最大重试次数
+        :param interval: 重试间隔（秒）
+        :return: 页面源码
+        """
+        for i in range(retries):
+            try:
+                page.wait_for_load_state("domcontentloaded", timeout=10 * 1000)
+                return page.content()
+            except Exception as e:
+                if i >= retries - 1:
+                    raise
+                logger.warning(f"获取页面源码失败：{str(e)}，{interval}秒后重试 ({i + 1}/{retries - 1})")
+                time.sleep(interval)
+        return None
+
+    @staticmethod
     def parse_cookies(cookies: list) -> str:
         """
         将浏览器返回的cookies转化为字符串
@@ -93,7 +115,7 @@ class CookieHelper:
             :return: Cookie和UA
             """
             # 登录页面代码
-            html_text = page.content()
+            html_text = self.get_page_content(page)
             if not html_text:
                 return None, None, "获取源码失败"
             # 查找用户名输入框
@@ -189,7 +211,7 @@ class CookieHelper:
                 if "verify" in page.url:
                     if not otp_code:
                         return None, None, "需要二次验证码"
-                    html = etree.HTML(page.content())
+                    html = etree.HTML(self.get_page_content(page))
                     for xpath in self._SITE_LOGIN_XPATH.get("twostep"):
                         if html.xpath(xpath):
                             try:
@@ -205,7 +227,7 @@ class CookieHelper:
                             break
 
                 # 登录后的源码
-                html_text = page.content()
+                html_text = self.get_page_content(page)
                 if not html_text:
                     return None, None, "获取网页源码失败"
                 if SiteUtils.is_logged_in(html_text):

--- a/app/helper/cookie.py
+++ b/app/helper/cookie.py
@@ -69,8 +69,16 @@ class CookieHelper:
         :return: 页面源码
         """
         for i in range(retries):
+            # 等待加载失败不代表源码不可读取，最后一次等待失败时仍尝试直接获取源码
             try:
                 page.wait_for_load_state("domcontentloaded", timeout=10 * 1000)
+            except Exception as e:
+                if i < retries - 1:
+                    logger.warning(f"等待页面加载完成失败：{str(e)}，{interval}秒后重试 ({i + 1}/{retries - 1})")
+                    time.sleep(interval)
+                    continue
+                logger.warning(f"等待页面加载完成失败：{str(e)}，尝试直接获取源码")
+            try:
                 return page.content()
             except Exception as e:
                 if i >= retries - 1:
@@ -121,6 +129,8 @@ class CookieHelper:
                 return None, None, "获取源码失败"
             # 查找用户名输入框
             html = etree.HTML(html_text)
+            if html is None:
+                return None, None, "解析网页源码失败"
             try:
                 username_xpath = None
                 for xpath in self._SITE_LOGIN_XPATH.get("username"):
@@ -216,6 +226,8 @@ class CookieHelper:
                     if not html_text:
                         return None, None, "获取网页源码失败"
                     html = etree.HTML(html_text)
+                    if html is None:
+                        return None, None, "解析网页源码失败"
                     for xpath in self._SITE_LOGIN_XPATH.get("twostep"):
                         if html.xpath(xpath):
                             try:
@@ -238,7 +250,10 @@ class CookieHelper:
                     return self.parse_cookies(page.context.cookies()), \
                         page.evaluate("() => window.navigator.userAgent"), ""
                 else:
-                    # 读取错误信息
+                    # 从登录后的页面读取错误信息
+                    html = etree.HTML(html_text)
+                    if html is None:
+                        return None, None, "登录失败"
                     error_xpath = None
                     for xpath in self._SITE_LOGIN_XPATH.get("error"):
                         if html.xpath(xpath):


### PR DESCRIPTION
## 问题

使用「更新站点 Cookie & UA」（用户名密码模拟登录）时，部分站点始终失败并提示**未知错误**，日志中可见：

```
【ERROR】site.py - 站点【北洋园】Cookie&UA更新失败：未知错误
【ERROR】browser.py - 网页操作失败: Page.content: Unable to retrieve content because the page is navigating and changing the content.
```

## 原因

Playwright 规定页面处于导航状态时调用 `page.content()` 会直接抛异常。NexusPHP 类站点在登录流程前后存在多次跳转（首页 302 → login.php；登录成功后 → index.php），`CookieHelper.__page_handler` 中的三处 `page.content()` 调用与跳转产生竞态后异常上抛，被 `PlaywrightHelper.action` 捕获返回 None，前端只能显示「未知错误」。实测北洋园（tjupt.org，登录页为无验证码普通表单）在 v2.14.x 上稳定复现——站点本身可正常 curl 登录，排除网络与凭据问题。

## 修复

新增 `CookieHelper.get_page_content`：取源码前先 `wait_for_load_state("domcontentloaded")`，遇导航竞态异常时最多重试 3 次（间隔 1s），三处调用点统一替换。对原本正常的站点无行为变化。

## 测试情况

- 修复前：北洋园模拟登录 100% 复现「未知错误」（多日多次尝试，含最新版自更新后）。
- 补丁通过语法检查；重试逻辑仅在原本必然失败的异常路径上生效，对正常流程零影响。尚未在完整 MP 环境对北洋园实测补丁，欢迎维护者评估。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 35f4ec13e20a4ce19fb61ba1c4c6e0848edefebc

- 修复模拟登录跳转竞态
- 新增源码等待重试读取
- 补齐空源码解析校验
- 无配置变更；未新增测试

<!-- pr-agent-summary:end -->