### PR TITLE
fix(indexer): read HDDolby site message body via NexusPHP web API

### DIFF
--- a/app/modules/indexer/parser/hddolby.py
+++ b/app/modules/indexer/parser/hddolby.py
@@ -2,7 +2,9 @@
 import json
 from typing import Optional, Tuple
 
+from app.log import logger
 from app.modules.indexer.parser import SiteParserBase, SiteSchema
+from app.modules.indexer.parser.nexus_php import NexusPhpSiteUserInfo
 from app.utils.string import StringUtils
 
 
@@ -146,12 +148,44 @@ class HDDolbySiteUserInfo(SiteParserBase):
 
     def _parse_message_unread_links(self, html_text: str, msg_links: list) -> Optional[str]:
         """
-        解析未读消息链接，这里直接读出详情
+        解析未读消息链接
+        HDDolby 使用 API 模式，消息正文通过 _pase_unread_msgs 走网页接口读取。
         """
-        pass
+        return None
 
     def _parse_message_content(self, html_text) -> Tuple[Optional[str], Optional[str], Optional[str]]:
         """
         解析消息内容
+        HDDolby 使用 API 模式，消息正文通过 _pase_unread_msgs 走网页接口读取。
         """
-        pass
+        return None, None, None
+
+    def _pase_unread_msgs(self):
+        """
+        HDDolby API 仅返回未读消息数量，正文需通过 NexusPHP 网页接口读取。
+        """
+        if not self._site_cookie:
+            if self.message_unread:
+                logger.warn(
+                    f"{self._site_name} 未配置 Cookie，无法读取站点消息正文"
+                    f"（API 仅提供未读数量：{self.message_unread}）"
+                )
+            return
+
+        nexus = NexusPhpSiteUserInfo(
+            site_name=self._site_name,
+            url=self._site_url,
+            site_cookie=self._site_cookie,
+            apikey=self.apikey,
+            token=self.token,
+            session=self._session,
+            ua=self._ua,
+            emulate=self._emulate,
+            proxy=self._proxy,
+        )
+        nexus.message_unread = self.message_unread
+        nexus.message_read_force = self.message_unread > 0
+        nexus._pase_unread_msgs()
+        self.message_unread_contents = nexus.message_unread_contents.copy()
+        if self.message_unread_contents and not self.message_unread:
+            self.message_unread = len(self.message_unread_contents)

--- a/tests/test_hddolby_parser.py
+++ b/tests/test_hddolby_parser.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from app.modules.indexer.parser.hddolby import HDDolbySiteUserInfo
+from app.modules.indexer.parser.nexus_php import NexusPhpSiteUserInfo
+
+
+USER_DATA_JSON = """
+{
+  "status": 0,
+  "data": [{
+    "id": "41088",
+    "username": "g0m3e",
+    "added": "2023-12-18 13:58:19",
+    "class": "5",
+    "uploaded": "1000",
+    "downloaded": "500",
+    "seedbonus": "100.0",
+    "unread_messages": "1"
+  }]
+}
+"""
+
+
+def _build_parser(site_cookie: str = "") -> HDDolbySiteUserInfo:
+    return HDDolbySiteUserInfo(
+        site_name="高清杜比",
+        url="https://www.hddolby.com/",
+        site_cookie=site_cookie,
+        apikey="test-api-key",
+        token=None,
+    )
+
+
+def test_hddolby_parse_user_base_info_reads_unread_count():
+    parser = _build_parser()
+    parser._parse_user_base_info(USER_DATA_JSON)
+
+    assert parser.userid == "41088"
+    assert parser.username == "g0m3e"
+    assert parser.message_unread == 1
+
+
+def test_hddolby_skips_message_body_without_cookie():
+    parser = _build_parser(site_cookie="")
+    parser.message_unread = 1
+
+    parser._pase_unread_msgs()
+
+    assert parser.message_unread_contents == []
+
+
+def test_hddolby_reads_message_body_via_nexus_when_cookie_present(monkeypatch):
+    parser = _build_parser(site_cookie="c_secure_uid=1")
+    parser.message_unread = 1
+
+    def fake_pase_unread_msgs(self):
+        self.message_unread_contents = [
+            ("测试标题", "2026-07-21 10:00:00", "测试正文"),
+        ]
+
+    monkeypatch.setattr(NexusPhpSiteUserInfo, "_pase_unread_msgs", fake_pase_unread_msgs)
+
+    parser._pase_unread_msgs()
+
+    assert len(parser.message_unread_contents) == 1
+    head, date, content = parser.message_unread_contents[0]
+    assert head == "测试标题"
+    assert date == "2026-07-21 10:00:00"
+    assert content == "测试正文"


### PR DESCRIPTION
## Summary

- HDDolby uses API mode (`api/v1/user/data`) and only exposes unread message counts, while `_user_mail_unread_page` / `_sys_mail_unread_page` are unset, so `message_unread_contents` was always empty and notifications fell back to the generic "收到 N 条新消息，请登陆查看" text.
- When a site cookie is configured, delegate unread message parsing to the existing NexusPHP mailbox flow so notifications include title and content.
- Without a cookie, keep the previous behavior and log a warning.

## Configuration

HDDolby site message notifications require **both**:

| Item | Purpose |
|------|---------|
| **apikey** | Connectivity test, userdata refresh, unread message **count** |
| **Cookie** | Message **title/body** (API does not expose message content) |

Also enable **Settings → Sites → Read site messages** (`SITE_MESSAGE`).

- **apikey only**: notifications still fire, but with the generic fallback text ("收到 N 条新消息，请登陆查看").
- **apikey + Cookie + SITE_MESSAGE**: notifications show the real message title (e.g. level upgrade notices).

## Test plan

- [x] `pytest tests/test_hddolby_parser.py -q`
- [x] Verified locally on a real HDDolby site with apikey + cookie: notification shows message title (e.g. level upgrade notice)
- [ ] Maintainer review

## Notes

- Site connectivity test for HDDolby still uses apikey only (`__hddolby_test`); cookie is only needed for message body parsing.
- Notification `link` still points to the site homepage, not a specific message detail page.

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at fcd1e168110491bcfefa231a0b3b0b208f72392b

- 通过 NexusPHP 网页接口补全 HDDolby 未读消息正文
- 无 Cookie 时保留计数通知并记录警告
- 新增 API 未读数与消息读取路径测试
- 需配置 Cookie 才能显示消息标题和内容
<!-- pr-agent-summary:end -->
