### PR TITLE
fix(docker): repair helper resource permissions

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -409,6 +409,14 @@ function chown_plugin_runtime_path() {
     chown -h moviepilot:moviepilot "${plugin_path}"
 }
 
+function correct_helper_resource_permissions() {
+    local helper_dir="${IMAGE_HELPER_DIR:-/app/app/helper}"
+    [ -e "${helper_dir}" ] || return 0
+
+    INFO "→ 正在修复资源包目录权限：${helper_dir}"
+    chown -R moviepilot:moviepilot "${helper_dir}"
+}
+
 function correct_file_permissions() {
     local chown_start
     local chown_end
@@ -416,6 +424,7 @@ function correct_file_permissions() {
 
     INFO "→ 正在校正文件权限..."
     force_chown_image_paths_if_requested /app /public
+    correct_helper_resource_permissions
     chown_plugin_runtime_path /app/app/plugins
     correct_home_permissions
     chown -R moviepilot:moviepilot \

--- a/tests/test_docker_entrypoint_permissions.py
+++ b/tests/test_docker_entrypoint_permissions.py
@@ -38,13 +38,17 @@ def _run_permission_case(tmp_path: Path, body: str, env: dict[str, str] | None =
     fake_bin = _write_fake_chown(tmp_path)
     chown_log = tmp_path / "chown.log"
     app_dir = tmp_path / "app"
+    helper_dir = app_dir / "app" / "helper"
     public_dir = tmp_path / "public"
     home_dir = tmp_path / "home"
     (app_dir / "app" / "plugins").mkdir(parents=True)
+    helper_dir.mkdir(parents=True)
     public_dir.mkdir()
     (home_dir / ".cloakbrowser").mkdir(parents=True)
     (home_dir / "runtime").mkdir()
     (app_dir / "app" / "plugins" / "plugin.py").write_text("# plugin\n", encoding="utf-8")
+    (helper_dir / "user.sites.v2.bin").write_text("resources\n", encoding="utf-8")
+    (helper_dir / "sites.cpython-312-x86_64-linux-gnu.so").write_text("plugin\n", encoding="utf-8")
     (public_dir / "index.html").write_text("<!doctype html>\n", encoding="utf-8")
     (home_dir / ".cloakbrowser" / "chrome").write_text("browser cache\n", encoding="utf-8")
     (home_dir / "runtime" / "state").write_text("state\n", encoding="utf-8")
@@ -60,6 +64,7 @@ def _run_permission_case(tmp_path: Path, body: str, env: dict[str, str] | None =
         "APP_DIR": str(app_dir),
         "PUBLIC_DIR": str(public_dir),
         "HOME_DIR": str(home_dir),
+        "IMAGE_HELPER_DIR": str(helper_dir),
         "CONFIG_DIR": str(tmp_path / "config"),
         "PUID": str(os.getuid()),
         "PGID": str(os.getgid()),
@@ -187,9 +192,22 @@ def test_runtime_writable_paths_are_still_corrected(tmp_path: Path) -> None:
     assert f"-R moviepilot:moviepilot {tmp_path}/home/runtime" in lines
     assert f"-R moviepilot:moviepilot {tmp_path}/config /var/lib/nginx /var/log/nginx" in lines
     assert "moviepilot:moviepilot /etc/hosts /tmp" in lines
+    assert f"-R moviepilot:moviepilot {tmp_path}/app/app/helper" in lines
     assert not any(line.startswith("-R ") and ".cloakbrowser" in line for line in lines)
     assert not any(f"{tmp_path}/app " in line for line in lines)
     assert not any(f"{tmp_path}/public" in line for line in lines)
+
+
+def test_helper_resource_permissions_are_repaired_even_when_owner_matches(tmp_path: Path) -> None:
+    log = _run_permission_case(
+        tmp_path,
+        'correct_helper_resource_permissions',
+    )
+
+    lines = log.splitlines()
+    assert f"-R moviepilot:moviepilot {tmp_path}/app/app/helper" in lines
+    assert not any(line.startswith("-R ") and f"{tmp_path}/app " in line for line in lines)
+    assert not any(line.startswith("-R ") and f"{tmp_path}/public" in line for line in lines)
 
 
 def test_backend_ready_log_uses_configured_ports(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Repair ownership of `/app/app/helper` during Docker startup so runtime resource updates can overwrite bundled helper resources when running with non-root `PUID`/`PGID`.
- Keep the existing optimization that skips recursive `chown` of the full `/app` and `/public` trees by default.
- Add regression coverage to ensure helper resources are repaired without reintroducing full image path chown.

## Validation
- `bash -n docker/entrypoint.sh`
- `git diff --check`
- Shell-level entrypoint permission simulation confirmed `correct_file_permissions` chowns only the helper resource directory plus existing runtime paths.
- Runtime smoke test on a Docker deployment: recreated MoviePilot with non-root `PUID=1000`/`PGID=1001`, resource update completed and container reached `healthy` without the previous `PermissionError` restart loop.

## Compatibility / Risk
- Low risk: only touches `/app/app/helper`, not the full image tree.
- Existing `MOVIEPILOT_FORCE_CHOWN=true` behavior remains unchanged.

## Migration
- No migration required.

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 3bd1bf14a0594126cd21256433e6840e5613770a

- 修复非 root 容器资源包写入权限
- 启动时递归修复 `helper` 目录属主
- 保持默认跳过完整镜像目录 `chown`
- 增加权限修复范围回归测试
<!-- pr-agent-summary:end -->
