### PR TITLE
fix(subscribe): seerr 端点电影订阅不传季号，避免通知标题出现 S00

### DIFF
--- a/app/api/endpoints/subscribe.py
+++ b/app/api/endpoints/subscribe.py
@@ -504,7 +504,8 @@ async def seerr_subscribe(
             tmdbid=tmdbId,
             title=subject,
             year="",
-            season=0,
+            # 电影不传季号，避免被误判为剧集（S00）并污染通知标题
+            season=None,
             username=user_name,
         )
     else:


### PR DESCRIPTION
## 问题

MoviePilot 的 `POST /api/v1/subscribe/seerr` 端点为电影订阅硬编码传 `season=0`。而 `SubscribeChain.add` 中有：

```python
if season is not None:
    metainfo.type = MediaType.TV
    metainfo.begin_season = season
```

任何非 `None` 的季号（包括 `0`）都会被强制按剧集处理。电影经该端点创建订阅后，`metainfo.begin_season` 被记为 `0`，导致「添加订阅成功」通知标题中电影名称被拼上 `S00`（如 `某某电影 (2024) S00 添加订阅成功！`）。

订阅数据本身正常（数据库里季号随后会被归一化为 `null`），问题仅出现在通知标题。

## 修改

电影分支由 `season=0` 改为 `season=None`，避免电影被误判为剧集、通知标题不再出现 `S00`。

```diff
 if media_type == MediaType.MOVIE:
     background_tasks.add_task(
         start_subscribe_add,
         mtype=media_type,
         tmdbid=tmdbId,
         title=subject,
         year="",
-        season=0,
+        season=None,
         username=user_name,
     )
```

## 说明

- 该端点主要用于 OverSeerr / Jellyseerr / Sinerr 等第三方请求应用的回调，电影订阅本就不该携带季号。
- 剧集分支不受影响（季号来自 `extra` 的 `Requested Seasons`）。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 3577b38c2288213be6eac249272ef06cdbb3a769

- 电影订阅不再传递 `season=0`
- 避免误判剧集并显示 `S00`
- 剧集订阅季号处理保持不变
<!-- pr-agent-summary:end -->
