### PR TITLE
fix: refresh plugin scheduler jobs after reload

### DIFF
--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -25,7 +25,7 @@ from app.chain.subscribe import SubscribeChain
 from app.chain.transfer import TransferChain
 from app.chain.workflow import WorkflowChain
 from app.core.config import settings, global_vars
-from app.core.event import eventmanager
+from app.core.event import Event, eventmanager
 from app.core.plugin import PluginManager
 from app.db import SessionFactory
 from app.db.models.downloadhistory import DownloadHistory, DownloadFiles
@@ -986,6 +986,14 @@ class Scheduler(ConfigReloadMixin, metaclass=SingletonClass):
         """
         for pid in PluginManager().get_running_plugin_ids():
             self.update_plugin_job(pid)
+
+    @eventmanager.register(EventType.PluginReload)
+    def on_plugin_reload(self, event: Event) -> None:
+        """插件重载后按当前实例重新注册全部定时服务"""
+        plugin_id = event.event_data.get("plugin_id")
+        if not plugin_id:
+            return
+        self.update_plugin_job(plugin_id)
 
     def init_workflow_jobs(self):
         """

--- a/tests/test_plugin_local_sync.py
+++ b/tests/test_plugin_local_sync.py
@@ -1,3 +1,4 @@
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Iterator
@@ -7,9 +8,11 @@ import pytest
 from packaging.version import Version
 from watchfiles import Change
 
+from app.core.event import Event, eventmanager
 from app.core.plugin import PluginManager
 from app.helper.plugin import PluginHelper
-from app.schemas.types import SystemConfigKey
+from app.scheduler import Scheduler
+from app.schemas.types import EventType, SystemConfigKey
 from app.utils.singleton import Singleton
 
 
@@ -77,6 +80,34 @@ def _set_running_render_mode(
     plugin_manager.running_plugins["DemoPlugin"] = SimpleNamespace(
         get_render_mode=lambda: (render_mode, dist_path),
     )
+
+
+class _FakeSchedulerBackend:
+    """提供插件服务增删所需的最小 APScheduler 契约。"""
+
+    def __init__(self, job_ids: list[str]):
+        self.jobs = {job_id: {"id": job_id} for job_id in job_ids}
+
+    def get_jobs(self):
+        """返回当前注册的 APScheduler job。"""
+        return [SimpleNamespace(id=job_id) for job_id in self.jobs]
+
+    def remove_job(self, job_id: str) -> None:
+        """移除指定 APScheduler job。"""
+        self.jobs.pop(job_id)
+
+    def add_job(self, func, trigger, **kwargs) -> None:
+        """记录并替换指定 APScheduler job。"""
+        self.jobs[kwargs["id"]] = {"func": func, "trigger": trigger, **kwargs}
+
+
+def _build_scheduler_for_plugin_reload(jobs: dict, backend) -> Scheduler:
+    """构造不启动后台线程的插件服务 Scheduler。"""
+    scheduler = object.__new__(Scheduler)
+    scheduler._lock = threading.RLock()
+    scheduler._jobs = jobs
+    scheduler._scheduler = backend
+    return scheduler
 
 
 def test_dev_local_plugin_candidate_keeps_hot_sync_allowed_when_system_version_lags(
@@ -511,3 +542,53 @@ def test_local_python_and_federated_changes_share_one_batch_sync(
 
     assert sync_spy.call_count == 1
     reload_spy.assert_called_once_with("DemoPlugin")
+
+
+def test_plugin_reload_refreshes_scheduler_services_idempotently(monkeypatch):
+    """插件重载事件必须按当前服务拓扑幂等刷新 Scheduler。"""
+    current_func = Mock()
+    plugin_manager = Mock()
+    plugin_manager.get_plugin_services.return_value = [
+        {
+            "id": "new",
+            "name": "新服务",
+            "func": current_func,
+            "trigger": "interval",
+            "kwargs": {"minutes": 5},
+            "func_kwargs": {"marker": "new"},
+        }
+    ]
+    plugin_manager.get_plugin_attr.return_value = "测试插件"
+    monkeypatch.setattr("app.scheduler.PluginManager", lambda: plugin_manager)
+    backend = _FakeSchedulerBackend(["DemoPlugin_old"])
+    scheduler = _build_scheduler_for_plugin_reload(
+        jobs={
+            "DemoPlugin_old": {
+                "func": Mock(),
+                "name": "旧服务",
+                "pid": "DemoPlugin",
+            }
+        },
+        backend=backend,
+    )
+    event = Event(EventType.PluginReload, {"plugin_id": "DemoPlugin"})
+
+    reload_handlers = {
+        item["handler_identifier"]
+        for item in eventmanager.visualize_handlers()
+        if item["event_type"] == EventType.PluginReload.value
+        and item["status"] == "enabled"
+    }
+    assert "app.scheduler.Scheduler.on_plugin_reload" in reload_handlers
+    scheduler.on_plugin_reload(event)
+    scheduler.on_plugin_reload(event)
+
+    assert set(scheduler._jobs) == {"DemoPlugin_new"}
+    service = scheduler._jobs["DemoPlugin_new"]
+    assert service["func"] is current_func
+    assert service["kwargs"] == {"marker": "new"}
+    assert set(backend.jobs) == {"DemoPlugin_new"}
+    registered_job = backend.jobs["DemoPlugin_new"]
+    assert registered_job["trigger"] == "interval"
+    assert registered_job["minutes"] == 5
+    assert registered_job["kwargs"] == {"job_id": "DemoPlugin_new"}


### PR DESCRIPTION
## 变更说明

- 为 `Scheduler` 注册 `PluginReload` 事件处理器，在插件实例重载完成后调用现有 `update_plugin_job()` 刷新该插件的全部定时服务。
- 重新读取当前插件实例声明的服务，删除旧服务并同步新增、移除及 `trigger`、调度参数和函数参数变化。
- 保持现有所有权边界，不额外保存插件实例，不引入 generation 状态或统一生命周期框架。

## 影响范围

- `app/scheduler.py`
- `tests/test_plugin_local_sync.py`

## 验证

- 后端全量测试：`1912 passed, 1 skipped`
- `python -m pylint app`：`10.00/10`
- `git diff --check`：通过

## 设计边界

`PluginReload` 为异步广播；已经触发或正在执行的旧任务不会被强制中止。本 PR 负责事件送达后的定时服务拓扑收敛，不扩展 Scheduler 异步任务的取消与等待机制。

本 PR 为 Codex 协作提交

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 6f8fe38d9addf59dbc3d7b05a3a1e3b4d6b34fe4

- 重载后刷新插件定时服务
- 基于当前服务声明收敛任务
- 覆盖重复重载的幂等行为
- 兼容：执行中的旧任务不取消

<!-- pr-agent-summary:end -->