### PR TITLE
fix(cache): align subscribe share region capacity

### DIFF
--- a/app/helper/server.py
+++ b/app/helper/server.py
@@ -668,7 +668,7 @@ class MoviePilotServerHelper:
         return params
 
     @classmethod
-    @cached(region="subscribe_share", maxsize=5, ttl=1800, skip_empty=True)
+    @cached(region="subscribe_share", maxsize=32, ttl=1800, skip_empty=True)
     def get_subscribe_statistic(
             cls,
             stype: str,
@@ -696,7 +696,7 @@ class MoviePilotServerHelper:
         return cls._handle_list_response(cls.subscribe_statistic(params))
 
     @classmethod
-    @cached(region="subscribe_share", maxsize=5, ttl=1800, skip_empty=True)
+    @cached(region="subscribe_share", maxsize=32, ttl=1800, skip_empty=True)
     async def async_get_subscribe_statistic(
             cls,
             stype: str,
@@ -882,7 +882,7 @@ class MoviePilotServerHelper:
         return cls._handle_response(await cls.async_subscribe_fork(share_id))
 
     @classmethod
-    @cached(region="subscribe_share", maxsize=1, ttl=1800, skip_empty=True)
+    @cached(region="subscribe_share", maxsize=32, ttl=1800, skip_empty=True)
     def get_subscribe_shares(
             cls,
             name: Optional[str] = None,
@@ -910,7 +910,7 @@ class MoviePilotServerHelper:
         return cls._handle_list_response(cls.subscribe_shares(params))
 
     @classmethod
-    @cached(region="subscribe_share", maxsize=1, ttl=1800, skip_empty=True)
+    @cached(region="subscribe_share", maxsize=32, ttl=1800, skip_empty=True)
     async def async_get_subscribe_shares(
             cls,
             name: Optional[str] = None,
@@ -938,7 +938,7 @@ class MoviePilotServerHelper:
         return cls._handle_list_response(await cls.async_subscribe_shares(params))
 
     @classmethod
-    @cached(region="subscribe_share", maxsize=1, ttl=1800, skip_empty=True)
+    @cached(region="subscribe_share", maxsize=32, ttl=1800, skip_empty=True)
     def get_subscribe_share_statistics(cls) -> List[dict]:
         """
         获取订阅分享统计数据。
@@ -948,7 +948,7 @@ class MoviePilotServerHelper:
         return cls._handle_list_response(cls.subscribe_share_statistics())
 
     @classmethod
-    @cached(region="subscribe_share", maxsize=1, ttl=1800, skip_empty=True)
+    @cached(region="subscribe_share", maxsize=32, ttl=1800, skip_empty=True)
     async def async_get_subscribe_share_statistics(cls) -> List[dict]:
         """
         异步获取订阅分享统计数据。


### PR DESCRIPTION
## 问题与背景

`MoviePilotServerHelper` 的订阅分享统计、列表和汇总入口共用 `subscribe_share` 内存缓存 region，但各入口配置的 `maxsize` 分别为 5 和 1。

共享 region 只创建一个底层缓存实例，容量由首次调用的入口确定。因此调用顺序可能让整个 region 固定为容量 1，分页、筛选或统计参数稍有变化就会频繁淘汰，缓存基本无法覆盖实际工作集。

## 原因分析

逐 key TTL 已由上游缓存实现支持，但 `maxsize` 仍属于 region 级属性，不会随同一 region 的后续写入重新创建或扩容。同一 region 混用不同容量会形成隐式的调用顺序依赖。

## 解决方案

将 `subscribe_share` region 的六个同步、异步入口统一为 `maxsize=32`：

- 订阅分享统计查询；
- 订阅分享列表查询；
- 订阅分享汇总统计。

统一调用方契约即可消除顺序依赖，不需要改变通用缓存后端、TTL、缓存键或接口行为。容量 32 能覆盖常见分页和筛选组合，同时保持内存占用有界。

## 影响与风险

改动只影响订阅分享相关结果在进程内存中的保留数量。缓存 TTL 仍为 30 分钟，API 参数、响应、持久化数据和业务语义均不变化。

风险主要是该 region 最多保留 32 个条目；相较原容量会增加少量、可控的内存占用。

## 验证

- 后端全量测试：2136 passed，1 skipped；
- `python -m pylint app`：10.00/10；
- `git diff --check`：通过。

## 关联

Refs #6161

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 8547b562e9171f68e60fc5922370402efc847675

- 统一 `subscribe_share` 缓存容量为 32
- 消除共享 region 的调用顺序容量依赖
- 覆盖统计、列表及汇总同步异步入口
- 保持 30 分钟 TTL 与接口行为不变
<!-- pr-agent-summary:end -->
