### PR TITLE
fix: clear Rust parse options cache after updating custom identifiers

### DIFF
--- a/app/agent/tools/impl/update_custom_identifiers.py
+++ b/app/agent/tools/impl/update_custom_identifiers.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 
 from app.agent.tools.base import MoviePilotTool
 from app.agent.tools.tags import ToolTag
+from app.core.metainfo import clear_rust_parse_options_cache
 from app.db.systemconfig_oper import SystemConfigOper
 from app.log import logger
 from app.schemas.types import SystemConfigKey
@@ -85,6 +86,7 @@ class UpdateCustomIdentifiersTool(MoviePilotTool):
                 SystemConfigKey.CustomIdentifiers, value
             )
             if success:
+                clear_rust_parse_options_cache()
                 return json.dumps(
                     {
                         "success": True,


### PR DESCRIPTION
## Problem

The `update_custom_identifiers` MCP tool saves new rules to the database but does not invalidate the `@lru_cache` on `_rust_default_parse_options()` in `app/core/metainfo.py`. When the Rust meta parser is active (the default in Docker images), subsequent `recognize_media` calls still use the stale cached `custom_words` until the process restarts.

The HTTP API path was already correct — it fires a `ConfigChanged` event that the `FilterModule` listens to and clears the same cache via `clear_rust_parse_options_cache()`.

## Fix

Add a `clear_rust_parse_options_cache()` call after the successful database write in `update_custom_identifiers.py` so the next recognition picks up the updated identifiers immediately.

## Related

- `_rust_default_parse_options()` at `app/core/metainfo.py:224` — the `@lru_cache(maxsize=1)` that caches custom_words
- `clear_rust_parse_options_cache()` at `app/core/metainfo.py:272` — the existing cache invalidation function
- `FilterModule.CONFIG_WATCH` at `app/modules/filter/__init__.py:68` — already includes `CustomIdentifiers` for HTTP API path

## PR-Agent Summary

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 159247fb362f3aa1da628b47236c418acac3aed9

- 修复 MCP 更新后的旧缓存
- 保存成功后清理 Rust 解析选项
- 新识别词无需重启即可生效
- 无迁移；风险限于缓存刷新

<!-- pr-agent-summary:end -->