### PR TITLE
fix(emby): fall back to configured user

### DIFF
--- a/app/modules/emby/emby.py
+++ b/app/modules/emby/emby.py
@@ -191,7 +191,12 @@ class Emby:
 
     def get_user(self, user_name: Optional[str] = None) -> Optional[Union[str, int]]:
         """
-        获得管理员用户
+        获取用于查询用户范围数据的用户ID
+
+        优先匹配指定用户名，其次匹配媒体服务器配置用户名，最后回退管理员。
+
+        :param user_name: 优先匹配的用户名
+        :return: 匹配到的用户ID，未找到可用用户时返回None
         """
         if not self._host or not self._apikey:
             return None
@@ -203,15 +208,18 @@ class Emby:
             res = RequestUtils().get_res(url, params)
             if res:
                 users = res.json()
-                # 先查询是否有与当前用户名称匹配的
-                if user_name:
-                    for user in users:
-                        if user.get("Name") == user_name:
-                            return user.get("Id")
+                candidate_usernames = []
+                for candidate_username in (user_name, self._username):
+                    if candidate_username and candidate_username not in candidate_usernames:
+                        candidate_usernames.append(candidate_username)
+                for candidate_username in candidate_usernames:
+                    for emby_user in users:
+                        if emby_user.get("Name") == candidate_username:
+                            return emby_user.get("Id")
                 # 查询管理员
-                for user in users:
-                    if user.get("Policy", {}).get("IsAdministrator"):
-                        return user.get("Id")
+                for emby_user in users:
+                    if emby_user.get("Policy", {}).get("IsAdministrator"):
+                        return emby_user.get("Id")
             else:
                 logger.error(f"Users 未获取到返回数据")
         except Exception as e:

--- a/tests/test_emby_user_resolution.py
+++ b/tests/test_emby_user_resolution.py
@@ -1,0 +1,59 @@
+from unittest.mock import Mock, patch
+
+from app.modules.emby.emby import Emby
+
+
+def _resolve_user(users: list[dict], requested_username: str, configured_username: str):
+    emby = Emby.__new__(Emby)
+    emby._host = "http://emby.local/"
+    emby._apikey = "test-api-key"
+    emby._username = configured_username
+
+    response = Mock()
+    response.json.return_value = users
+    with patch("app.modules.emby.emby.RequestUtils") as request_utils:
+        request_utils.return_value.get_res.return_value = response
+        return emby.get_user(requested_username)
+
+
+def test_get_user_prefers_requested_username():
+    """指定用户名存在时应优先使用该用户。"""
+    result = _resolve_user(
+        users=[
+            {"Id": "requested-id", "Name": "mp-user", "Policy": {}},
+            {"Id": "configured-id", "Name": "configured-user", "Policy": {}},
+            {"Id": "admin-id", "Name": "admin", "Policy": {"IsAdministrator": True}},
+        ],
+        requested_username="mp-user",
+        configured_username="configured-user",
+    )
+
+    assert result == "requested-id"
+
+
+def test_get_user_falls_back_to_configured_username():
+    """指定用户名不存在时应回退媒体服务器配置用户。"""
+    result = _resolve_user(
+        users=[
+            {"Id": "configured-id", "Name": "configured-user", "Policy": {}},
+            {"Id": "admin-id", "Name": "admin", "Policy": {"IsAdministrator": True}},
+        ],
+        requested_username="missing-mp-user",
+        configured_username="configured-user",
+    )
+
+    assert result == "configured-id"
+
+
+def test_get_user_falls_back_to_administrator():
+    """指定用户和配置用户均不存在时应回退管理员。"""
+    result = _resolve_user(
+        users=[
+            {"Id": "regular-id", "Name": "regular", "Policy": {}},
+            {"Id": "admin-id", "Name": "admin", "Policy": {"IsAdministrator": True}},
+        ],
+        requested_username="missing-mp-user",
+        configured_username="missing-configured-user",
+    )
+
+    assert result == "admin-id"


### PR DESCRIPTION
# 背景
- 2024 年先加入“按当前 MP 用户匹配 Emby/Jellyfin 用户”。
- 2025 年才加入 Emby 配置用户名，但只改了默认实例用户，没有调整首页的用户优先级。
导致当前获取首页的媒体库数据时（继续播放），当媒体库配置中的 Emby 配置用户名没有生效，当找不到和MP用户同名emby用户时，当前实现回退到管理员，而不是配置的 Emby 用户。

# 修复
将用户匹配逻辑更新为：
1. 当前 MP 登录用户的同名 Emby 用户
2. 媒体服务器设置中配置的 Emby 用户
3. Emby 管理员用户

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 4d92b9dbc57a296e111f0456221bd4e0dba46c4f

- 修复 Emby 用户解析的回退顺序
- 优先当前用户，再用配置用户
- 最后回退至 Emby 管理员
- 新增三层优先级单元测试
<!-- pr-agent-summary:end -->
