### PR TITLE
fix(transfer): 手动指定媒体信息与历史记录不一致时不再拦截手动整理

### DIFF
--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -3102,6 +3102,38 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
         else:
             logger.info(f"正在计划整理 {planned_file_count} 个文件...")
 
+        def _same_history_media(transferd: TransferHistory) -> bool:
+            """
+            判断当前手动整理指定的媒体信息是否与历史记录一致。
+
+            手动整理时用户会重新指定媒体信息（如修正误识别的年份/季），
+            此时历史记录的源路径虽未变化，但所属媒体已不同，不应被当作
+            "已整理过"拦截，否则用户永远无法用手动整理修正误识别的结果。
+            """
+            if not mediainfo:
+                return True
+            current_source = mediainfo.source
+            current_media_id = mediainfo.to_dict().get("media_id")
+            if transferd.media_source and transferd.media_id:
+                if current_source and current_media_id:
+                    return (
+                        transferd.media_source == current_source
+                        and transferd.media_id == current_media_id
+                    )
+                return True
+            # 兼容未记录统一媒体标识的历史数据，回退比较各来源的ID
+            for current_id, history_id in (
+                    (mediainfo.tmdb_id, transferd.tmdbid),
+                    (mediainfo.douban_id, transferd.doubanid),
+                    (mediainfo.imdb_id, transferd.imdbid),
+                    (mediainfo.tvdb_id, transferd.tvdbid),
+                    (mediainfo.bangumi_id, transferd.bangumiid),
+                    (mediainfo.anilist_id, transferd.anilistid),
+            ):
+                if current_id and history_id:
+                    return str(current_id) == str(history_id)
+            return True
+
         # 整理所有文件
         transfer_tasks: List[TransferTask] = []
         skipped_history_count = 0
@@ -3114,12 +3146,13 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                     raise OperationInterrupted()
                 file_path = Path(file_item.path)
 
-                # 整理成功的不再处理
+                # 整理成功的不再处理，但手动整理时如果本次指定的媒体信息
+                # 与历史记录不一致（用户在修正误识别的媒体），则不视为已整理过
                 if not force and not preview:
                     transferd = TransferHistoryOper().get_by_src(
                         file_item.path, storage=file_item.storage
                     )
-                    if transferd:
+                    if transferd and (not manual or _same_history_media(transferd)):
                         skipped_history_count += 1
                         if not transferd.status:
                             all_success = False

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -3112,17 +3112,23 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
             """
             if not mediainfo:
                 return True
-            current_source = mediainfo.source
             current_media_id = mediainfo.to_dict().get("media_id")
-            if transferd.media_source and transferd.media_id:
-                if current_source and current_media_id:
-                    return (
-                        transferd.media_source == current_source
-                        and transferd.media_id == current_media_id
-                    )
-                return True
-            # 兼容未记录统一媒体标识的历史数据，回退比较各来源的ID
+            # 统一媒体标识(来源+原生ID)与各来源专属ID都作为独立的一项，
+            # 任一相同即视为同一媒体；必须比较完所有项后仍无一致才判定
+            # 为不同媒体，避免比较到第一个不一致的项就短路误判。
+            # 统一标识用元组而非字符串拼接比较，避免不同 (来源, ID) 组合
+            # 拼接后恰好得到相同字符串这一理论上的碰撞可能。
+            unified_current = (
+                (mediainfo.source, current_media_id)
+                if mediainfo.source and current_media_id else None
+            )
+            unified_history = (
+                (transferd.media_source, transferd.media_id)
+                if transferd.media_source and transferd.media_id else None
+            )
+            has_comparable_id = False
             for current_id, history_id in (
+                    (unified_current, unified_history),
                     (mediainfo.tmdb_id, transferd.tmdbid),
                     (mediainfo.douban_id, transferd.doubanid),
                     (mediainfo.imdb_id, transferd.imdbid),
@@ -3130,9 +3136,16 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
                     (mediainfo.bangumi_id, transferd.bangumiid),
                     (mediainfo.anilist_id, transferd.anilistid),
             ):
-                if current_id and history_id:
-                    return str(current_id) == str(history_id)
-            return True
+                if not current_id or not history_id:
+                    continue
+                has_comparable_id = True
+                if isinstance(current_id, tuple):
+                    if current_id == history_id:
+                        return True
+                elif str(current_id) == str(history_id):
+                    return True
+            # 没有任何可比较的ID时无法判断，保守回退为同一媒体
+            return not has_comparable_id
 
         # 整理所有文件
         transfer_tasks: List[TransferTask] = []

--- a/tests/test_transfer_job_manager.py
+++ b/tests/test_transfer_job_manager.py
@@ -55,15 +55,16 @@ class FakeMeta:
 
 
 class FakeMedia:
-    def __init__(self, tmdb_id: int = 12345):
+    def __init__(self, tmdb_id: int = 12345, imdb_id: str = None, source: str = "themoviedb",
+                 douban_id: str = None):
         """构造与正式 MediaInfo 身份字段一致的测试媒体对象。"""
         self.tmdb_id = tmdb_id
-        self.douban_id = None
-        self.imdb_id = None
+        self.douban_id = douban_id
+        self.imdb_id = imdb_id
         self.tvdb_id = None
         self.bangumi_id = None
         self.anilist_id = None
-        self.source = "themoviedb"
+        self.source = source
         self.type = MediaType.TV
         self.title_year = "Test Show (2026)"
 
@@ -82,6 +83,7 @@ class FakeMedia:
             "douban_id": self.douban_id,
             "bangumi_id": self.bangumi_id,
             "anilist_id": self.anilist_id,
+            "media_id": str(self.tmdb_id) if self.source == "themoviedb" else self.douban_id,
         }
 
 
@@ -449,10 +451,17 @@ class TransferJobManagerTest(unittest.TestCase):
         # 手动集数偏移只能应用一次，避免 E14 + (-1) 被二次处理成 E12。
         self.assertEqual([13], planned_episodes)
 
-    def _run_manual_reorganize_with_history(self, history_tmdbid: int, current_tmdbid: int):
+    def _run_manual_reorganize_with_history(
+            self, history_tmdbid: int, current_tmdbid: int,
+            history_imdbid: str = None, current_imdbid: str = None,
+            history_media_source: str = None, history_media_id: str = None,
+            current_source: str = "themoviedb", current_doubanid: str = None,
+    ):
         """
-        构造一次手动整理，源文件已有历史记录（tmdbid=history_tmdbid），
-        本次指定的媒体信息 tmdbid=current_tmdbid，返回 (state, errmsg, handled)。
+        构造一次手动整理，源文件已有历史记录（tmdbid=history_tmdbid[, imdbid=history_imdbid,
+        media_source=history_media_source, media_id=history_media_id]），
+        本次指定的媒体信息 tmdbid=current_tmdbid[, imdbid=current_imdbid, source=current_source]，
+        返回 (state, errmsg, handled)。
         """
         chain = make_transfer_chain()
         source_fileitem = make_fileitem("/downloads/Test.Show.2026.S01E14.mkv")
@@ -470,11 +479,11 @@ class TransferJobManagerTest(unittest.TestCase):
             status=True,
             download_hash=None,
             downloader=None,
-            media_source=None,
-            media_id=None,
+            media_source=history_media_source,
+            media_id=history_media_id,
             tmdbid=history_tmdbid,
             doubanid=None,
-            imdbid=None,
+            imdbid=history_imdbid,
             tvdbid=None,
             bangumiid=None,
             anilistid=None,
@@ -494,7 +503,10 @@ class TransferJobManagerTest(unittest.TestCase):
                 patch("app.chain.transfer.MetaInfoPath", lambda *args, **kwargs: FakeMeta(14)):
             state, errmsg = chain.do_transfer(
                 fileitem=source_fileitem,
-                mediainfo=FakeMedia(tmdb_id=current_tmdbid),
+                mediainfo=FakeMedia(
+                    tmdb_id=current_tmdbid, imdb_id=current_imdbid,
+                    source=current_source, douban_id=current_doubanid,
+                ),
                 target_path=Path("/library"),
                 manual=True,
                 background=False,
@@ -521,6 +533,35 @@ class TransferJobManagerTest(unittest.TestCase):
         self.assertTrue(state, errmsg)
         self.assertEqual("", errmsg)
         self.assertEqual(1, len(handled))
+
+    def test_manual_reorganize_skips_when_any_legacy_id_matches_despite_tmdbid_mismatch(self):
+        # 旧历史记录同时存有 tmdbid 和 imdbid：tmdbid 不同但 imdbid 相同，
+        # 只要任一来源ID一致就应判定为同一媒体，继续拦截，而不能在比较到
+        # 第一个不一致的ID（tmdbid）时就短路判定为不同媒体。
+        state, errmsg, handled = self._run_manual_reorganize_with_history(
+            history_tmdbid=99999, current_tmdbid=12345,
+            history_imdbid="tt0000001", current_imdbid="tt0000001",
+        )
+
+        self.assertTrue(state)
+        self.assertEqual("Test.Show.2026.S01E14.mkv 已整理过", errmsg)
+        self.assertEqual([], handled)
+
+    def test_manual_reorganize_skips_when_tmdbid_matches_despite_different_media_source(self):
+        # 历史记录的统一媒体标识(media_source="themoviedb")与本次指定的
+        # 媒体信息(source="douban")不同，但两者的 tmdbid 实际相同（同一部剧，
+        # 只是这次换了个数据源重新识别）。统一标识和各来源专属ID是平等的
+        # 比较项，只要其中任一相同就应判定为同一媒体，继续拦截，而不能
+        # 仅凭统一标识不同就判定为不同媒体。
+        state, errmsg, handled = self._run_manual_reorganize_with_history(
+            history_tmdbid=12345, current_tmdbid=12345,
+            history_media_source="themoviedb", history_media_id="12345",
+            current_source="douban", current_doubanid="36516448",
+        )
+
+        self.assertTrue(state)
+        self.assertEqual("Test.Show.2026.S01E14.mkv 已整理过", errmsg)
+        self.assertEqual([], handled)
 
     def test_completed_media_job_is_removed_after_last_meta_task_fails(self):
         jobview = JobManager()

--- a/tests/test_transfer_job_manager.py
+++ b/tests/test_transfer_job_manager.py
@@ -59,6 +59,8 @@ class FakeMedia:
         """构造与正式 MediaInfo 身份字段一致的测试媒体对象。"""
         self.tmdb_id = tmdb_id
         self.douban_id = None
+        self.imdb_id = None
+        self.tvdb_id = None
         self.bangumi_id = None
         self.anilist_id = None
         self.source = "themoviedb"
@@ -446,6 +448,79 @@ class TransferJobManagerTest(unittest.TestCase):
         self.assertTrue(state, errmsg)
         # 手动集数偏移只能应用一次，避免 E14 + (-1) 被二次处理成 E12。
         self.assertEqual([13], planned_episodes)
+
+    def _run_manual_reorganize_with_history(self, history_tmdbid: int, current_tmdbid: int):
+        """
+        构造一次手动整理，源文件已有历史记录（tmdbid=history_tmdbid），
+        本次指定的媒体信息 tmdbid=current_tmdbid，返回 (state, errmsg, handled)。
+        """
+        chain = make_transfer_chain()
+        source_fileitem = make_fileitem("/downloads/Test.Show.2026.S01E14.mkv")
+        handled = []
+
+        chain._TransferChain__get_trans_fileitems = lambda fileitem, predicate: [
+            (source_fileitem, False)
+        ]
+        chain._TransferChain__put_to_jobview = lambda task: True
+        chain._TransferChain__register_scrape_batch_task = lambda task: None
+        chain._TransferChain__close_scrape_batch = lambda batch_id: None
+        chain._TransferChain__handle_transfer = lambda task, callback=None: handled.append(task) or (True, "")
+
+        history = SimpleNamespace(
+            status=True,
+            download_hash=None,
+            downloader=None,
+            media_source=None,
+            media_id=None,
+            tmdbid=history_tmdbid,
+            doubanid=None,
+            imdbid=None,
+            tvdbid=None,
+            bangumiid=None,
+            anilistid=None,
+        )
+        transfer_history_oper = SimpleNamespace(get_by_src=lambda src, storage=None: history)
+        download_history_oper = SimpleNamespace(
+            get_by_hash=lambda download_hash: None,
+            get_file_by_fullpath=lambda fullpath: None,
+            get_files_by_savepath=lambda savepath: [],
+            get_by_path=lambda path: None,
+        )
+        system_config_oper = SimpleNamespace(get=lambda key: None)
+
+        with patch("app.chain.transfer.TransferHistoryOper", return_value=transfer_history_oper), \
+                patch("app.chain.transfer.DownloadHistoryOper", return_value=download_history_oper), \
+                patch("app.chain.transfer.SystemConfigOper", return_value=system_config_oper), \
+                patch("app.chain.transfer.MetaInfoPath", lambda *args, **kwargs: FakeMeta(14)):
+            state, errmsg = chain.do_transfer(
+                fileitem=source_fileitem,
+                mediainfo=FakeMedia(tmdb_id=current_tmdbid),
+                target_path=Path("/library"),
+                manual=True,
+                background=False,
+            )
+        return state, errmsg, handled
+
+    def test_manual_reorganize_skips_when_history_media_matches(self):
+        # 手动整理未修正媒体信息（同一部剧），历史记录应继续拦截，避免重复整理。
+        state, errmsg, handled = self._run_manual_reorganize_with_history(
+            history_tmdbid=12345, current_tmdbid=12345
+        )
+
+        self.assertTrue(state)
+        self.assertEqual("Test.Show.2026.S01E14.mkv 已整理过", errmsg)
+        self.assertEqual([], handled)
+
+    def test_manual_reorganize_proceeds_when_history_media_differs(self):
+        # 用户在手动整理中修正了误识别的媒体（tmdbid 变化），
+        # 不应被旧的整理记录拦截，否则手动整理无法用于纠错。
+        state, errmsg, handled = self._run_manual_reorganize_with_history(
+            history_tmdbid=99999, current_tmdbid=12345
+        )
+
+        self.assertTrue(state, errmsg)
+        self.assertEqual("", errmsg)
+        self.assertEqual(1, len(handled))
 
     def test_completed_media_job_is_removed_after_last_meta_task_fails(self):
         jobview = JobManager()


### PR DESCRIPTION
## 问题（Fixes #6191）

手动整理（`TransferChain.do_transfer`，`app/chain/transfer.py` 约 3117 行）判断"是否已整理过"时，只按源文件路径查询 `TransferHistory`，只要该源路径存在过历史记录就直接跳过，完全不比较本次整理指定的媒体信息与历史记录是否一致。

当用户通过"手动整理"重新指定正确的媒体信息（例如原本被自动识别成错误的年份/剧集，用户改用正确的 TMDB/豆瓣编号重新整理）来修正误识别结果时，源文件路径没有变化，但所属媒体已经完全不同——此时仍被当作"重复整理"拦截，用户必须先去"整理历史"里逐条删除记录才能重新整理，手动整理因此无法用于修正误识别结果。

详细复现步骤、日志佐证见 #6191。

## 修复方式

新增 `_same_history_media()`，仅在满足以下**全部**条件时才跳过原有的"已整理过"拦截：

- 是手动整理（`manual=True`）
- 调用方已显式提供本次的媒体信息（`mediainfo` 非空——即用户在界面上选择了具体的 TMDB/豆瓣编号，而非留空走自动识别）
- 本次 `mediainfo` 与历史记录 `TransferHistory` 的媒体标识**不一致**

媒体标识比较优先使用统一字段 `media_source` + `media_id`（`add_success` 写入历史记录时始终会写入这两个字段）；对不含这两个字段的历史数据（早于该字段引入的旧记录），回退按各数据源的原生 ID（tmdbid/doubanid/imdbid/tvdbid/bangumiid/anilistid）比较，任一数据源双方都有值且相同即视为同一媒体。

整理成功后 `TransferHistoryOper.add_success()` 内部调用的 `add_force()` 本来就会按源路径删除旧记录再插入新记录，因此放行后旧的、指向错误媒体的历史记录会被自然替换，不需要额外清理逻辑。

### 执行边界（刻意保留、未处理的场景）

- **仅覆盖"手动整理时显式指定媒体编号"这一条路径**（`manual_transfer()` 中 `tmdbid/doubanid/bangumiid/anilistid/media_id` 任一非空的分支，`app/chain/transfer.py:3641`）。手动整理"留空、自动识别"的分支（同文件 3696 行起）调用 `do_transfer` 时 `mediainfo` 为 `None`，本次改动的判断函数在此直接回退到原有行为（`if not mediainfo: return True`），"已整理过"拦截依然存在。这是本次修复刻意划定的范围，不在本 PR 处理。
- **自动整理（下载完成后自动入库、目录监控等，`manual=False`）行为完全不变**——本次改动只在 `manual=True` 分支生效，不影响自动整理已有的重复入库保护逻辑。
- **历史记录数据不完整（无任何一对可比较的媒体 ID 重合）时，保守回退为"视为同一媒体"，维持跳过（旧行为）**，不会因为数据缺失而错误地触发一次不必要的重新整理。
- 用户在手动整理时如果只是更换了识别数据源但实际上是同一部媒体（例如同一部剧，这次选择豆瓣而不是 TMDB），会被判定为"媒体不同"从而重新执行一次整理（多一次移动/复制，但不会产生数据错误）——这是手动整理场景下可接受的代价，因为触发条件是用户在界面上显式选择数据源/编号，而非自动化流程静默触发。

## 验证

- 新增单元测试（`tests/test_transfer_job_manager.py`）：
  - `test_manual_reorganize_skips_when_history_media_matches`：手动整理未修正媒体信息（tmdbid 相同）时，历史记录仍然拦截，行为不变。
  - `test_manual_reorganize_proceeds_when_history_media_differs`：手动整理修正了媒体信息（tmdbid 不同）时，不再被历史记录拦截，正常进入整理流程。
- 原有覆盖"已整理过"跳过逻辑的测试（`test_successful_history_skip_marks_downloader_hash_completed`、`test_failed_history_skip_still_marks_downloader_hash_completed`，均为 `manual=False` 场景）保持通过，确认自动整理路径行为未变。
- `pytest tests/` 全量：2220 passed, 1 skipped（另有 3 个与本次修改无关的仓库存量失败：`test_bluray.py`、`test_recommend_dashboard_contract.py`、`test_workflow_actions.py`，均在未应用本次改动的 `origin/v2` 上复现，与本 PR 无关）。
- `pylint app/chain/transfer.py`：10.00/10，无新增告警。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at adb919ecd07e14e70237902d2e1850a495b7580c

- 手动整理按媒体标识校验历史记录
- 媒体不一致时允许纠正误识别
- 多来源 ID 任一匹配仍阻止重复整理
- 增加媒体比较与短路回归测试
<!-- pr-agent-summary:end -->
