### PR TITLE
[codex] Fix Agent task relative-time validation

### DIFF
--- a/app/agent/tools/impl/create_agent_task.py
+++ b/app/agent/tools/impl/create_agent_task.py
@@ -60,13 +60,12 @@ class CreateAgentTaskInput(BaseModel):
         if not self.name or not self.content:
             raise ValueError("name 和 content 不能只包含空白字符")
         if self.trigger_type == "date":
-            if (self.trigger is None) == (self.delay_minutes is None):
-                raise ValueError("date 任务必须且只能提供 trigger 或 delay_minutes 之一")
             if self.delay_minutes is not None:
-                timezone = pytz.timezone(settings.TZ)
-                self.trigger = (
-                    datetime.now(timezone) + timedelta(minutes=self.delay_minutes)
-                ).isoformat(timespec="seconds")
+                # LangChain 会在 run() 前后各校验一次，延迟时间在持久化前统一计算。
+                self.trigger = None
+                return self
+            if self.trigger is None:
+                raise ValueError("date 任务必须提供 trigger 或 delay_minutes")
         elif self.trigger is None or self.delay_minutes is not None:
             raise ValueError("cron 任务必须提供 trigger，且不能提供 delay_minutes")
         self.trigger_type, self.trigger = TimerUtils.normalize_schedule_trigger(
@@ -102,6 +101,18 @@ class CreateAgentTaskTool(MoviePilotTool):
         """持久化任务并立即注册到运行时调度器。"""
         from app.scheduler import Scheduler
 
+        trigger_value = payload.trigger
+        if payload.trigger_type == "date" and payload.delay_minutes is not None:
+            timezone = pytz.timezone(settings.TZ)
+            trigger_value = (
+                datetime.now(timezone) + timedelta(minutes=payload.delay_minutes)
+            ).isoformat(timespec="seconds")
+        _, trigger_value = TimerUtils.normalize_schedule_trigger(
+            trigger_type=payload.trigger_type,
+            trigger_value=trigger_value,
+            timezone_name=settings.TZ,
+            require_future=True,
+        )
         chat = AgentChatOper().get(
             session_id=self._session_id,
             user_id=self._user_id,
@@ -110,8 +121,8 @@ class CreateAgentTaskTool(MoviePilotTool):
             name=payload.name.strip(),
             content=payload.content.strip(),
             trigger_type=payload.trigger_type,
-            cron_expression=payload.trigger if payload.trigger_type == "cron" else None,
-            run_at=payload.trigger if payload.trigger_type == "date" else None,
+            cron_expression=trigger_value if payload.trigger_type == "cron" else None,
+            run_at=trigger_value if payload.trigger_type == "date" else None,
             user_id=str(self._user_id),
             username=self._username or (chat.username if chat else None),
             session_id=str(self._session_id),

--- a/app/agent/tools/impl/update_agent_task.py
+++ b/app/agent/tools/impl/update_agent_task.py
@@ -61,13 +61,11 @@ class UpdateAgentTaskInput(BaseModel):
             if self.trigger_type is None:
                 raise ValueError("修改触发配置时必须提供 trigger_type")
             if self.trigger_type == "date":
-                if (self.trigger is None) == (self.delay_minutes is None):
-                    raise ValueError("date 任务必须且只能提供 trigger 或 delay_minutes 之一")
                 if self.delay_minutes is not None:
-                    timezone = pytz.timezone(settings.TZ)
-                    self.trigger = (
-                        datetime.now(timezone) + timedelta(minutes=self.delay_minutes)
-                    ).isoformat(timespec="seconds")
+                    # 保持校验幂等，具体绝对时间在更新调度前只计算一次。
+                    self.trigger = None
+                elif self.trigger is None:
+                    raise ValueError("date 任务必须提供 trigger 或 delay_minutes")
             elif self.trigger is None or self.delay_minutes is not None:
                 raise ValueError("cron 任务必须提供 trigger，且不能提供 delay_minutes")
         if all(
@@ -112,9 +110,16 @@ class UpdateAgentTaskTool(MoviePilotTool):
             return {"error": f"Agent 定时任务 {payload.task_id} 正在执行，请稍后再修改"}
 
         trigger_type = payload.trigger_type or task.trigger_type
-        trigger_value = payload.trigger or (
-            task.cron_expression if trigger_type == "cron" else task.run_at
-        )
+        trigger_value = payload.trigger
+        if trigger_type == "date" and payload.delay_minutes is not None:
+            timezone = pytz.timezone(settings.TZ)
+            trigger_value = (
+                datetime.now(timezone) + timedelta(minutes=payload.delay_minutes)
+            ).isoformat(timespec="seconds")
+        if trigger_value is None:
+            trigger_value = (
+                task.cron_expression if trigger_type == "cron" else task.run_at
+            )
         enabled = task.enabled if payload.enabled is None else payload.enabled
         normalized_type, normalized_trigger = TimerUtils.normalize_schedule_trigger(
             trigger_type=trigger_type,
@@ -128,7 +133,7 @@ class UpdateAgentTaskTool(MoviePilotTool):
             update_payload["name"] = payload.name.strip()
         if payload.content is not None:
             update_payload["content"] = payload.content.strip()
-        if payload.trigger is not None:
+        if payload.trigger_type is not None:
             update_payload.update(
                 {
                     "trigger_type": normalized_type,

--- a/tests/test_agent_scheduled_tasks.py
+++ b/tests/test_agent_scheduled_tasks.py
@@ -195,14 +195,12 @@ async def test_agent_task_tools_manage_persistent_schedule(monkeypatch) -> None:
     monkeypatch.setattr("app.scheduler.Scheduler", lambda: fake_scheduler)
 
     create_tool = _build_tool(CreateAgentTaskTool, user_id)
-    created = json.loads(
-        await create_tool.run(
-            name="十分钟后检查",
-            content="检查示例电影是否有资源，不要自动下载",
-            trigger_type="date",
-            delay_minutes=10,
-        )
-    )
+    created = json.loads(await create_tool.ainvoke({
+        "name": "十分钟后检查",
+        "content": "检查示例电影是否有资源，不要自动下载",
+        "trigger_type": "date",
+        "delay_minutes": 10,
+    }))
     task_id = created["id"]
     assert created["enabled"] is True
     assert datetime.fromisoformat(created["run_at"]) > datetime.now(
@@ -217,6 +215,16 @@ async def test_agent_task_tools_manage_persistent_schedule(monkeypatch) -> None:
     assert queried["tasks"][0]["content"].startswith("检查示例电影")
 
     update_tool = _build_tool(UpdateAgentTaskTool, user_id)
+    delayed_update = json.loads(await update_tool.ainvoke({
+        "task_id": task_id,
+        "trigger_type": "date",
+        "delay_minutes": 20,
+    }))
+    assert delayed_update["trigger_type"] == "date"
+    assert datetime.fromisoformat(delayed_update["run_at"]) > datetime.now(
+        pytz.timezone(settings.TZ)
+    )
+
     updated = json.loads(
         await update_tool.run(
             task_id=task_id,


### PR DESCRIPTION
## 修改内容

- 修复 Agent 通过 `delay_minutes` 创建一次性定时任务时被重复校验拒绝的问题。
- 同步修复更新定时任务时的相同问题。
- 将相对时间转换为绝对执行时间的操作延迟到持久化或更新前执行，保证 Pydantic 校验器可重复运行。
- 使用真实的 LangChain `ainvoke()` 调用路径补充创建和更新回归测试。

## 根因

LangChain 会先通过工具的 `args_schema` 校验参数，再在工具 `run()` 中重新构造输入模型。原校验器首次运行时会将 `delay_minutes` 转换成 `trigger`，第二次校验便同时收到 `trigger` 和 `delay_minutes`，触发互斥校验并导致智能体认为无法创建定时任务。

## 影响

Agent 现在可以正确创建和更新“若干分钟后执行”的一次性任务；cron 任务和显式绝对时间任务仍沿用原有标准化及未来时间校验。

## 验证

- 定时任务相关测试：`47 passed`
- 变更模块 Pylint：`10.00/10`
- `git diff --check`：通过
- 全量测试：`1973 passed, 4 skipped, 7 failed`

全量测试剩余 7 个失败均与本次改动无关，来自本地环境缺少 `trio`、`boto3`，Rust/metainfo 解析器差异及 Telegram 依赖/环境差异；定时任务测试没有失败。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 0a102a73b9cd2cf00026eb89425ede29a629fc24

- 修复相对延迟任务的重复校验失败
- 持久化前统一转换为绝对执行时间
- 更新任务正确写入延迟调度配置
- 增加 LangChain `ainvoke` 回归覆盖

<!-- pr-agent-summary:end -->