### PR TITLE
fix(storage): 网络文件系统分块复制不再强制搬运源文件权限位

### DIFF
--- a/app/modules/filemanager/storages/local.py
+++ b/app/modules/filemanager/storages/local.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from pathlib import Path
 from typing import Optional, List
@@ -217,8 +218,10 @@ class LocalStorage(StorageBase):
                     if progress_callback:
                         percent = copied_size / total_size * 100
                         progress_callback(percent)
-            # 保留文件时间戳、权限等信息
-            shutil.copystat(src, dest)
+            # 保留文件时间戳（不使用 shutil.copystat，避免在支持 ACL 的文件系统上
+            # 因显式 chmod 而清除目标文件继承自父目录的 ACL 权限）
+            src_stat = src.stat()
+            os.utime(dest, ns=(src_stat.st_atime_ns, src_stat.st_mtime_ns))
             return True
         except Exception as e:
             logger.error(f"【本地】复制文件 {src} 失败：{e}")

--- a/tests/test_local_storage.py
+++ b/tests/test_local_storage.py
@@ -1,0 +1,62 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+from app.modules.filemanager.storages import local as local_storage_module
+
+
+def _make_storage():
+    """
+    绕过 __init__（依赖数据库/配置），仅用于测试不依赖实例状态的方法
+    """
+    return object.__new__(local_storage_module.LocalStorage)
+
+
+def test_copy_with_progress_preserves_mtime(tmp_path):
+    """
+    _copy_with_progress 应保留源文件的修改时间（用 os.utime 而不是 shutil.copystat）
+    """
+    src = tmp_path / "src.bin"
+    dest = tmp_path / "dest.bin"
+    src.write_bytes(b"hello world" * 1000)
+
+    old_time = 1_000_000_000  # 2001-09-09，明显区别于当前时间
+    os.utime(src, (old_time, old_time))
+
+    storage = _make_storage()
+    with patch.object(local_storage_module, "transfer_process", return_value=lambda *a, **k: None):
+        result = storage._copy_with_progress(src, dest)
+
+    assert result is True
+    assert dest.read_bytes() == src.read_bytes()
+    assert dest.stat().st_mtime == pytest.approx(old_time, abs=1)
+
+
+def test_copy_with_progress_does_not_force_source_mode_onto_dest(tmp_path):
+    """
+    回归测试：_copy_with_progress 不应把源文件的权限位强制搬到目标文件上。
+
+    这是本次修复的核心行为——之前用 shutil.copystat 会显式 chmod 目标文件，
+    在支持 ACL 的文件系统上会连带清空目标文件继承自父目录的 ACL。
+    目标文件的权限应由写入进程的 umask 决定（标准 cp 语义），而不是照抄源文件权限。
+    """
+    src = tmp_path / "src2.bin"
+    dest = tmp_path / "dest2.bin"
+    src.write_bytes(b"data")
+    # 故意给源文件设置一个不常见的严格权限
+    src.chmod(0o600)
+
+    # 用一个哨兵文件确定当前 umask 下、新建文件本该有的默认权限
+    sentinel = tmp_path / "sentinel.bin"
+    sentinel.write_bytes(b"")
+    default_mode = sentinel.stat().st_mode & 0o777
+
+    storage = _make_storage()
+    with patch.object(local_storage_module, "transfer_process", return_value=lambda *a, **k: None):
+        result = storage._copy_with_progress(src, dest)
+
+    assert result is True
+    dest_mode = dest.stat().st_mode & 0o777
+    assert dest_mode == default_mode
+    assert dest_mode != 0o600

--- a/tests/test_local_storage.py
+++ b/tests/test_local_storage.py
@@ -44,13 +44,18 @@ def test_copy_with_progress_does_not_force_source_mode_onto_dest(tmp_path):
     src = tmp_path / "src2.bin"
     dest = tmp_path / "dest2.bin"
     src.write_bytes(b"data")
-    # 故意给源文件设置一个不常见的严格权限
-    src.chmod(0o600)
 
-    # 用一个哨兵文件确定当前 umask 下、新建文件本该有的默认权限
+    # 用一个哨兵文件确定当前 umask 下、新建文件本该有的默认权限，
+    # 再让源文件权限刻意偏离这个值——不管当前测试环境 umask 是什么，
+    # 都能保证"源文件权限"与"默认创建权限"不同，断言不依赖任何硬编码的
+    # 具体权限数值，避免在限制性 umask 环境下产生误报。
     sentinel = tmp_path / "sentinel.bin"
     sentinel.write_bytes(b"")
     default_mode = sentinel.stat().st_mode & 0o777
+    # 属主始终保留读权限（测试进程自己要能读源文件），只让它与默认权限
+    # 不同，具体数值不依赖任何硬编码假设，避免限制性 umask 环境下误报
+    source_mode = 0o600 if default_mode != 0o600 else 0o640
+    src.chmod(source_mode)
 
     storage = _make_storage()
     with patch.object(local_storage_module, "transfer_process", return_value=lambda *a, **k: None):
@@ -59,4 +64,4 @@ def test_copy_with_progress_does_not_force_source_mode_onto_dest(tmp_path):
     assert result is True
     dest_mode = dest.stat().st_mode & 0o777
     assert dest_mode == default_mode
-    assert dest_mode != 0o600
+    assert dest_mode != source_mode


### PR DESCRIPTION
## 问题（Fixes #6189）

`_copy_with_progress()` 在写完文件内容后调用 `shutil.copystat(src, dest)`，本意是保留时间戳，但 `copystat` 同时会把源文件的裸 POSIX 权限位显式 `chmod` 到目标文件上。在依赖 ACL 授权的文件系统上（如群晖 Btrfs ACL），目标文件的裸权限位通常只是一个保守的兼容性占位值，真正的授权完全由继承自父目录的 ACL 决定；显式 `chmod` 会连带清空这份继承的 ACL，导致依赖该 ACL 读取文件的账号/服务（如 Emby、Jellyfin）静默失去读取权限。

详细复现步骤、根因定位（含 commit 溯源）和历史关联 issue（#3972、#4954）见 #6189。

## 修复方式

只保留时间戳（用 `os.utime`，纳秒精度与 `copystat` 对齐），不再复制权限位。目标文件权限交由写入进程的 umask 及目标目录的默认权限/继承 ACL 决定——即标准 `cp` 语义，而非这段代码此前隐含的 `cp -p` 语义。

对不支持 ACL 的普通文件系统，这是一处有意的行为调整，而非完全无变化：目标文件权限不再照抄源文件权限位，而是由写入进程的 umask 决定（标准 `cp` 语义）。多数情况下二者结果一致，但如果源文件权限被刻意设置得比 umask 默认值更收紧（例如手动 `chmod 600`），整理后的目标文件权限会变宽松。这是刻意的取舍：整理媒体文件的目的就是让媒体服务器能够读取它，继续保留源文件任意收紧的权限位反而正是本 PR 要修复的那类问题的根源；"复制源文件权限位"从未是这段代码文档化或依赖的契约，只是 `shutil.copystat` 的副作用。如需更严格的隐私控制，应通过媒体库目录自身的 umask/ACL 策略实现，而非依赖下载来源偶然的文件权限延续。

本 PR 仅修复"网络文件系统间、带进度条"的分块复制路径。`SystemUtils.copy()`/`SystemUtils.move()` 同样存在类似问题，但这两个函数是被插件备份、Agent 运行时文件同步、启动流程等多处无关场景共用的基础设施，改动它们的默认行为影响面更广，计划另开 PR 单独处理，避免这次改动范围过大。

## 验证

- 新增 `tests/test_local_storage.py`：
  - `test_copy_with_progress_preserves_mtime`：确认时间戳仍被保留
  - `test_copy_with_progress_does_not_force_source_mode_onto_dest`：回归测试，确认目标文件不再被强制设成源文件的权限位（临时改回 `shutil.copystat` 验证过此测试确实会失败）
- `pytest tests/test_local_storage.py`：2/2 通过
- `pylint app/modules/filemanager/storages/local.py`：10.00/10
- 全量测试 `python tests/run.py`：2007 passed, 1 skipped；另有 2 个失败（`test_bluray.py`、`test_workflow_actions.py`）经验证为仓库存量失败，与本次改动无关（stash 掉本次改动后同样失败）

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at eb4c7d06baa8d855967e238e4984bbb6abf2ca73

- 修复分块复制清除继承 ACL
- 保留源文件访问和修改时间
- 目标权限改由目录 ACL/umask 决定
- 新增时间戳与权限回归测试
<!-- pr-agent-summary:end -->

