### PR TITLE
docs: clarify Chinese docstring punctuation style

### DIFF
--- a/docs/rules/08-comment-styles.md
+++ b/docs/rules/08-comment-styles.md
@@ -10,6 +10,8 @@ All **public classes**, **public methods**, and **public functions** in this pro
 
 ## Docstring Format
 
+Short, label-style docstrings should follow the surrounding code style and must not gain a period mechanically. Complete sentences that explain non-obvious behavior should use normal Chinese punctuation.
+
 ### Single-line (for simple, obvious descriptions)
 
 ```python
@@ -28,7 +30,7 @@ def download(
     download_dir: Path,
 ) -> Optional[str]:
     """
-    添加下载任务到下载器。
+    添加下载任务到下载器
 
     :param context: 当前媒体上下文，包含识别结果和种子选择信息
     :param torrent: 要下载的种子信息
@@ -43,7 +45,7 @@ def download(
 ```python
 class DownloadChain(ChainBase):
     """
-    下载处理链，负责协调搜索结果的种子选择、下载器调度和下载后处理。
+    下载处理链，负责协调搜索结果的种子选择、下载器调度和下载后处理
     """
 ```
 


### PR DESCRIPTION
## 变更说明

- 明确短小、标签式中文 docstring 应遵循周边代码风格，不机械添加句号。
- 明确非显然行为的完整说明句继续使用正常中文标点。
- 调整文档示例，使示例与规则保持一致。

## 影响范围

- `docs/rules/08-comment-styles.md`

仅修改开发规范文档，不影响运行时行为。

## 验证

- `python tests/run.py`：1911 passed，1 skipped
- `python -m pylint app`：10.00/10
- `git diff --check`：通过

本 PR 为 Codex 协作提交

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at a4a468e63d9d9a4c5916f5a37474df5cf44fd030

- 明确中文 docstring 的标点适用规则
- 更新短标签式 docstring 示例
- 不影响运行时兼容性
- 未新增自动化测试

<!-- pr-agent-summary:end -->