### PR TITLE
[codex] add async plugin data interfaces

### DIFF
--- a/app/db/plugindata_oper.py
+++ b/app/db/plugindata_oper.py
@@ -24,6 +24,24 @@ class PluginDataOper(DbOper):
         else:
             PluginData(plugin_id=plugin_id, key=key, value=value).create(self._db)
 
+    async def async_save(self, plugin_id: str, key: str, value: Any) -> None:
+        """
+        异步保存插件数据
+
+        :param plugin_id: 插件ID
+        :param key: 数据键
+        :param value: 数据值
+        """
+        plugin = await PluginData.async_get_plugin_data_by_key(
+            self._db, plugin_id, key
+        )
+        if plugin:
+            await plugin.async_update(self._db, {"value": value})
+        else:
+            await PluginData(
+                plugin_id=plugin_id, key=key, value=value
+            ).async_create(self._db)
+
     def get_data(self, plugin_id: str, key: Optional[str] = None) -> Any:
         """
         获取插件数据

--- a/app/plugins/__init__.py
+++ b/app/plugins/__init__.py
@@ -277,6 +277,20 @@ class _PluginBase(metaclass=ABCMeta):
             plugin_id = self.__class__.__name__
         self.plugindata.save(plugin_id, key, value)
 
+    async def async_save_data(
+        self, key: str, value: Any, plugin_id: Optional[str] = None
+    ) -> None:
+        """
+        异步保存插件数据
+
+        :param key: 数据键
+        :param value: 数据值
+        :param plugin_id: 插件ID
+        """
+        if not plugin_id:
+            plugin_id = self.__class__.__name__
+        await self.plugindata.async_save(plugin_id, key, value)
+
     def get_data(self, key: Optional[str] = None, plugin_id: Optional[str] = None) -> Any:
         """
         获取插件数据
@@ -286,6 +300,20 @@ class _PluginBase(metaclass=ABCMeta):
         if not plugin_id:
             plugin_id = self.__class__.__name__
         return self.plugindata.get_data(plugin_id, key)
+
+    async def async_get_data(
+        self, key: Optional[str] = None, plugin_id: Optional[str] = None
+    ) -> Any:
+        """
+        异步获取插件数据
+
+        :param key: 数据键
+        :param plugin_id: 插件ID
+        :return: 指定键的数据值或插件的全部数据
+        """
+        if not plugin_id:
+            plugin_id = self.__class__.__name__
+        return await self.plugindata.async_get_data(plugin_id, key)
 
     def del_data(self, key: str, plugin_id: Optional[str] = None) -> Any:
         """

--- a/tests/test_plugin_data.py
+++ b/tests/test_plugin_data.py
@@ -1,0 +1,77 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+from app.db.plugindata_oper import PluginDataOper
+from app.plugins import _PluginBase
+
+
+class DemoPlugin(_PluginBase):
+    """用于验证插件数据接口的测试插件"""
+
+    def init_plugin(self, config: dict = None):
+        """初始化测试插件"""
+
+    def get_state(self) -> bool:
+        """返回测试插件运行状态"""
+        return True
+
+    def get_api(self) -> list[dict]:
+        """返回测试插件API"""
+        return []
+
+    def get_form(self) -> tuple[None, dict]:
+        """返回测试插件配置表单"""
+        return None, {}
+
+    def get_page(self) -> None:
+        """返回测试插件详情页面"""
+
+    def stop_service(self):
+        """停止测试插件"""
+
+
+def test_async_plugin_data_oper_saves_and_gets_data() -> None:
+    """异步接口应支持新增、覆盖更新以及按键和全量读取。"""
+
+    async def run_test() -> None:
+        oper = PluginDataOper()
+        plugin_id = "AsyncPluginDataOperTest"
+
+        await oper.async_save(plugin_id, "settings", {"enabled": True})
+        await oper.async_save(plugin_id, "settings", {"enabled": False})
+        await oper.async_save(plugin_id, "history", [1, 2])
+
+        assert await oper.async_get_data(plugin_id, "settings") == {
+            "enabled": False
+        }
+        assert await oper.async_get_data(plugin_id, "missing") is None
+
+        all_data = await oper.async_get_data(plugin_id)
+        assert {item.key: item.value for item in all_data} == {
+            "settings": {"enabled": False},
+            "history": [1, 2],
+        }
+
+    asyncio.run(run_test())
+
+
+def test_plugin_base_async_data_interfaces_delegate_plugin_id() -> None:
+    """插件基类异步接口应默认使用类名并允许显式指定插件ID。"""
+
+    async def run_test() -> None:
+        plugin = DemoPlugin()
+        plugin.plugindata.async_save = AsyncMock()
+        plugin.plugindata.async_get_data = AsyncMock(return_value={"value": 1})
+
+        await plugin.async_save_data("key", "value")
+        result = await plugin.async_get_data("key", plugin_id="ClonePlugin")
+
+        plugin.plugindata.async_save.assert_awaited_once_with(
+            "DemoPlugin", "key", "value"
+        )
+        plugin.plugindata.async_get_data.assert_awaited_once_with(
+            "ClonePlugin", "key"
+        )
+        assert result == {"value": 1}
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## 变更内容

- 为 `PluginDataOper` 增加异步保存接口，支持新增和覆盖更新插件数据。
- 为插件基类增加 `async_save_data` 和 `async_get_data`，支持默认插件类名及显式插件 ID。
- 增加异步保存、更新、读取和插件 ID 委托测试。

## 目的

插件的异步任务可以直接使用异步数据库会话保存和读取持久化数据，避免在事件循环中调用同步数据库接口。

## 验证

- `pytest tests/test_plugin_data.py`：2 passed
- `pylint app/db/plugindata_oper.py app/plugins/__init__.py`：10.00/10
- `python tests/run.py`：2118 passed, 1 skipped, 2 failed

全量套件的两个失败位于未修改的 `tests/test_bluray.py::BluRayTest::test` 和 `tests/test_workflow_actions.py::test_workflow_manager_list_actions_exposes_contract`，与本次插件数据接口变更无关。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at b2129f60d37f4a1f758b2d6051482d6c42de5f63

- 新增插件数据异步读写接口
- 支持默认或指定插件 ID
- 覆盖新增、更新及委托测试
- 风险：测试使用真实数据库初始化
<!-- pr-agent-summary:end -->
