### PR TITLE
fix: verify real plugin module for targeted MessageAction dispatch

### DIFF
--- a/app/core/event.py
+++ b/app/core/event.py
@@ -83,6 +83,8 @@ class EventManager(metaclass=Singleton):
         self.__broadcast_subscribers: Dict[EventType, Dict[str, Callable]] = {}
         # 链式事件的订阅者
         self.__chain_subscribers: Dict[ChainEventType, Dict[str, tuple[int, Callable]]] = {}
+        # 插件管理器确认后的事件处理器归属，key 为 (handler_identifier, handler_object_id)，value 为 plugin_id
+        self.__handler_plugin_ids: Dict[Tuple[str, int], str] = {}
         # 禁用的事件处理器集合
         self.__disabled_handlers = set()
         # 禁用的事件处理器类集合
@@ -210,6 +212,8 @@ class EventManager(metaclass=Singleton):
                 else:
                     logger.debug(f"Subscribed to broadcast event: {event_type.value} - {handler_identifier}")
                 handlers[handler_identifier] = handler
+            self.__prune_stale_handler_plugin_bindings(handler_identifier)
+        self.__bind_loaded_plugin_event_handler(handler_identifier, handler)
 
     def remove_event_listener(self, event_type: Union[EventType, ChainEventType], handler: Callable):
         """
@@ -226,6 +230,191 @@ class EventManager(metaclass=Singleton):
             elif event_type in self.__broadcast_subscribers:
                 self.__broadcast_subscribers[event_type].pop(handler_identifier, None)
                 logger.debug(f"Unsubscribed from broadcast event: {event_type.value} - {handler_identifier}")
+            self.__prune_stale_handler_plugin_bindings(handler_identifier)
+
+    def bind_plugin_event_handlers(self, plugin_id: str, plugin_cls: type):
+        """
+        将已注册的事件处理器绑定到插件管理器确认的真实插件ID。
+        :param plugin_id: 插件ID
+        :param plugin_cls: 插件类
+        """
+        if not plugin_id or not isinstance(plugin_cls, type):
+            return
+        if plugin_cls.__name__ != plugin_id:
+            return
+        try:
+            from app.core.plugin import PluginManager
+        except ImportError:
+            return
+        if PluginManager().plugins.get(plugin_id) is not plugin_cls:
+            return
+        with self.__lock:
+            self.__handler_plugin_ids = {
+                handler_key: bound_plugin_id
+                for handler_key, bound_plugin_id in self.__handler_plugin_ids.items()
+                if bound_plugin_id != plugin_id
+            }
+            plugin_handler_ids = self.__get_plugin_handler_object_ids(plugin_cls)
+            if not plugin_handler_ids:
+                return
+            for subscribers in self.__broadcast_subscribers.values():
+                self.__bind_subscriber_handlers(plugin_id, plugin_handler_ids, subscribers)
+            for subscribers in self.__chain_subscribers.values():
+                self.__bind_subscriber_handlers(plugin_id, plugin_handler_ids, subscribers)
+
+    def unbind_plugin_event_handlers(self, plugin_id: Optional[str] = None):
+        """
+        清理插件事件处理器归属绑定。
+        :param plugin_id: 插件ID；为空时清理全部插件绑定
+        """
+        with self.__lock:
+            if plugin_id is None:
+                self.__handler_plugin_ids.clear()
+                return
+            self.__handler_plugin_ids = {
+                handler_key: bound_plugin_id
+                for handler_key, bound_plugin_id in self.__handler_plugin_ids.items()
+                if bound_plugin_id != plugin_id
+            }
+
+    @classmethod
+    def __get_plugin_handler_object_ids(cls, plugin_cls: type) -> Dict[str, set]:
+        """
+        获取插件类及其基类上按方法名分组的可调用处理器对象ID。
+        """
+        handler_ids = {}
+        for candidate_cls in inspect.getmro(plugin_cls):
+            if candidate_cls is object:
+                continue
+            for name, value in candidate_cls.__dict__.items():
+                try:
+                    handler = cls.__normalize_handler_callable(value)
+                except Exception as err:
+                    logger.debug(
+                        "Plugin handler scan skipped because handler normalization failed: "
+                        f"plugin={plugin_cls.__name__}, handler={name}, error={err}"
+                    )
+                    continue
+                if callable(handler):
+                    handler_ids.setdefault(name, set()).add(id(handler))
+        return handler_ids
+
+    def __bind_subscriber_handlers(self, plugin_id: str, plugin_handler_ids: Dict[str, set],
+                                   subscribers: Dict[str, Any]):
+        """
+        将订阅表中属于插件类的处理器标记为该插件。
+        """
+        for handler_identifier, handler_data in subscribers.items():
+            handler = handler_data[1] if isinstance(handler_data, tuple) else handler_data
+            try:
+                class_name, method_name = self.__parse_handler_names(handler)
+                handler_object_id = id(self.__normalize_handler_callable(handler))
+            except Exception as err:
+                logger.debug(
+                    "Plugin handler binding skipped because handler lookup failed: "
+                    f"plugin={plugin_id}, handler={handler_identifier}, error={err}"
+                )
+                continue
+            identifier_parts = (handler_identifier or "").split(".")
+            if (
+                    class_name != plugin_id
+                    or len(identifier_parts) < 2
+                    or identifier_parts[-2:] != [class_name, method_name]
+            ):
+                continue
+            if handler_object_id in plugin_handler_ids.get(method_name, set()):
+                self.__handler_plugin_ids[(handler_identifier, handler_object_id)] = plugin_id
+
+    def __bind_loaded_plugin_event_handler(self, handler_identifier: str, handler: Callable):
+        """
+        对运行期新增或重注册的处理器，尝试绑定到已加载插件。
+        """
+        try:
+            handler_object_id = id(self.__normalize_handler_callable(handler))
+            class_name, method_name = self.__parse_handler_names(handler)
+            if not class_name or not method_name:
+                return
+            from app.core.plugin import PluginManager
+            plugin_cls = PluginManager().plugins.get(class_name)
+            handler_belongs_to_plugin = (
+                    plugin_cls
+                    and plugin_cls.__name__ == class_name
+                    and handler_object_id in self.__get_plugin_handler_object_ids(plugin_cls).get(method_name, set())
+            )
+        except Exception as err:
+            logger.debug(
+                "Plugin handler binding skipped because ownership check failed: "
+                f"handler={handler_identifier}, error={err}"
+            )
+            return
+        handler_key = (handler_identifier, handler_object_id)
+        with self.__lock:
+            if not self.__is_handler_object_registered(handler_identifier, handler_object_id):
+                self.__handler_plugin_ids.pop(handler_key, None)
+                return
+            if handler_belongs_to_plugin:
+                self.__handler_plugin_ids[handler_key] = class_name
+            else:
+                self.__handler_plugin_ids.pop(handler_key, None)
+
+    def __prune_stale_handler_plugin_bindings(self, handler_identifier: str):
+        """
+        清理同一处理器标识下已不在当前订阅表中的对象归属绑定。
+        """
+        self.__handler_plugin_ids = {
+            handler_key: bound_plugin_id
+            for handler_key, bound_plugin_id in self.__handler_plugin_ids.items()
+            if handler_key[0] != handler_identifier
+            or self.__is_handler_object_registered(handler_key[0], handler_key[1])
+        }
+
+    def __is_handler_registered(self, handler_identifier: str) -> bool:
+        """
+        检查处理器标识是否仍存在于任一订阅表。
+        """
+        return (
+                any(handler_identifier in subscribers for subscribers in self.__broadcast_subscribers.values())
+                or any(handler_identifier in subscribers for subscribers in self.__chain_subscribers.values())
+        )
+
+    def __is_handler_object_registered(self, handler_identifier: str, handler_object_id: int) -> bool:
+        """
+        检查指定标识当前是否仍有同一处理器对象订阅。
+        """
+        for subscribers in self.__broadcast_subscribers.values():
+            handler = subscribers.get(handler_identifier)
+            if handler is None:
+                continue
+            try:
+                if id(self.__normalize_handler_callable(handler)) == handler_object_id:
+                    return True
+            except Exception as err:
+                logger.debug(
+                    "Handler binding lookup skipped because handler normalization failed: "
+                    f"handler={handler_identifier}, error={err}"
+                )
+        for subscribers in self.__chain_subscribers.values():
+            handler_data = subscribers.get(handler_identifier)
+            if handler_data is None:
+                continue
+            try:
+                if id(self.__normalize_handler_callable(handler_data[1])) == handler_object_id:
+                    return True
+            except Exception as err:
+                logger.debug(
+                    "Handler binding lookup skipped because handler normalization failed: "
+                    f"handler={handler_identifier}, error={err}"
+                )
+        return False
+
+    @staticmethod
+    def __normalize_handler_callable(handler: Any) -> Any:
+        """
+        归一化函数、绑定方法、staticmethod/classmethod 包装。
+        """
+        if isinstance(handler, (staticmethod, classmethod)):
+            return handler.__func__
+        return getattr(handler, "__func__", handler)
 
     def disable_event_handler(self, target: Union[Callable, type]):
         """
@@ -467,17 +656,16 @@ class EventManager(metaclass=Singleton):
                 # 对于同步函数，在线程池中运行
                 self.__executor.submit(self.__safe_invoke_handler, handler, isolated_event)
 
-    @classmethod
     def __should_dispatch_to_target_plugin(
-            cls,
+            self,
             handler: Callable,
             handler_identifier: str,
             target_plugin_id: str,
     ) -> bool:
         """
-        限定插件输入事件只投递给目标插件，避免自由文本被其他插件观察到。
+        限定插件输入事件只投递给目标插件的真实处理器。
         """
-        class_name, method_name = cls.__parse_handler_names(handler)
+        class_name, method_name = self.__parse_handler_names(handler)
         if class_name != target_plugin_id:
             return False
         identifier_parts = (handler_identifier or "").split(".")
@@ -493,7 +681,98 @@ class EventManager(metaclass=Singleton):
                 f"target={target_plugin_id}, handler={handler_identifier}, parsed={class_name}.{method_name}"
             )
             return False
+        try:
+            handler_object_id = id(self.__normalize_handler_callable(handler))
+            binding = self.__handler_plugin_ids.get((handler_identifier, handler_object_id))
+        except Exception as err:
+            logger.debug(
+                "Target plugin dispatch skipped because handler binding lookup failed: "
+                f"target={target_plugin_id}, handler={handler_identifier}, error={err}"
+            )
+            return False
+        if binding != target_plugin_id:
+            logger.debug(
+                "Target plugin dispatch skipped because handler is not bound to target plugin: "
+                f"target={target_plugin_id}, handler={handler_identifier}, binding={binding}"
+            )
+            return False
+        try:
+            from app.core.plugin import PluginManager
+
+            plugin_manager = PluginManager()
+            plugin_cls = plugin_manager.plugins.get(target_plugin_id)
+            plugin_obj = plugin_manager.running_plugins.get(target_plugin_id)
+        except Exception as err:
+            logger.debug(
+                "Target plugin dispatch skipped because plugin manager is unavailable: "
+                f"target={target_plugin_id}, handler={handler_identifier}, error={err}"
+            )
+            return False
+        if plugin_cls is None or plugin_obj is None or type(plugin_obj) is not plugin_cls:
+            logger.debug(
+                "Target plugin dispatch skipped because target plugin is not running: "
+                f"target={target_plugin_id}, handler={handler_identifier}"
+            )
+            return False
+        try:
+            plugin_enabled = bool(plugin_obj.get_state())
+        except Exception as err:
+            logger.debug(
+                "Target plugin dispatch skipped because target plugin state is unavailable: "
+                f"target={target_plugin_id}, handler={handler_identifier}, error={err}"
+            )
+            return False
+        if not plugin_enabled:
+            logger.debug(
+                "Target plugin dispatch skipped because target plugin is disabled: "
+                f"target={target_plugin_id}, handler={handler_identifier}"
+            )
+            return False
+        expected_class = plugin_cls.__name__
+        if expected_class != target_plugin_id:
+            logger.debug(
+                "Target plugin dispatch skipped because target plugin class name is invalid: "
+                f"target={target_plugin_id}, handler={handler_identifier}, plugin_class={expected_class}"
+            )
+            return False
+        try:
+            handler_owned_by_plugin = (
+                    handler_object_id in self.__get_plugin_handler_object_ids(plugin_cls).get(method_name, set())
+            )
+            handler_bound_to_running_plugin = self.__is_handler_bound_to_running_plugin(
+                handler, plugin_cls, plugin_obj
+            )
+        except Exception as err:
+            logger.debug(
+                "Target plugin dispatch skipped because handler ownership check failed: "
+                f"target={target_plugin_id}, handler={handler_identifier}, error={err}"
+            )
+            return False
+        if not handler_owned_by_plugin:
+            logger.debug(
+                "Target plugin dispatch skipped because handler is not owned by current target plugin: "
+                f"target={target_plugin_id}, handler={handler_identifier}"
+            )
+            return False
+        if not handler_bound_to_running_plugin:
+            logger.debug(
+                "Target plugin dispatch skipped because handler is bound to another plugin object: "
+                f"target={target_plugin_id}, handler={handler_identifier}"
+            )
+            return False
         return True
+
+    @staticmethod
+    def __is_handler_bound_to_running_plugin(handler: Callable, plugin_cls: type, plugin_obj: Any) -> bool:
+        """
+        确认绑定方法属于当前运行中的插件实例或插件类。
+        """
+        bound_owner = getattr(handler, "__self__", None)
+        if bound_owner is None:
+            return True
+        if isinstance(bound_owner, type):
+            return bound_owner is plugin_cls
+        return bound_owner is plugin_obj
 
     def __safe_invoke_handler(self, handler: Callable, event: Event):
         """

--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -98,6 +98,7 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                     # 如果是插件热更新实例，这里则进行替换
                     if plugin_id in self._plugins:
                         self._plugins[plugin_id] = plugin
+                    eventmanager.unbind_plugin_event_handlers(plugin_id)
                     continue
                 # 存储Class
                 self._plugins[plugin_id] = plugin
@@ -110,10 +111,13 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                 logger.info(f"加载插件：{plugin_id} 版本：{plugin_obj.plugin_version}")
                 # 启用的插件才设置事件注册状态可用
                 if plugin_obj.get_state():
+                    eventmanager.bind_plugin_event_handlers(plugin_id, plugin)
                     eventmanager.enable_event_handler(plugin)
                 else:
                     eventmanager.disable_event_handler(plugin)
+                    eventmanager.unbind_plugin_event_handlers(plugin_id)
             except Exception as err:
+                eventmanager.unbind_plugin_event_handlers(plugin_id)
                 logger.error(f"加载插件 {plugin_id} 出错：{str(err)} - {traceback.format_exc()}")
         self.clear_plugin_agent_tools_cache()
 
@@ -126,15 +130,21 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         plugin = self._running_plugins.get(plugin_id)
         if not plugin:
             return
-        # 初始化插件
-        plugin.init_plugin(conf)
-        # 检查插件状态并启用/禁用事件处理器
-        if plugin.get_state():
-            # 启用插件类的事件处理器
-            eventmanager.enable_event_handler(type(plugin))
-        else:
-            # 禁用插件类的事件处理器
-            eventmanager.disable_event_handler(type(plugin))
+        try:
+            # 初始化插件
+            plugin.init_plugin(conf)
+            # 检查插件状态并启用/禁用事件处理器
+            if plugin.get_state():
+                # 启用插件类的事件处理器
+                eventmanager.bind_plugin_event_handlers(plugin_id, type(plugin))
+                eventmanager.enable_event_handler(type(plugin))
+            else:
+                # 禁用插件类的事件处理器
+                eventmanager.disable_event_handler(type(plugin))
+                eventmanager.unbind_plugin_event_handlers(plugin_id)
+        except Exception:
+            eventmanager.unbind_plugin_event_handlers(plugin_id)
+            raise
         self.clear_plugin_agent_tools_cache()
 
     def clear_plugin_agent_tools_cache(self) -> None:
@@ -162,10 +172,17 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
                 plugins = {pid: plugin_obj}
         else:
             logger.info("正在停止所有插件...")
-            plugins = self._running_plugins
+            plugins = dict(self._running_plugins)
         for plugin_id, plugin in plugins.items():
-            eventmanager.disable_event_handler(type(plugin))
-            self.__stop_plugin(plugin)
+            try:
+                eventmanager.disable_event_handler(type(plugin))
+                self.__stop_plugin(plugin)
+            finally:
+                eventmanager.unbind_plugin_event_handlers(plugin_id)
+        if pid and not plugins:
+            eventmanager.unbind_plugin_event_handlers(pid)
+        elif not pid:
+            eventmanager.unbind_plugin_event_handlers()
         # 清空对象
         if pid:
             # 清空指定插件

--- a/tests/test_media_interaction.py
+++ b/tests/test_media_interaction.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
@@ -9,7 +10,7 @@ from app.core.context import Context, MediaInfo, TorrentInfo
 from app.core.meta import MetaBase
 from app.helper.interaction import media_interaction_manager, plugin_input_interaction_manager
 from app.schemas import CommingMessage, TransferDirectoryConf
-from app.schemas.types import EventType, MediaType, MessageChannel
+from app.schemas.types import ChainEventType, EventType, MediaType, MessageChannel
 
 
 @pytest.fixture(autouse=True)
@@ -1469,8 +1470,24 @@ def test_plugin_input_session_pop_by_user_removes_expired_prompt_session():
     ) is None
 
 
+def _mock_running_plugin(plugin_manager, plugin_id: str, plugin_cls: type):
+    plugin_obj = plugin_cls()
+    if not callable(getattr(plugin_obj, "get_state", None)):
+        plugin_obj.get_state = lambda: True
+    plugin_manager.return_value.plugins = {plugin_id: plugin_cls}
+    plugin_manager.return_value.running_plugins = {plugin_id: plugin_obj}
+
+
+def _handler_binding_key(handler_identifier: str, handler):
+    return (
+        handler_identifier,
+        id(EventManager._EventManager__normalize_handler_callable(handler)),
+    )
+
+
 def test_target_plugin_filter_only_allows_target_plugin_handler():
     """带目标插件的输入事件不应投递给其他插件或模块级处理器。"""
+    manager = EventManager()
 
     def demo_plugin_handler(_event):
         return None
@@ -1484,20 +1501,1430 @@ def test_target_plugin_filter_only_allows_target_plugin_handler():
     def module_handler(_event):
         return None
 
-    should_dispatch = EventManager._EventManager__should_dispatch_to_target_plugin
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
     handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    handler_module = ".".join(handler_id.split(".")[:-2])
+    plugin_class = type("demo_plugin", (), {"handle": demo_plugin_handler, "__module__": handler_module})
 
-    assert should_dispatch(
-        demo_plugin_handler, "tests.plugins.demo_plugin.handle", "demo_plugin"
-    ) is True
-    assert should_dispatch(demo_plugin_handler, handler_id, "demo_plugin") is True
-    assert should_dispatch(
-        demo_plugin_handler, "tests.plugins.other_plugin.handle", "demo_plugin"
-    ) is False
-    assert should_dispatch(
-        other_plugin_handler, "tests.plugins.other_plugin.handle", "demo_plugin"
-    ) is False
-    assert should_dispatch(module_handler, "tests.module_handler", "demo_plugin") is False
+    manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    try:
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            _mock_running_plugin(plugin_manager, "demo_plugin", plugin_class)
+            manager.bind_plugin_event_handlers("demo_plugin", plugin_class)
+
+            assert should_dispatch(demo_plugin_handler, handler_id, "demo_plugin") is True
+            assert should_dispatch(
+                demo_plugin_handler, f"{handler_module}.other_plugin.handle", "demo_plugin"
+            ) is False
+            assert should_dispatch(
+                other_plugin_handler, f"{handler_module}.other_plugin.handle", "demo_plugin"
+            ) is False
+            assert should_dispatch(module_handler, "tests.module_handler", "demo_plugin") is False
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+
+
+def test_target_plugin_filter_rejects_same_named_handler_from_other_module():
+    """其他模块中的同名插件类处理器不应通过定向过滤。"""
+    manager = EventManager()
+
+    def spoofed_handler(_event):
+        return None
+
+    spoofed_handler.__qualname__ = "demo_plugin.handle"
+    spoofed_handler.__module__ = "app.plugins.other_plugin"
+    target_plugin_class = type("demo_plugin", (), {"__module__": "app.plugins.demo_plugin"})
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    with patch("app.core.plugin.PluginManager") as plugin_manager:
+        plugin_manager.return_value.plugins = {"demo_plugin": target_plugin_class}
+
+        assert should_dispatch(
+            spoofed_handler, "app.plugins.other_plugin.demo_plugin.handle", "demo_plugin"
+        ) is False
+
+
+def test_target_plugin_filter_rejects_handler_object_from_other_module():
+    """注册标识匹配但处理器对象来自其他模块时仍应拒绝投递。"""
+    manager = EventManager()
+
+    def spoofed_handler(_event):
+        return None
+
+    spoofed_handler.__qualname__ = "demo_plugin.handle"
+    spoofed_handler.__module__ = "app.plugins.other_plugin"
+    target_plugin_class = type("demo_plugin", (), {"__module__": "app.plugins.demo_plugin"})
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    with patch("app.core.plugin.PluginManager") as plugin_manager:
+        plugin_manager.return_value.plugins = {"demo_plugin": target_plugin_class}
+
+        assert should_dispatch(
+            spoofed_handler, "app.plugins.demo_plugin.demo_plugin.handle", "demo_plugin"
+        ) is False
+
+
+def test_target_plugin_filter_rejects_when_target_plugin_is_not_loaded():
+    """插件管理器没有目标插件记录时应 fail-closed。"""
+    manager = EventManager()
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    demo_plugin_handler.__module__ = "app.plugins.demo_plugin"
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    with patch("app.core.plugin.PluginManager") as plugin_manager:
+        plugin_manager.return_value.plugins = {}
+
+        assert should_dispatch(
+            demo_plugin_handler, "app.plugins.demo_plugin.demo_plugin.handle", "demo_plugin"
+        ) is False
+
+
+def test_target_plugin_filter_allows_clone_plugin_handler():
+    """分身插件类名和模块均匹配时应通过定向过滤。"""
+    manager = EventManager()
+
+    def clone_plugin_handler(_event):
+        return None
+
+    clone_plugin_handler.__qualname__ = "demo_pluginclone.handle"
+    handler_id = EventManager._EventManager__get_handler_identifier(clone_plugin_handler)
+    handler_module = ".".join(handler_id.split(".")[:-2])
+    clone_plugin_class = type(
+        "demo_pluginclone", (), {"handle": clone_plugin_handler, "__module__": handler_module}
+    )
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    manager.add_event_listener(EventType.MessageAction, clone_plugin_handler)
+    try:
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            _mock_running_plugin(plugin_manager, "demo_pluginclone", clone_plugin_class)
+            manager.bind_plugin_event_handlers("demo_pluginclone", clone_plugin_class)
+
+            assert should_dispatch(
+                clone_plugin_handler,
+                handler_id,
+                "demo_pluginclone",
+            ) is True
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, clone_plugin_handler)
+        manager.unbind_plugin_event_handlers("demo_pluginclone")
+
+
+def test_target_plugin_filter_allows_reimported_plugin_class():
+    """热重载后的新类对象只要模块名一致仍应通过定向过滤。"""
+    manager = EventManager()
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    handler_module = ".".join(handler_id.split(".")[:-2])
+    original_plugin_class = type(
+        "demo_plugin", (), {"handle": demo_plugin_handler, "__module__": handler_module}
+    )
+    reimported_plugin_class = type(
+        "demo_plugin", (), {"handle": demo_plugin_handler, "__module__": handler_module}
+    )
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    assert original_plugin_class is not reimported_plugin_class
+    manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    try:
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            _mock_running_plugin(plugin_manager, "demo_plugin", reimported_plugin_class)
+            manager.bind_plugin_event_handlers("demo_plugin", reimported_plugin_class)
+
+            assert should_dispatch(
+                demo_plugin_handler, handler_id, "demo_plugin"
+            ) is True
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+
+
+def test_target_plugin_filter_uses_bound_plugin_metadata_when_handler_module_changes():
+    """处理器模块属性被改写时，应以加载器绑定的插件归属为准。"""
+
+    manager = EventManager()
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    demo_plugin = type("demo_plugin", (), {"handle": demo_plugin_handler})
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    original_module = demo_plugin_handler.__module__
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    try:
+        demo_plugin_handler.__module__ = "app.plugins.other_plugin"
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            _mock_running_plugin(plugin_manager, "demo_plugin", demo_plugin)
+            manager.bind_plugin_event_handlers("demo_plugin", demo_plugin)
+
+            assert should_dispatch(demo_plugin_handler, handler_id, "demo_plugin") is True
+    finally:
+        demo_plugin_handler.__module__ = original_module
+        manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+
+
+def test_target_plugin_filter_rejects_spoofed_handler_bound_to_other_plugin():
+    """类名和模块看似匹配目标时，仍应拒绝归属到其他插件的处理器。"""
+
+    manager = EventManager()
+
+    def spoofed_handler(_event):
+        return None
+
+    spoofed_handler.__qualname__ = "demo_plugin.handle"
+    other_plugin = type("other_plugin", (), {"handle": spoofed_handler})
+    handler_id = EventManager._EventManager__get_handler_identifier(spoofed_handler)
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+    target_plugin_class = type(
+        "demo_plugin", (), {"__module__": spoofed_handler.__module__}
+    )
+
+    manager.add_event_listener(EventType.MessageAction, spoofed_handler)
+    try:
+        manager.bind_plugin_event_handlers("other_plugin", other_plugin)
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            plugin_manager.return_value.plugins = {"demo_plugin": target_plugin_class}
+
+            assert should_dispatch(spoofed_handler, handler_id, "demo_plugin") is False
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, spoofed_handler)
+        manager.unbind_plugin_event_handlers("other_plugin")
+
+
+def test_target_plugin_filter_rejects_bind_from_untrusted_plugin_class():
+    """绑定入口不应接受插件管理器未确认的同名插件类。"""
+    manager = EventManager()
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    trusted_plugin = type("demo_plugin", (), {})
+    untrusted_plugin = type("demo_plugin", (), {"handle": demo_plugin_handler})
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    try:
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            plugin_manager.return_value.plugins = {"demo_plugin": trusted_plugin}
+            manager.bind_plugin_event_handlers("demo_plugin", untrusted_plugin)
+
+            assert should_dispatch(demo_plugin_handler, handler_id, "demo_plugin") is False
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+
+
+def test_target_plugin_filter_rejects_handler_on_wrong_plugin_method_name():
+    """处理器对象只挂在目标插件其他属性上时，不应当成目标方法归属。"""
+    manager = EventManager()
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    demo_plugin = type(
+        "demo_plugin",
+        (),
+        {
+            "other_handle": demo_plugin_handler,
+            "get_state": lambda self: True,
+        },
+    )
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    try:
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            _mock_running_plugin(plugin_manager, "demo_plugin", demo_plugin)
+            manager.bind_plugin_event_handlers("demo_plugin", demo_plugin)
+
+            assert should_dispatch(demo_plugin_handler, handler_id, "demo_plugin") is False
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+
+
+def test_target_plugin_filter_rejects_bound_method_from_stale_plugin_instance():
+    """绑定方法来自旧插件实例时，即使函数对象相同也应拒绝定向投递。"""
+    manager = EventManager()
+
+    def demo_plugin_handler(_self, _event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    demo_plugin = type(
+        "demo_plugin",
+        (),
+        {
+            "handle": demo_plugin_handler,
+            "get_state": lambda self: True,
+        },
+    )
+    stale_plugin_obj = demo_plugin()
+    running_plugin_obj = demo_plugin()
+    handler = stale_plugin_obj.handle
+    handler_id = EventManager._EventManager__get_handler_identifier(handler)
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    manager.add_event_listener(EventType.MessageAction, handler)
+    try:
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            plugin_manager.return_value.plugins = {"demo_plugin": demo_plugin}
+            plugin_manager.return_value.running_plugins = {"demo_plugin": running_plugin_obj}
+            manager.bind_plugin_event_handlers("demo_plugin", demo_plugin)
+
+            assert should_dispatch(handler, handler_id, "demo_plugin") is False
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+
+
+def test_target_plugin_filter_allows_bound_method_from_running_plugin_instance():
+    """绑定方法来自当前运行插件实例时，应保留正常定向投递。"""
+    manager = EventManager()
+
+    def demo_plugin_handler(_self, _event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    demo_plugin = type(
+        "demo_plugin",
+        (),
+        {
+            "handle": demo_plugin_handler,
+            "get_state": lambda self: True,
+        },
+    )
+    running_plugin_obj = demo_plugin()
+    handler = running_plugin_obj.handle
+    handler_id = EventManager._EventManager__get_handler_identifier(handler)
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    manager.add_event_listener(EventType.MessageAction, handler)
+    try:
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            plugin_manager.return_value.plugins = {"demo_plugin": demo_plugin}
+            plugin_manager.return_value.running_plugins = {"demo_plugin": running_plugin_obj}
+            manager.bind_plugin_event_handlers("demo_plugin", demo_plugin)
+
+            assert should_dispatch(handler, handler_id, "demo_plugin") is True
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+
+
+def test_plugin_manager_start_binds_target_plugin_event_handlers():
+    """插件管理器加载插件类后，应自动回填目标事件处理器归属。"""
+    import app.core.plugin as plugin_module
+
+    event_manager = plugin_module.eventmanager
+    plugin_manager = plugin_module.PluginManager()
+    original_plugins = dict(plugin_manager.plugins)
+    original_running_plugins = dict(plugin_manager.running_plugins)
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    original_module = demo_plugin_handler.__module__
+
+    class DemoPluginBase:
+        plugin_name = "Demo"
+        plugin_version = "1.0"
+        name = "Demo"
+
+        def init_plugin(self, _config):
+            return None
+
+        def get_state(self):
+            return True
+
+    demo_plugin = type(
+        "demo_plugin",
+        (DemoPluginBase,),
+        {"handle": demo_plugin_handler, "__module__": original_module},
+    )
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    should_dispatch = event_manager._EventManager__should_dispatch_to_target_plugin
+
+    event_manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    try:
+        with patch("app.core.plugin.SystemConfigOper") as system_config_oper, patch.object(
+            plugin_module.PluginManager, "_load_selective_plugins", return_value=[demo_plugin]
+        ), patch.object(
+            plugin_manager, "_PluginManager__set_and_check_auth_level", return_value=True
+        ), patch.object(
+            plugin_manager, "get_plugin_config", return_value={}
+        ):
+            system_config_oper.return_value.get.return_value = ["demo_plugin"]
+            plugin_manager.start("demo_plugin")
+
+        demo_plugin_handler.__module__ = "app.plugins.other_plugin"
+
+        assert should_dispatch(demo_plugin_handler, handler_id, "demo_plugin") is True
+    finally:
+        demo_plugin_handler.__module__ = original_module
+        event_manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        event_manager.unbind_plugin_event_handlers("demo_plugin")
+        plugin_manager._plugins = original_plugins
+        plugin_manager._running_plugins = original_running_plugins
+
+
+def test_plugin_manager_start_unbinds_target_handlers_when_auth_fails():
+    """插件认证失败时，应清理该插件旧的定向处理器绑定。"""
+    import app.core.plugin as plugin_module
+
+    event_manager = plugin_module.eventmanager
+    plugin_manager = plugin_module.PluginManager()
+    original_plugins = dict(plugin_manager.plugins)
+    original_running_plugins = dict(plugin_manager.running_plugins)
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    original_module = demo_plugin_handler.__module__
+
+    class DemoPluginBase:
+        plugin_name = "Demo"
+        plugin_version = "1.0"
+        name = "Demo"
+
+        def get_state(self):
+            return True
+
+    demo_plugin = type(
+        "demo_plugin",
+        (DemoPluginBase,),
+        {"handle": demo_plugin_handler, "__module__": original_module},
+    )
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    should_dispatch = event_manager._EventManager__should_dispatch_to_target_plugin
+
+    plugin_manager._plugins = {"demo_plugin": demo_plugin}
+    plugin_manager._running_plugins = {"demo_plugin": demo_plugin()}
+    event_manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    try:
+        event_manager.bind_plugin_event_handlers("demo_plugin", demo_plugin)
+        assert should_dispatch(demo_plugin_handler, handler_id, "demo_plugin") is True
+
+        with patch("app.core.plugin.SystemConfigOper") as system_config_oper, patch.object(
+            plugin_module.PluginManager, "_load_selective_plugins", return_value=[demo_plugin]
+        ), patch.object(
+            plugin_manager, "_PluginManager__set_and_check_auth_level", return_value=False
+        ):
+            system_config_oper.return_value.get.return_value = ["demo_plugin"]
+            plugin_manager.start("demo_plugin")
+
+        assert should_dispatch(demo_plugin_handler, handler_id, "demo_plugin") is False
+    finally:
+        event_manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        event_manager.unbind_plugin_event_handlers("demo_plugin")
+        plugin_manager._plugins = original_plugins
+        plugin_manager._running_plugins = original_running_plugins
+
+
+def test_add_event_listener_binds_handler_when_plugin_is_already_loaded():
+    """插件加载后动态注册或重注册处理器时，应立即恢复插件归属绑定。"""
+    from app.core.plugin import PluginManager
+
+    manager = EventManager()
+    plugin_manager = PluginManager()
+    original_plugins = dict(plugin_manager.plugins)
+    original_running_plugins = dict(plugin_manager.running_plugins)
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    demo_plugin = type(
+        "demo_plugin",
+        (),
+        {"handle": demo_plugin_handler, "get_state": lambda self: True},
+    )
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    original_module = demo_plugin_handler.__module__
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    plugin_manager._plugins = {"demo_plugin": demo_plugin}
+    plugin_manager._running_plugins = {"demo_plugin": demo_plugin()}
+    manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    try:
+        demo_plugin_handler.__module__ = "app.plugins.other_plugin"
+
+        assert should_dispatch(demo_plugin_handler, handler_id, "demo_plugin") is True
+    finally:
+        demo_plugin_handler.__module__ = original_module
+        manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+        plugin_manager._plugins = original_plugins
+        plugin_manager._running_plugins = original_running_plugins
+
+
+def test_add_event_listener_keeps_registration_when_plugin_manager_lookup_fails():
+    """插件管理器查询异常时，动态监听器注册仍应成功。"""
+    manager = EventManager()
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    handler_key = _handler_binding_key(handler_id, demo_plugin_handler)
+
+    try:
+        with patch("app.core.plugin.PluginManager", side_effect=RuntimeError("plugin manager unavailable")):
+            manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+
+        assert handler_id in manager._EventManager__broadcast_subscribers[EventType.MessageAction]
+        assert handler_key not in manager._EventManager__handler_plugin_ids
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+
+
+def test_add_event_listener_keeps_existing_binding_when_plugin_manager_lookup_fails():
+    """动态重注册无法查询插件管理器时，不应清理已有插件归属绑定。"""
+    manager = EventManager()
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    demo_plugin = type(
+        "demo_plugin",
+        (),
+        {
+            "handle": demo_plugin_handler,
+            "get_state": lambda self: True,
+        },
+    )
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    handler_key = _handler_binding_key(handler_id, demo_plugin_handler)
+
+    manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    try:
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            _mock_running_plugin(plugin_manager, "demo_plugin", demo_plugin)
+            manager.bind_plugin_event_handlers("demo_plugin", demo_plugin)
+        original_binding = manager._EventManager__handler_plugin_ids[handler_key]
+
+        with patch("app.core.plugin.PluginManager", side_effect=RuntimeError("lookup failed")):
+            manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+
+        assert manager._EventManager__handler_plugin_ids[handler_key] == original_binding
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+
+
+def test_add_event_listener_clears_existing_binding_when_handler_no_longer_belongs_to_plugin():
+    """动态重注册确认处理器不再属于插件类时，应清理陈旧归属绑定。"""
+    manager = EventManager()
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    old_plugin = type(
+        "demo_plugin",
+        (),
+        {
+            "handle": demo_plugin_handler,
+            "get_state": lambda self: True,
+        },
+    )
+    new_plugin = type(
+        "demo_plugin",
+        (),
+        {
+            "get_state": lambda self: True,
+        },
+    )
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    handler_key = _handler_binding_key(handler_id, demo_plugin_handler)
+
+    manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    try:
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            _mock_running_plugin(plugin_manager, "demo_plugin", old_plugin)
+            manager.bind_plugin_event_handlers("demo_plugin", old_plugin)
+        assert handler_key in manager._EventManager__handler_plugin_ids
+
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            _mock_running_plugin(plugin_manager, "demo_plugin", new_plugin)
+            manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+
+        assert handler_key not in manager._EventManager__handler_plugin_ids
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+
+
+def test_add_event_listener_binds_loaded_handler_after_releasing_lock():
+    """动态绑定查询应在订阅表写锁释放后执行，避免插件加载重入死锁。"""
+    manager = EventManager()
+
+    def demo_plugin_handler(_event):
+        return None
+
+    lock_states = []
+
+    def record_lock_state(_handler_identifier, _handler):
+        lock_states.append(manager._EventManager__lock.locked())
+
+    try:
+        with patch.object(
+            manager,
+            "_EventManager__bind_loaded_plugin_event_handler",
+            side_effect=record_lock_state,
+        ):
+            manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+
+        assert lock_states == [False]
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+
+
+def test_remove_event_listener_keeps_binding_when_handler_still_registered():
+    """同一处理器仍订阅其他事件时，退订单个事件不应清理插件归属绑定。"""
+    from app.core.plugin import PluginManager
+
+    manager = EventManager()
+    plugin_manager = PluginManager()
+    original_plugins = dict(plugin_manager.plugins)
+    original_running_plugins = dict(plugin_manager.running_plugins)
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    demo_plugin = type(
+        "demo_plugin",
+        (),
+        {"handle": demo_plugin_handler, "get_state": lambda self: True},
+    )
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    plugin_manager._plugins = {"demo_plugin": demo_plugin}
+    plugin_manager._running_plugins = {"demo_plugin": demo_plugin()}
+    manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    manager.add_event_listener(ChainEventType.NameRecognize, demo_plugin_handler)
+    try:
+        manager.bind_plugin_event_handlers("demo_plugin", demo_plugin)
+        manager.remove_event_listener(ChainEventType.NameRecognize, demo_plugin_handler)
+
+        assert should_dispatch(demo_plugin_handler, handler_id, "demo_plugin") is True
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+        plugin_manager._plugins = original_plugins
+        plugin_manager._running_plugins = original_running_plugins
+
+
+def test_remove_event_listener_clears_only_removed_handler_object_binding():
+    """同一标识仍有其他对象订阅时，应只清理已退订对象的归属。"""
+    manager = EventManager()
+
+    def old_handler(_event):
+        return None
+
+    def new_handler(_event):
+        return None
+
+    old_handler.__qualname__ = "demo_plugin.handle"
+    new_handler.__qualname__ = "demo_plugin.handle"
+    handler_id = EventManager._EventManager__get_handler_identifier(old_handler)
+    old_key = _handler_binding_key(handler_id, old_handler)
+    new_key = _handler_binding_key(handler_id, new_handler)
+
+    manager.add_event_listener(EventType.MessageAction, old_handler)
+    manager.add_event_listener(ChainEventType.NameRecognize, new_handler)
+    try:
+        manager._EventManager__handler_plugin_ids[old_key] = "demo_plugin"
+        manager._EventManager__handler_plugin_ids[new_key] = "demo_plugin"
+
+        manager.remove_event_listener(EventType.MessageAction, old_handler)
+
+        assert old_key not in manager._EventManager__handler_plugin_ids
+        assert manager._EventManager__handler_plugin_ids[new_key] == "demo_plugin"
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, old_handler)
+        manager.remove_event_listener(ChainEventType.NameRecognize, new_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+
+
+def test_bind_plugin_event_handlers_does_not_steal_shared_handler_from_parsed_plugin():
+    """其他插件复用同一函数对象时，不应覆盖处理器解析出的插件归属。"""
+    manager = EventManager()
+
+    def shared_handler(_event):
+        return None
+
+    shared_handler.__qualname__ = "demo_plugin.handle"
+    demo_plugin = type(
+        "demo_plugin",
+        (),
+        {"handle": shared_handler, "get_state": lambda self: True},
+    )
+    other_plugin = type(
+        "other_plugin",
+        (),
+        {"handle": shared_handler, "get_state": lambda self: True},
+    )
+    handler_id = EventManager._EventManager__get_handler_identifier(shared_handler)
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    manager.add_event_listener(EventType.MessageAction, shared_handler)
+    try:
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            plugin_manager.return_value.plugins = {
+                "demo_plugin": demo_plugin,
+                "other_plugin": other_plugin,
+            }
+            plugin_manager.return_value.running_plugins = {
+                "demo_plugin": demo_plugin(),
+                "other_plugin": other_plugin(),
+            }
+            manager.bind_plugin_event_handlers("demo_plugin", demo_plugin)
+            manager.bind_plugin_event_handlers("other_plugin", other_plugin)
+
+            assert should_dispatch(shared_handler, handler_id, "demo_plugin") is True
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, shared_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+        manager.unbind_plugin_event_handlers("other_plugin")
+
+
+def test_add_event_listener_binds_loaded_handler_by_parsed_plugin_id():
+    """动态注册共享处理器时，应按处理器类名绑定目标插件而非首个匹配类。"""
+    from app.core.plugin import PluginManager
+
+    manager = EventManager()
+    plugin_manager = PluginManager()
+    original_plugins = dict(plugin_manager.plugins)
+    original_running_plugins = dict(plugin_manager.running_plugins)
+
+    def shared_handler(_event):
+        return None
+
+    shared_handler.__qualname__ = "demo_plugin.handle"
+    other_plugin = type(
+        "other_plugin",
+        (),
+        {"handle": shared_handler, "get_state": lambda self: True},
+    )
+    demo_plugin = type(
+        "demo_plugin",
+        (),
+        {"handle": shared_handler, "get_state": lambda self: True},
+    )
+    handler_id = EventManager._EventManager__get_handler_identifier(shared_handler)
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    plugin_manager._plugins = {
+        "other_plugin": other_plugin,
+        "demo_plugin": demo_plugin,
+    }
+    plugin_manager._running_plugins = {
+        "other_plugin": other_plugin(),
+        "demo_plugin": demo_plugin(),
+    }
+    manager.add_event_listener(EventType.MessageAction, shared_handler)
+    try:
+        assert should_dispatch(shared_handler, handler_id, "demo_plugin") is True
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, shared_handler)
+        manager.unbind_plugin_event_handlers("other_plugin")
+        manager.unbind_plugin_event_handlers("demo_plugin")
+        plugin_manager._plugins = original_plugins
+        plugin_manager._running_plugins = original_running_plugins
+
+
+def test_target_plugin_filter_rejects_stale_handler_object_after_rebind():
+    """同一标识被新处理器重绑后，旧处理器对象不应继续通过定向过滤。"""
+    manager = EventManager()
+
+    def old_handler(_event):
+        return None
+
+    def new_handler(_event):
+        return None
+
+    old_handler.__qualname__ = "demo_plugin.handle"
+    new_handler.__qualname__ = "demo_plugin.handle"
+    handler_id = EventManager._EventManager__get_handler_identifier(old_handler)
+    old_plugin = type("demo_plugin", (), {"handle": old_handler})
+    new_plugin = type("demo_plugin", (), {"handle": new_handler})
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    manager.add_event_listener(EventType.MessageAction, old_handler)
+    try:
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            _mock_running_plugin(plugin_manager, "demo_plugin", old_plugin)
+            manager.bind_plugin_event_handlers("demo_plugin", old_plugin)
+            manager.add_event_listener(EventType.MessageAction, new_handler)
+            _mock_running_plugin(plugin_manager, "demo_plugin", new_plugin)
+            manager.bind_plugin_event_handlers("demo_plugin", new_plugin)
+
+            assert should_dispatch(old_handler, handler_id, "demo_plugin") is False
+            assert should_dispatch(new_handler, handler_id, "demo_plugin") is True
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, new_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+
+
+def test_target_plugin_filter_allows_inherited_plugin_handler():
+    """插件类继承的处理器也应能绑定到真实插件归属。"""
+    manager = EventManager()
+
+    def inherited_handler(_event):
+        return None
+
+    inherited_handler.__qualname__ = "demo_plugin.handle"
+    base_plugin = type("BasePlugin", (), {"handle": inherited_handler})
+    demo_plugin = type("demo_plugin", (base_plugin,), {})
+    handler_id = EventManager._EventManager__get_handler_identifier(inherited_handler)
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    manager.add_event_listener(EventType.MessageAction, inherited_handler)
+    try:
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            _mock_running_plugin(plugin_manager, "demo_plugin", demo_plugin)
+            manager.bind_plugin_event_handlers("demo_plugin", demo_plugin)
+
+            assert should_dispatch(inherited_handler, handler_id, "demo_plugin") is True
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, inherited_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+
+
+def test_target_plugin_filter_rejects_when_target_plugin_is_not_running():
+    """目标插件只有类记录但没有运行实例时，应 fail-closed。"""
+    from app.core.plugin import PluginManager
+
+    manager = EventManager()
+    plugin_manager = PluginManager()
+    original_plugins = dict(plugin_manager.plugins)
+    original_running_plugins = dict(plugin_manager.running_plugins)
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    demo_plugin = type("demo_plugin", (), {"handle": demo_plugin_handler})
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    plugin_manager._plugins = {"demo_plugin": demo_plugin}
+    plugin_manager._running_plugins = {}
+    manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    try:
+        manager.bind_plugin_event_handlers("demo_plugin", demo_plugin)
+
+        assert should_dispatch(demo_plugin_handler, handler_id, "demo_plugin") is False
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+        plugin_manager._plugins = original_plugins
+        plugin_manager._running_plugins = original_running_plugins
+
+
+def test_target_plugin_filter_rejects_when_target_plugin_is_disabled():
+    """目标插件实例仍在运行表但已禁用时，应 fail-closed。"""
+    manager = EventManager()
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    demo_plugin = type(
+        "demo_plugin",
+        (),
+        {
+            "handle": demo_plugin_handler,
+            "get_state": lambda self: False,
+        },
+    )
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    try:
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            plugin_manager.return_value.plugins = {"demo_plugin": demo_plugin}
+            plugin_manager.return_value.running_plugins = {"demo_plugin": demo_plugin()}
+            manager.bind_plugin_event_handlers("demo_plugin", demo_plugin)
+
+            assert should_dispatch(demo_plugin_handler, handler_id, "demo_plugin") is False
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+
+
+def test_target_plugin_filter_rejects_when_target_plugin_state_lookup_fails():
+    """无法确认目标插件启用状态时，应 fail-closed。"""
+    manager = EventManager()
+
+    def demo_plugin_handler(_event):
+        return None
+
+    def get_state(_self):
+        raise RuntimeError("state unavailable")
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    demo_plugin = type(
+        "demo_plugin",
+        (),
+        {
+            "handle": demo_plugin_handler,
+            "get_state": get_state,
+        },
+    )
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    try:
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            plugin_manager.return_value.plugins = {"demo_plugin": demo_plugin}
+            plugin_manager.return_value.running_plugins = {"demo_plugin": demo_plugin()}
+            manager.bind_plugin_event_handlers("demo_plugin", demo_plugin)
+
+            assert should_dispatch(demo_plugin_handler, handler_id, "demo_plugin") is False
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+
+
+def test_bind_plugin_event_handlers_clears_stale_binding_when_handler_removed():
+    """热更新后的插件类移除处理器时，应清理同插件旧绑定。"""
+    from app.core.plugin import PluginManager
+
+    manager = EventManager()
+    plugin_manager = PluginManager()
+    original_plugins = dict(plugin_manager.plugins)
+    original_running_plugins = dict(plugin_manager.running_plugins)
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    old_plugin = type("demo_plugin", (), {"handle": demo_plugin_handler})
+    new_plugin = type("demo_plugin", (), {})
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    plugin_manager._plugins = {"demo_plugin": old_plugin}
+    plugin_manager._running_plugins = {"demo_plugin": old_plugin()}
+    manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    try:
+        manager.bind_plugin_event_handlers("demo_plugin", old_plugin)
+        plugin_manager._plugins = {"demo_plugin": new_plugin}
+        plugin_manager._running_plugins = {"demo_plugin": new_plugin()}
+        manager.bind_plugin_event_handlers("demo_plugin", new_plugin)
+
+        assert should_dispatch(demo_plugin_handler, handler_id, "demo_plugin") is False
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+        plugin_manager._plugins = original_plugins
+        plugin_manager._running_plugins = original_running_plugins
+
+
+def test_plugin_manager_stop_unbinds_target_handlers_when_stop_raises():
+    """停止插件过程抛错时，也应清理定向事件处理器归属。"""
+    import app.core.plugin as plugin_module
+
+    event_manager = plugin_module.eventmanager
+    plugin_manager = plugin_module.PluginManager()
+    original_plugins = dict(plugin_manager.plugins)
+    original_running_plugins = dict(plugin_manager.running_plugins)
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    demo_plugin = type("demo_plugin", (), {"handle": demo_plugin_handler})
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    should_dispatch = event_manager._EventManager__should_dispatch_to_target_plugin
+
+    plugin_manager._plugins = {"demo_plugin": demo_plugin}
+    plugin_manager._running_plugins = {"demo_plugin": demo_plugin()}
+    event_manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    try:
+        event_manager.bind_plugin_event_handlers("demo_plugin", demo_plugin)
+        with patch.object(
+            plugin_manager, "_PluginManager__stop_plugin", side_effect=RuntimeError("stop failed")
+        ), pytest.raises(RuntimeError):
+            plugin_manager.stop("demo_plugin")
+
+        assert should_dispatch(demo_plugin_handler, handler_id, "demo_plugin") is False
+    finally:
+        event_manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        event_manager.unbind_plugin_event_handlers("demo_plugin")
+        plugin_manager._plugins = original_plugins
+        plugin_manager._running_plugins = original_running_plugins
+
+
+def test_plugin_manager_stop_all_keeps_bindings_for_plugins_not_attempted_after_stop_error():
+    """批量停止某个插件失败时，不应清理仍在运行且未尝试停止的其他插件绑定。"""
+    import app.core.plugin as plugin_module
+
+    event_manager = plugin_module.eventmanager
+    plugin_manager = plugin_module.PluginManager()
+    original_plugins = dict(plugin_manager.plugins)
+    original_running_plugins = dict(plugin_manager.running_plugins)
+
+    def demo_plugin_handler(_event):
+        return None
+
+    def other_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    other_plugin_handler.__qualname__ = "other_plugin.handle"
+    demo_plugin = type(
+        "demo_plugin",
+        (),
+        {"handle": demo_plugin_handler, "get_state": lambda self: True},
+    )
+    other_plugin = type(
+        "other_plugin",
+        (),
+        {"handle": other_plugin_handler, "get_state": lambda self: True},
+    )
+    demo_handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    other_handler_id = EventManager._EventManager__get_handler_identifier(other_plugin_handler)
+    should_dispatch = event_manager._EventManager__should_dispatch_to_target_plugin
+
+    plugin_manager._plugins = {"demo_plugin": demo_plugin, "other_plugin": other_plugin}
+    plugin_manager._running_plugins = {
+        "demo_plugin": demo_plugin(),
+        "other_plugin": other_plugin(),
+    }
+    event_manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    event_manager.add_event_listener(EventType.MessageAction, other_plugin_handler)
+    try:
+        event_manager.bind_plugin_event_handlers("demo_plugin", demo_plugin)
+        event_manager.bind_plugin_event_handlers("other_plugin", other_plugin)
+        with patch.object(
+            plugin_manager, "_PluginManager__stop_plugin", side_effect=RuntimeError("stop failed")
+        ), pytest.raises(RuntimeError):
+            plugin_manager.stop()
+
+        assert should_dispatch(demo_plugin_handler, demo_handler_id, "demo_plugin") is False
+        assert should_dispatch(other_plugin_handler, other_handler_id, "other_plugin") is True
+    finally:
+        event_manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        event_manager.remove_event_listener(EventType.MessageAction, other_plugin_handler)
+        event_manager.unbind_plugin_event_handlers("demo_plugin")
+        event_manager.unbind_plugin_event_handlers("other_plugin")
+        plugin_manager._plugins = original_plugins
+        plugin_manager._running_plugins = original_running_plugins
+
+
+def test_plugin_manager_start_does_not_bind_target_handlers_when_init_fails():
+    """插件实例初始化失败时，不应留下该插件的定向处理器归属绑定。"""
+    import app.core.plugin as plugin_module
+
+    event_manager = plugin_module.eventmanager
+    plugin_manager = plugin_module.PluginManager()
+    original_plugins = dict(plugin_manager.plugins)
+    original_running_plugins = dict(plugin_manager.running_plugins)
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+
+    class DemoPluginBase:
+        plugin_name = "Demo"
+        plugin_version = "1.0"
+        name = "Demo"
+
+        def init_plugin(self, _config):
+            raise RuntimeError("init failed")
+
+        def get_state(self):
+            return True
+
+    demo_plugin = type("demo_plugin", (DemoPluginBase,), {"handle": demo_plugin_handler})
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    handler_key = _handler_binding_key(handler_id, demo_plugin_handler)
+
+    event_manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    try:
+        with patch("app.core.plugin.SystemConfigOper") as system_config_oper, patch.object(
+            plugin_module.PluginManager, "_load_selective_plugins", return_value=[demo_plugin]
+        ), patch.object(
+            plugin_manager, "_PluginManager__set_and_check_auth_level", return_value=True
+        ), patch.object(
+            plugin_manager, "get_plugin_config", return_value={}
+        ):
+            system_config_oper.return_value.get.return_value = ["demo_plugin"]
+            plugin_manager.start("demo_plugin")
+
+        assert handler_key not in event_manager._EventManager__handler_plugin_ids
+    finally:
+        event_manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        event_manager.unbind_plugin_event_handlers("demo_plugin")
+        plugin_manager._plugins = original_plugins
+        plugin_manager._running_plugins = original_running_plugins
+
+
+def test_plugin_manager_init_plugin_unbinds_target_handlers_when_init_fails():
+    """已运行插件重新初始化失败时，应清理旧的定向处理器归属。"""
+    import app.core.plugin as plugin_module
+
+    event_manager = plugin_module.eventmanager
+    plugin_manager = plugin_module.PluginManager()
+    original_plugins = dict(plugin_manager.plugins)
+    original_running_plugins = dict(plugin_manager.running_plugins)
+
+    def demo_plugin_handler(_event):
+        return None
+
+    class DemoPluginBase:
+        def init_plugin(self, _config):
+            raise RuntimeError("init failed")
+
+        def get_state(self):
+            return True
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    demo_plugin = type("demo_plugin", (DemoPluginBase,), {"handle": demo_plugin_handler})
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    handler_key = _handler_binding_key(handler_id, demo_plugin_handler)
+
+    plugin_manager._plugins = {"demo_plugin": demo_plugin}
+    plugin_manager._running_plugins = {"demo_plugin": demo_plugin()}
+    event_manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    try:
+        event_manager.bind_plugin_event_handlers("demo_plugin", demo_plugin)
+
+        with pytest.raises(RuntimeError, match="init failed"):
+            plugin_manager.init_plugin("demo_plugin", {})
+
+        assert handler_key not in event_manager._EventManager__handler_plugin_ids
+    finally:
+        event_manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        event_manager.unbind_plugin_event_handlers("demo_plugin")
+        plugin_manager._plugins = original_plugins
+        plugin_manager._running_plugins = original_running_plugins
+
+
+@pytest.mark.parametrize(
+    ("plugin_state", "failure_method"),
+    [
+        ("error", None),
+        (True, "bind_plugin_event_handlers"),
+        (True, "enable_event_handler"),
+        (False, "disable_event_handler"),
+    ],
+)
+def test_plugin_manager_init_plugin_unbinds_target_handlers_when_lifecycle_step_fails(
+    plugin_state,
+    failure_method,
+):
+    """插件重配置后续生命周期步骤失败时，也应统一清理定向归属。"""
+    import app.core.plugin as plugin_module
+
+    event_manager = plugin_module.eventmanager
+    plugin_manager = plugin_module.PluginManager()
+    original_plugins = dict(plugin_manager.plugins)
+    original_running_plugins = dict(plugin_manager.running_plugins)
+
+    def demo_plugin_handler(_event):
+        return None
+
+    class DemoPluginBase:
+        def init_plugin(self, _config):
+            return None
+
+        def get_state(self):
+            if plugin_state == "error":
+                raise RuntimeError("lifecycle failed")
+            return plugin_state
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    demo_plugin = type("demo_plugin", (DemoPluginBase,), {"handle": demo_plugin_handler})
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    handler_key = _handler_binding_key(handler_id, demo_plugin_handler)
+
+    plugin_manager._plugins = {"demo_plugin": demo_plugin}
+    plugin_manager._running_plugins = {"demo_plugin": demo_plugin()}
+    event_manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    try:
+        event_manager.bind_plugin_event_handlers("demo_plugin", demo_plugin)
+        failure_context = (
+            patch.object(event_manager, failure_method, side_effect=RuntimeError("lifecycle failed"))
+            if failure_method
+            else nullcontext()
+        )
+
+        with failure_context, pytest.raises(RuntimeError, match="lifecycle failed"):
+            plugin_manager.init_plugin("demo_plugin", {})
+
+        assert handler_key not in event_manager._EventManager__handler_plugin_ids
+    finally:
+        event_manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        event_manager.unbind_plugin_event_handlers("demo_plugin")
+        plugin_manager._plugins = original_plugins
+        plugin_manager._running_plugins = original_running_plugins
+
+
+def test_target_plugin_filter_returns_false_when_plugin_manager_import_fails():
+    """运行时无法导入插件管理器时，目标插件过滤应 fail-closed 而不是中断事件消费。"""
+    import builtins
+
+    manager = EventManager()
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    handler_key = _handler_binding_key(handler_id, demo_plugin_handler)
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+    original_import = builtins.__import__
+    original_binding = manager._EventManager__handler_plugin_ids.get(handler_key)
+
+    def import_or_fail(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "app.core.plugin" and fromlist == ("PluginManager",):
+            raise ImportError("plugin manager unavailable")
+        return original_import(name, globals, locals, fromlist, level)
+
+    try:
+        manager._EventManager__handler_plugin_ids[handler_key] = "demo_plugin"
+        with patch("builtins.__import__", side_effect=import_or_fail):
+            assert should_dispatch(demo_plugin_handler, handler_id, "demo_plugin") is False
+    finally:
+        if original_binding is None:
+            manager._EventManager__handler_plugin_ids.pop(handler_key, None)
+        else:
+            manager._EventManager__handler_plugin_ids[handler_key] = original_binding
+
+
+def test_target_plugin_filter_returns_false_when_handler_ownership_check_fails():
+    """处理器归属校验异常时，应 fail-closed 而不是中断事件消费。"""
+    manager = EventManager()
+
+    class BrokenCallable:
+        def __getattribute__(self, name):
+            if name == "__func__":
+                raise RuntimeError("ownership unavailable")
+            return object.__getattribute__(self, name)
+
+        def __call__(self, _event):
+            return None
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    demo_plugin = type(
+        "demo_plugin",
+        (),
+        {
+            "handle": BrokenCallable(),
+            "get_state": lambda self: True,
+        },
+    )
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    handler_key = _handler_binding_key(handler_id, demo_plugin_handler)
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+
+    try:
+        manager._EventManager__handler_plugin_ids[handler_key] = "demo_plugin"
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            plugin_manager.return_value.plugins = {"demo_plugin": demo_plugin}
+            plugin_manager.return_value.running_plugins = {"demo_plugin": demo_plugin()}
+
+            assert should_dispatch(demo_plugin_handler, handler_id, "demo_plugin") is False
+    finally:
+        manager._EventManager__handler_plugin_ids.pop(handler_key, None)
+
+
+def test_add_event_listener_clears_stale_binding_when_handler_is_rebound():
+    """同一标识被新对象重注册时，应清理旧处理器对象的插件归属绑定。"""
+    manager = EventManager()
+
+    def old_handler(_event):
+        return None
+
+    def new_handler(_event):
+        return None
+
+    old_handler.__qualname__ = "demo_plugin.handle"
+    new_handler.__qualname__ = "demo_plugin.handle"
+    handler_id = EventManager._EventManager__get_handler_identifier(old_handler)
+    old_key = _handler_binding_key(handler_id, old_handler)
+    new_key = _handler_binding_key(handler_id, new_handler)
+    old_plugin = type("demo_plugin", (), {"handle": old_handler})
+    new_plugin = type("demo_plugin", (), {"handle": new_handler})
+
+    try:
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            _mock_running_plugin(plugin_manager, "demo_plugin", old_plugin)
+            manager.add_event_listener(EventType.MessageAction, old_handler)
+            assert manager._EventManager__handler_plugin_ids[old_key] == "demo_plugin"
+
+            _mock_running_plugin(plugin_manager, "demo_plugin", new_plugin)
+            manager.add_event_listener(EventType.MessageAction, new_handler)
+
+            assert old_key not in manager._EventManager__handler_plugin_ids
+            assert manager._EventManager__handler_plugin_ids[new_key] == "demo_plugin"
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, new_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+
+
+def test_target_plugin_filter_returns_false_when_handler_binding_lookup_fails():
+    """目标投递过滤归一化处理器失败时，应 fail-closed 而不是中断事件消费。"""
+    manager = EventManager()
+
+    class BrokenHandler:
+        def __getattribute__(self, name):
+            if name == "__func__":
+                raise RuntimeError("handler unavailable")
+            return object.__getattribute__(self, name)
+
+        def __call__(self, _event):
+            return None
+
+    should_dispatch = manager._EventManager__should_dispatch_to_target_plugin
+    handler = BrokenHandler()
+    handler.__qualname__ = "demo_plugin.handle"
+
+    assert should_dispatch(handler, "tests.demo_plugin.handle", "demo_plugin") is False
+
+
+def test_add_event_listener_skips_plugin_binding_when_handler_scan_fails():
+    """运行期绑定插件归属扫描失败时，应保留订阅但不抛错、不留下归属绑定。"""
+    manager = EventManager()
+
+    class BrokenPluginCallable:
+        def __getattribute__(self, name):
+            if name == "__func__":
+                raise RuntimeError("plugin scan unavailable")
+            return object.__getattribute__(self, name)
+
+        def __call__(self, _event):
+            return None
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    handler_key = _handler_binding_key(handler_id, demo_plugin_handler)
+    demo_plugin = type("demo_plugin", (), {"handle": BrokenPluginCallable()})
+
+    try:
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            _mock_running_plugin(plugin_manager, "demo_plugin", demo_plugin)
+            manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+
+            assert handler_key not in manager._EventManager__handler_plugin_ids
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+
+
+def test_bind_plugin_event_handlers_skips_broken_plugin_class_handler():
+    """批量扫描插件类时，单个异常处理器不应阻断其他真实处理器绑定。"""
+    manager = EventManager()
+
+    class BrokenPluginCallable:
+        def __getattribute__(self, name):
+            if name == "__func__":
+                raise RuntimeError("plugin scan unavailable")
+            return object.__getattribute__(self, name)
+
+        def __call__(self, _event):
+            return None
+
+    def demo_plugin_handler(_event):
+        return None
+
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    handler_key = _handler_binding_key(handler_id, demo_plugin_handler)
+    demo_plugin = type(
+        "demo_plugin",
+        (),
+        {
+            "broken": BrokenPluginCallable(),
+            "handle": demo_plugin_handler,
+        },
+    )
+
+    manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    try:
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            plugin_manager.return_value.plugins = {"demo_plugin": demo_plugin}
+
+            manager.bind_plugin_event_handlers("demo_plugin", demo_plugin)
+
+            assert manager._EventManager__handler_plugin_ids[handler_key] == "demo_plugin"
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
+
+
+def test_bind_plugin_event_handlers_skips_broken_subscriber_handler():
+    """批量绑定订阅表时，单个异常订阅处理器不应阻断其他真实处理器绑定。"""
+    manager = EventManager()
+
+    class BrokenSubscriber:
+        def __getattribute__(self, name):
+            if name == "__func__":
+                raise RuntimeError("subscriber unavailable")
+            return object.__getattribute__(self, name)
+
+        def __call__(self, _event):
+            return None
+
+    def demo_plugin_handler(_event):
+        return None
+
+    broken_handler = BrokenSubscriber()
+    broken_handler.__qualname__ = "demo_plugin.broken"
+    demo_plugin_handler.__qualname__ = "demo_plugin.handle"
+    handler_id = EventManager._EventManager__get_handler_identifier(demo_plugin_handler)
+    handler_key = _handler_binding_key(handler_id, demo_plugin_handler)
+    demo_plugin = type("demo_plugin", (), {"handle": demo_plugin_handler})
+
+    manager.add_event_listener(EventType.MessageAction, broken_handler)
+    manager.add_event_listener(EventType.MessageAction, demo_plugin_handler)
+    try:
+        with patch("app.core.plugin.PluginManager") as plugin_manager:
+            plugin_manager.return_value.plugins = {"demo_plugin": demo_plugin}
+
+            manager.bind_plugin_event_handlers("demo_plugin", demo_plugin)
+
+            assert manager._EventManager__handler_plugin_ids[handler_key] == "demo_plugin"
+    finally:
+        manager.remove_event_listener(EventType.MessageAction, broken_handler)
+        manager.remove_event_listener(EventType.MessageAction, demo_plugin_handler)
+        manager.unbind_plugin_event_handlers("demo_plugin")
 
 
 def test_noai_prefix_starts_traditional_search_when_global_ai_enabled():


### PR DESCRIPTION
Closes #6070

## Summary

定向 `MessageAction` 分发此前只校验 handler 的类名和方法名。其他模块若注册同名类 handler，可能通过过滤。

调用层会按类名反查真实目标插件实例，因此实际影响是：

- 使用 handler 中的方法名强制触发真实插件实例上的方法；
- 同名 handler 导致同一事件被重复投递。

本 PR 增加第三步模块归属校验：

- 从 `PluginManager.plugins` 获取加载器认可的目标插件类；
- 比较 handler identifier 的模块前缀与目标插件类的 `__module__`；
- 目标插件未加载或模块不一致时 fail-closed，并记录 debug 日志。

不新增 API，不要求现有插件修改。

## Validation

- `pytest tests/test_media_interaction.py -k target_plugin -q`
  - `5 passed, 57 deselected`
- `pytest tests/test_media_interaction.py -q`
  - `62 passed`
- `python -m py_compile app/core/event.py tests/test_media_interaction.py`
- `pylint app/ --errors-only`
  - 无 error 级问题
- `git diff --check`
- diff 脱敏扫描无命中
- `claude-fable-5` 无工具 diff 复审
  - 无必须修复项

全量 `python tests/run.py` 结果：

- `1823 passed`
- `1 skipped`
- `1 failed`

失败项为未修改的
`tests/test_data_cleanup_chain.py::DataCleanupChainTest::test_transferhistory_keeps_boundary_records`。
该时间边界用例可单独稳定复现，与本次事件分发改动没有调用关系。

## Compatibility / Risk

- 仅影响带 `__mp_target_plugin_id` 的定向 `MessageAction` 路径；
- 普通广播事件和链式事件不受影响；
- 目标插件未加载或处于重载空窗时会按设计拒绝投递；
- 克隆插件与重新 import 后的新类对象均有测试覆盖；
- 日志不包含用户输入内容。

## Migration

无需迁移或配置变更。

后续如需进一步增强事件系统，可考虑在注册期显式绑定 `plugin_id` 元数据；本 PR 保持最小范围，不引入注册表结构变化。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at d9c082a4dfb7cf82546415c9864dabb45be4f3ba

- 加固定向 `MessageAction` 投递
  - 绑定真实 `plugin_id`
  - 不匹配即 fail-closed
- 同步插件生命周期清理
  - 启动、重配、停止自动维护
  - 异常路径统一解绑
- 保持旧插件兼容
  - 普通事件不受影响
  - 无需插件手动改造
- 扩展安全回归测试
  - 覆盖同名处理器与旧实例
  - 验证禁用、热重载、异常场景

<!-- pr-agent-summary:end -->