### PR TITLE
fix(site): 模拟登录适配JS渲染(SPA)登录页

### DIFF
--- a/app/helper/cookie.py
+++ b/app/helper/cookie.py
@@ -20,6 +20,7 @@ class CookieHelper:
             '//input[@name="username"]',
             '//input[@id="form_item_username"]',
             '//input[@id="username"]',
+            '//input[contains(@placeholder,"用户名")]',
         ],
         "password": [
             '//input[@name="password"]',
@@ -138,6 +139,20 @@ class CookieHelper:
                         username_xpath = xpath
                         break
                 if not username_xpath:
+                    # 登录页可能为JS动态渲染（如SPA），等待输入框出现后重试
+                    try:
+                        page.wait_for_selector("input", timeout=5000)
+                    except Exception:
+                        pass
+                    html_text = self.get_page_content(page)
+                    html = etree.HTML(html_text) if html_text else None
+                    if html is None:
+                        return None, None, "解析网页源码失败"
+                    for xpath in self._SITE_LOGIN_XPATH.get("username"):
+                        if html.xpath(xpath):
+                            username_xpath = xpath
+                            break
+                if not username_xpath:
                     return None, None, "未找到用户名输入框"
                 # 查找密码输入框
                 password_xpath = None
@@ -242,13 +257,17 @@ class CookieHelper:
                                 return None, None, f"二次验证码输入失败：{str(e)}"
                             break
 
-                # 登录后的源码
-                html_text = self.get_page_content(page)
+                # 登录后的源码（部分站点登录成功后由前端脚本延迟跳转，等待并重试判定）
+                html_text = None
+                for i in range(3):
+                    if i:
+                        time.sleep(2)
+                    html_text = self.get_page_content(page)
+                    if html_text and SiteUtils.is_logged_in(html_text):
+                        return self.parse_cookies(page.context.cookies()), \
+                            page.evaluate("() => window.navigator.userAgent"), ""
                 if not html_text:
                     return None, None, "获取网页源码失败"
-                if SiteUtils.is_logged_in(html_text):
-                    return self.parse_cookies(page.context.cookies()), \
-                        page.evaluate("() => window.navigator.userAgent"), ""
                 else:
                     # 从登录后的页面读取错误信息
                     html = etree.HTML(html_text)

--- a/app/helper/cookie.py
+++ b/app/helper/cookie.py
@@ -262,10 +262,20 @@ class CookieHelper:
                 for i in range(3):
                     if i:
                         time.sleep(2)
-                    html_text = self.get_page_content(page)
-                    if html_text and SiteUtils.is_logged_in(html_text):
+                    latest_text = self.get_page_content(page)
+                    if not latest_text:
+                        continue
+                    if SiteUtils.is_logged_in(latest_text):
                         return self.parse_cookies(page.context.cookies()), \
                             page.evaluate("() => window.navigator.userAgent"), ""
+                    # 保留首个快照用于失败时解析错误信息，避免提示被后续跳转或自动消失覆盖
+                    if html_text is None:
+                        html_text = latest_text
+                    # 页面已出现明确的登录错误信息时提前结束重试
+                    latest_html = etree.HTML(latest_text)
+                    if latest_html is not None and \
+                            any(latest_html.xpath(x) for x in self._SITE_LOGIN_XPATH.get("error")):
+                        break
                 if not html_text:
                     return None, None, "获取网页源码失败"
                 else:

--- a/app/helper/cookie.py
+++ b/app/helper/cookie.py
@@ -139,9 +139,10 @@ class CookieHelper:
                         username_xpath = xpath
                         break
                 if not username_xpath:
-                    # 登录页可能为JS动态渲染（如SPA），等待输入框出现后重试
+                    # 登录页可能为JS动态渲染（如SPA），等待用户名输入框出现后重试
                     try:
-                        page.wait_for_selector("input", timeout=5000)
+                        username_union_xpath = " | ".join(self._SITE_LOGIN_XPATH.get("username"))
+                        page.wait_for_selector(f"xpath={username_union_xpath}", timeout=5000)
                     except Exception:
                         pass
                     html_text = self.get_page_content(page)
@@ -271,10 +272,11 @@ class CookieHelper:
                     # 保留首个快照用于失败时解析错误信息，避免提示被后续跳转或自动消失覆盖
                     if html_text is None:
                         html_text = latest_text
-                    # 页面已出现明确的登录错误信息时提前结束重试
+                    # 页面已出现明确的登录错误信息时，以该快照为准并提前结束重试
                     latest_html = etree.HTML(latest_text)
                     if latest_html is not None and \
                             any(latest_html.xpath(x) for x in self._SITE_LOGIN_XPATH.get("error")):
+                        html_text = latest_text
                         break
                 if not html_text:
                     return None, None, "获取网页源码失败"


### PR DESCRIPTION
## 问题

北邮人 (byr.pt) 等站点将登录页改为前端框架渲染的 SPA 后，站点卡片「更新 Cookie&UA」始终失败，报错依次为：

1. **未找到用户名输入框**：SPA 登录页的用户名输入框无 `name`/`id` 属性（仅有 placeholder），现有候选 XPATH 均无法匹配；且 `domcontentloaded` 时表单可能尚未渲染。
2. **登录失败**（误报）：登录 API 成功后，前端脚本延迟 1 秒才执行 `window.location.href` 跳转。而现有逻辑在 `networkidle` 后立即抓取页面判定登录态——此时页面仍停留在 /login（含密码输入框），`is_logged_in` 误判为未登录。实际上此刻 Cookie 已写入浏览器上下文。

## 修改

- `_SITE_LOGIN_XPATH["username"]` 末尾追加 `//input[contains(@placeholder,"用户名")]`（置于末位，经典站点仍优先按 name/id 匹配，无回归影响）
- 首次未找到用户名输入框时，`wait_for_selector("input", 5s)` 等待渲染后重取源码重试一次（仅失败路径触发）
- 登录成功判定改为最多 3 次、间隔 2 秒的重试，覆盖前端延迟跳转窗口（首次判定不等待，经典站点无额外延迟）

## 测试

- 北邮人 (byr.pt) 实测：修改前两处报错均复现；修改后「更新 Cookie&UA」成功，Cookie（auth_token/refresh_token/session_id 三件套）正确写入，站点连通性、用户数据解析、索引搜索均正常
- 假凭据提交实测：客户端表单校验与服务端错误响应路径不受影响
- 经典 NexusPHP 站点路径不受影响（新增 XPATH 在候选末位、重试仅在原失败路径触发）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 8b80ce001903e9a11eb0c53a35f8136c5fd2f5ab

- 适配 SPA 动态渲染的登录表单
- 增加用户名 placeholder 输入框匹配
- 重试登录态，保留错误快照
- 未新增自动化测试；延迟跳转仍有风险

<!-- pr-agent-summary:end -->