### PR TITLE
feat: 增加监控目录空文件夹清理开关

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -1188,7 +1188,14 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                                     logger.info(
                                         f"移动模式删除种子成功：{t.download_hash}"
                                     )
-                    if not t.download_hash and t.fileitem:
+                    if (
+                            not t.download_hash
+                            and t.fileitem
+                            and (
+                                not t.target_directory
+                                or t.target_directory.delete_empty_dirs is not False
+                            )
+                    ):
                         # 删除剩余空目录
                         StorageChain().delete_media_file(t.fileitem, delete_self=False)
 

--- a/app/schemas/system.py
+++ b/app/schemas/system.py
@@ -135,6 +135,8 @@ class TransferDirectoryConf(BaseModel):
     monitor_type: Optional[str] = None
     # 监控模式 fast / compatibility
     monitor_mode: Optional[str] = "fast"
+    # 是否删除源目录中的空文件夹
+    delete_empty_dirs: Optional[bool] = True
     # 整理方式 move/copy/link/softlink
     transfer_type: Optional[str] = None
     # 文件覆盖模式 always/size/never/latest

--- a/tests/test_transfer_empty_directory_cleanup.py
+++ b/tests/test_transfer_empty_directory_cleanup.py
@@ -1,0 +1,110 @@
+from types import SimpleNamespace
+
+from app.chain.transfer import TransferChain
+from app.core.config import settings
+from app.schemas import FileItem, TransferDirectoryConf, TransferInfo, TransferTask
+from app.schemas.types import MediaType
+
+
+def _run_move_callback(monkeypatch, target_directory):
+    deleted_paths = []
+    task = TransferTask(
+        fileitem=FileItem(
+            storage="cd2",
+            path="/115/待整理/测试剧集/Show.S01E01.mkv",
+            type="file",
+            name="Show.S01E01.mkv",
+            basename="Show.S01E01",
+            extension="mkv",
+            size=1024,
+        ),
+        meta=SimpleNamespace(begin_season=1),
+        mediainfo=SimpleNamespace(type=MediaType.TV),
+        target_directory=target_directory,
+    )
+    chain = object.__new__(TransferChain)
+    chain._media_exts = settings.RMT_MEDIAEXT
+    chain._subtitle_exts = settings.RMT_SUBEXT
+    chain._audio_exts = settings.RMT_AUDIOEXT
+    chain._success_target_files = {}
+    chain.eventmanager = SimpleNamespace(send_event=lambda *args, **kwargs: None)
+    chain.jobview = SimpleNamespace(
+        finish_task=lambda current_task: None,
+        is_finished=lambda current_task: False,
+        is_success=lambda current_task: True,
+        success_tasks=lambda mediainfo, season: [task],
+    )
+
+    monkeypatch.setattr(
+        "app.chain.transfer.TransferHistoryOper",
+        lambda: SimpleNamespace(add_success=lambda **kwargs: None),
+    )
+    monkeypatch.setattr(
+        "app.chain.transfer.SystemConfigOper",
+        lambda: SimpleNamespace(get=lambda key: None),
+    )
+    monkeypatch.setattr(
+        "app.chain.transfer.StorageChain",
+        lambda: SimpleNamespace(
+            delete_media_file=lambda fileitem, delete_self=True: (
+                deleted_paths.append(fileitem.path) or True
+            ),
+        ),
+    )
+
+    state, message = chain._TransferChain__default_callback(
+        task,
+        TransferInfo(success=True, transfer_type="move"),
+    )
+    return state, message, deleted_paths
+
+
+def test_transfer_directory_enables_empty_directory_cleanup_by_default():
+    """
+    旧目录配置未声明开关时应保持原有清理行为。
+    """
+    directory = TransferDirectoryConf()
+
+    assert directory.delete_empty_dirs is True
+
+
+def test_transfer_directory_can_disable_empty_directory_cleanup():
+    """
+    目录配置应保留关闭空目录清理的显式设置。
+    """
+    directory = TransferDirectoryConf(delete_empty_dirs=False)
+
+    assert directory.delete_empty_dirs is False
+
+
+def test_move_transfer_cleans_empty_source_directory_by_default(monkeypatch):
+    """
+    旧目录配置未声明开关时，移动整理成功后应继续清理源目录。
+    """
+    state, message, deleted_paths = _run_move_callback(
+        monkeypatch,
+        TransferDirectoryConf(monitor_type="monitor"),
+    )
+
+    assert state is True
+    assert message == ""
+    assert deleted_paths == ["/115/待整理/测试剧集/Show.S01E01.mkv"]
+
+
+def test_move_transfer_keeps_empty_source_directory_when_cleanup_is_disabled(
+        monkeypatch,
+):
+    """
+    目录监控关闭空目录清理后，移动整理成功也应保留源目录。
+    """
+    state, message, deleted_paths = _run_move_callback(
+        monkeypatch,
+        TransferDirectoryConf(
+            monitor_type="monitor",
+            delete_empty_dirs=False,
+        ),
+    )
+
+    assert state is True
+    assert message == ""
+    assert deleted_paths == []


### PR DESCRIPTION
Closes #5989

## 变更说明

- 为目录配置增加 `delete_empty_dirs` 字段，默认开启以兼容现有配置
- 移动整理成功后，仅在该字段未显式关闭时清理源空目录
- 增加回归测试，覆盖默认清理和关闭后保留目录的行为
- 前端配套：jxxghp/MoviePilot-Frontend#537

## 测试

- `venv/bin/pytest`（1970 passed, 1 skipped）
- `venv/bin/pylint app/chain/transfer.py app/schemas/system.py`（10.00/10）

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 36ac239faf790b00295eb6f60e28c5e9de465af1

- 新增监控目录空文件夹清理开关
- 默认开启，保持既有整理行为
- 关闭后移动整理保留源目录
- 增加默认与关闭场景回归测试

<!-- pr-agent-summary:end -->