### PR TITLE
fix(docker): 依赖更新后校正 venv 属主，修复降权启动 PermissionError

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -415,10 +415,16 @@ function chown_plugin_runtime_path() {
 function correct_venv_permissions_if_updated() {
     local flag="${CONFIG_DIR}/temp/moviepilot.venv_updated"
     [ -f "${flag}" ] || return 0
-    rm -f "${flag}"
+    # venv 目录不存在则保留标记，留待下次启动重试
     [ -d "${VENV_PATH}" ] || return 0
     INFO "→ 检测到依赖已更新，正在校正虚拟环境权限..."
-    chown -R moviepilot:moviepilot "${VENV_PATH}"
+    # 仅在递归 chown 成功后才清除标记；若 chown 失败或进程被终止，
+    # 标记保留，下次启动会重新校正，避免降权进程读取 root 属主文件失败
+    if chown -R moviepilot:moviepilot "${VENV_PATH}"; then
+        rm -f "${flag}"
+    else
+        WARN "→ 虚拟环境权限校正失败，标记已保留，将在下次启动时重试。"
+    fi
 }
 
 function correct_file_permissions() {

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -409,6 +409,18 @@ function chown_plugin_runtime_path() {
     chown -h moviepilot:moviepilot "${plugin_path}"
 }
 
+# 依赖更新以 root 写入 venv 后，update.sh 会留下标记，此处据此把 venv 属主
+# 校正为 moviepilot，避免后续降权进程（如 cloakbrowser install、后端主进程）读取被拒。
+# 仅在真正发生过依赖更新时才递归 chown，不拖慢常规启动。
+function correct_venv_permissions_if_updated() {
+    local flag="${CONFIG_DIR}/temp/moviepilot.venv_updated"
+    [ -f "${flag}" ] || return 0
+    rm -f "${flag}"
+    [ -d "${VENV_PATH}" ] || return 0
+    INFO "→ 检测到依赖已更新，正在校正虚拟环境权限..."
+    chown -R moviepilot:moviepilot "${VENV_PATH}"
+}
+
 function correct_file_permissions() {
     local chown_start
     local chown_end
@@ -418,6 +430,7 @@ function correct_file_permissions() {
     force_chown_image_paths_if_requested /app /public
     chown_plugin_runtime_path /app/app/plugins
     correct_home_permissions
+    correct_venv_permissions_if_updated
     chown -R moviepilot:moviepilot \
         "${CONFIG_DIR}" \
         /var/lib/nginx \

--- a/docker/update.sh
+++ b/docker/update.sh
@@ -110,6 +110,10 @@ function install_backend_and_download_resources() {
             if ! ${VENV_PATH}/bin/python -m cloakbrowser install; then
                 WARN "CloakBrowser 浏览器内核更新失败，后续首次使用时可能重新下载"
             fi
+            # pip/cloakbrowser 以 root 写入 venv，标记本次启动已更新依赖，
+            # 由 entrypoint 在完成 usermod 后据此校正 venv 属主，避免降权后读取被拒
+            mkdir -p "${CONFIG_DIR}/temp"
+            : > "${CONFIG_DIR}/temp/moviepilot.venv_updated"
             INFO "依赖更新成功"
         else
             INFO "依赖无变化，跳过依赖更新"

--- a/docker/update.sh
+++ b/docker/update.sh
@@ -90,6 +90,11 @@ function install_backend_and_download_resources() {
     if [ -f "${TMP_PATH}/App/requirements.in" ]; then
         if ! cmp -s /app/requirements.in "${TMP_PATH}/App/requirements.in"; then
             INFO "检测到依赖变化，正在更新虚拟环境..."
+            # 在任何 root 写入 venv 之前先建立待校正标记，覆盖整个更新过程：
+            # 即使 pip 部分写入后失败、或容器在内核安装期间被停止，下次启动
+            # 仍会看到标记并重新校正 venv 属主（由 entrypoint 校正成功后清除）。
+            mkdir -p "${CONFIG_DIR}/temp"
+            : > "${CONFIG_DIR}/temp/moviepilot.venv_updated"
             # 备份当前requirements.txt
             cp /app/requirements.txt /tmp/requirements.txt.backup
             # 复制新的requirements.in
@@ -110,10 +115,6 @@ function install_backend_and_download_resources() {
             if ! ${VENV_PATH}/bin/python -m cloakbrowser install; then
                 WARN "CloakBrowser 浏览器内核更新失败，后续首次使用时可能重新下载"
             fi
-            # pip/cloakbrowser 以 root 写入 venv，标记本次启动已更新依赖，
-            # 由 entrypoint 在完成 usermod 后据此校正 venv 属主，避免降权后读取被拒
-            mkdir -p "${CONFIG_DIR}/temp"
-            : > "${CONFIG_DIR}/temp/moviepilot.venv_updated"
             INFO "依赖更新成功"
         else
             INFO "依赖无变化，跳过依赖更新"


### PR DESCRIPTION
dev/release 自动更新时，update.sh 以 root 运行 pip install 写入 /opt/venv， 而 correct_file_permissions 从不覆盖 venv，导致后续 gosu moviepilot 降权执行 cloakbrowser install 及后端主进程读取这些包时报 PermissionError，后端异常退出。

改动：update.sh 依赖更新成功后写入标记 moviepilot.venv_updated；entrypoint 在 correct_file_permissions（usermod 之后、仍为 root）检测到标记即 chown -R moviepilot:moviepilot ${VENV_PATH} 并删除标记。仅在真正发生依赖 更新的启动里递归校正，不影响常规启动速度（呼应 #6071）。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at af18269f2f3fc12b1de10a9ccdbbc1e40a2aac50

- 修复更新后虚拟环境权限错误
- 更新前创建 venv 待校正标记
- 启动时按标记递归修复 `VENV_PATH`
- 校正成功才清除标记，失败自动重试
<!-- pr-agent-summary:end -->
