### PR TITLE
feat(site): 模拟登录支持勾选「记住我/保持登录」选项，获取长期会话

### DIFF
--- a/app/helper/cookie.py
+++ b/app/helper/cookie.py
@@ -52,6 +52,10 @@ class CookieHelper:
         "error": [
             "//table[@class='main']//td[@class='text']/text()",
         ],
+        "remember": [
+            '//input[@type="checkbox"][contains(@name,"remember") or contains(@id,"remember")]',
+            '//*[@role="checkbox"][contains(.,"保持登录") or contains(.,"记住我") or contains(.,"自动登录")]',
+        ],
         "twostep": [
             '//input[@name="two_step_code"]',
             '//input[@name="2fa_secret"]',
@@ -204,6 +208,20 @@ class CookieHelper:
                     page.fill(username_xpath, username)
                     # 输入密码
                     page.fill(password_xpath, password)
+                    # 勾选“记住我/保持登录”等选项，获取长期会话（部分站点默认发放短期会话）
+                    for xpath in self._SITE_LOGIN_XPATH.get("remember"):
+                        remember_element = page.query_selector(xpath)
+                        if not remember_element:
+                            continue
+                        try:
+                            checked = remember_element.get_attribute("aria-checked")
+                            if checked is None:
+                                checked = "true" if remember_element.is_checked() else "false"
+                            if checked != "true":
+                                remember_element.click()
+                        except Exception as e:
+                            logger.warning(f"勾选记住登录选项失败：{str(e)}")
+                        break
                     # 输入二步验证码
                     if twostep_xpath:
                         page.fill(twostep_xpath, otp_code)

--- a/app/helper/cookie.py
+++ b/app/helper/cookie.py
@@ -218,10 +218,12 @@ class CookieHelper:
                             if checked is None:
                                 checked = "true" if remember_element.is_checked() else "false"
                             if checked != "true":
-                                remember_element.click()
+                                remember_element.click(timeout=3000)
+                            break
                         except Exception as e:
-                            logger.warning(f"勾选记住登录选项失败：{str(e)}")
-                        break
+                            # 当前候选不可操作（如隐藏元素）时继续尝试后续候选
+                            logger.warning(f"勾选记住登录选项失败：{str(e)}，尝试下一候选")
+                            continue
                     # 输入二步验证码
                     if twostep_xpath:
                         page.fill(twostep_xpath, otp_code)


### PR DESCRIPTION
## 问题

#6137 的后续补充。部分站点登录页有「保持登录/记住我」勾选项且**默认不勾**，此时服务端仅发放短期会话（byr.pt 实测约 15-30 分钟失效）。模拟登录不会勾选该选项，导致「更新 Cookie&UA」成功后站点很快再次掉登录，需要反复更新。

## 修改

- `_SITE_LOGIN_XPATH` 新增 `remember` 候选：兼容原生 `input[type=checkbox]`（name/id 含 remember）与 ARIA `role=checkbox` 的前端组件（按「保持登录/记住我/自动登录」文本匹配）
- 填写密码后查找该选项：通过 `aria-checked`（ARIA 组件）或 `is_checked()`（原生 input）判断状态，仅在未勾选时点击；查找不到或点击异常时行为与现状完全一致

## 测试

- byr.pt 实测：勾选「保持登录」后获取的会话长期有效（数小时以上仍在登录态），未勾选的会话十几分钟即失效；playwright 对 naive-ui 的 `div[role=checkbox]` 点击后 `aria-checked` 正确翻转
- 无该选项的站点：`remember` 候选全部落空，流程与修改前无差异

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 6e00611a8b94e80fc4b75b8ffe53cdafcb46378f

- 自动勾选“记住我/保持登录”选项
- 兼容原生复选框与 ARIA 组件
- 不可操作候选自动回退
- 未新增自动化测试

<!-- pr-agent-summary:end -->