### PR TITLE
fix(subscribe): 重置订阅时恢复 TMDB 集数跟踪

### DIFF
--- a/app/api/endpoints/subscribe.py
+++ b/app/api/endpoints/subscribe.py
@@ -339,6 +339,8 @@ async def reset_subscribes(
                 "lack_episode": subscribe.total_episode,
                 "current_priority": None,
                 "episode_priority": {},
+                # 重置代表放弃手动总集数，后续订阅检查重新按 TMDB 集数更新。
+                "manual_total_episode": 0,
                 "state": "R",
             },
         )

--- a/tests/test_subscribe_endpoint.py
+++ b/tests/test_subscribe_endpoint.py
@@ -726,6 +726,7 @@ class SubscribeEndpointTest(TestCase):
             name="测试订阅",
             total_episode=10,
             lack_episode=3,
+            manual_total_episode=92,
             note=[1, 2],
             current_priority=80,
             episode_priority={"1": 80},
@@ -754,10 +755,18 @@ class SubscribeEndpointTest(TestCase):
         self.assertEqual(payload["scene"], "reset")
         self.assertEqual(
             payload["fields"],
-            ["current_priority", "episode_priority", "lack_episode", "note", "state"],
+            [
+                "current_priority",
+                "episode_priority",
+                "lack_episode",
+                "manual_total_episode",
+                "note",
+                "state",
+            ],
         )
         self.assertEqual(payload["subscribe_info"]["note"], [])
         self.assertEqual(payload["subscribe_info"]["lack_episode"], 10)
+        self.assertEqual(payload["subscribe_info"]["manual_total_episode"], 0)
 
     def test_update_subscribe_sends_modified_event_payload_without_progress_refresh(self):
         """


### PR DESCRIPTION
## 变更说明

- 重置订阅时同步清除手动总集数标记。
- 重置后的电视剧订阅可重新按 TMDB 总集数刷新，不再继续受旧手动集数锁定。
- `SubscribeModified` 重置事件会携带该字段变化，保持事件事实与数据库状态一致。

## 影响范围

- `app/api/endpoints/subscribe.py`
- `tests/test_subscribe_endpoint.py`

## 联动

- 订阅助手（增强版）集数跟踪与完成快照修正：InfinityPacer/MoviePilot-Plugins#350

## 验证

- 后端全量测试：1974 passed，1 skipped。
- `python -m pylint app`：10.00/10。
- `git diff --check` 通过。
