### PR TITLE
fix(transhandler): 优化动画/剧集 BD 特典与附加视频文件的整理与通知逻辑

### DIFF
--- a/app/modules/filemanager/transhandler.py
+++ b/app/modules/filemanager/transhandler.py
@@ -190,6 +190,21 @@ class TransHandler:
                 return True
             return False
 
+        def __is_special_extra_file(_fileitem: FileItem) -> bool:
+            """
+            判断是否为特典/附加视频文件（如 NCOP/NCED/Menu/CM/PV/Event/Logo 等无集数编号的视频/样本）
+            """
+            file_name = _fileitem.name or ""
+            return bool(
+                re.search(
+                    r"(?:^|[\s_.\-\[【(])("
+                    r"NC(?:OP|ED)|NCOP|NCED|OP|ED|MENU|PV|CM|TRAILER|TV\s*SPOT|SP|OVA|OAD|EVENT|IV|INTERVIEW|LOGO|PRODUCER\s*LOGO|BEHIND\s*THE\s*SCENES|FEATURETTE"
+                    r")(?:\d*|[\s_.\-\]】)]|$)",
+                    file_name,
+                    re.IGNORECASE,
+                )
+            )
+
         # 整理结果
         result = TransferInfo()
 
@@ -299,6 +314,17 @@ class TransHandler:
                 if mediainfo.type == MediaType.TV:
                     # 电视剧
                     if in_meta.begin_episode is None:
+                        if __is_special_extra_file(fileitem):
+                            logger.info(f"文件 {fileitem.path} 未识别到文件集数，识别为特典/附加视频文件，跳过正片集数整理")
+                            self.__update_result(
+                                result=result,
+                                success=True,
+                                fileitem=fileitem,
+                                transfer_type=transfer_type,
+                                need_notify=False,
+                            )
+                            return result
+
                         logger.warn(f"文件 {fileitem.path} 整理失败：未识别到文件集数")
                         self.__update_result(
                             result=result,


### PR DESCRIPTION
### 场景与痛点 (Problem)

在整理动画或剧集的 BD-BOX/完整资源包时，资源包中往往包含大量无常规正片集数编号的特典/附加视频文件（例如 `NCOP` 无字OP、`NCED` 无字ED、`Menu` 菜单片段、`PV` 预告、`CM` 商业广告、`SP` 特别篇、`Event` 声优活动/现场记录、`Logo` 制作商动画等）。

当整理这些单个特典文件时，由于文件名中无法提取出 `begin_episode` 正片集数，目前 MoviePilot 会无差别地将其判定为整理失败：
```
logger.warn(f"文件 {fileitem.path} 整理失败：未识别到文件集数")
```
并触发 `need_notify` 弹窗通知。

这导致：
1. 实际上正片（如 E01–E25）已经全部成功识别并入库，但用户手机/消息渠道会批量收到大量“整理失败：未识别到文件集数”的报错报警与强弹窗。
2. 用户误以为整体资源入库失败，反复尝试重试（`/redo`）。

### 解决方案 (Solution)

在 `transhandler.py` 的电视剧单文件整理逻辑中，当 `in_meta.begin_episode is None` 时：
1. 增加了对特典/附加视频文件（Special / Extra Sample Video Files）的识别正则：
   匹配常见的特典/附加标识（`NCOP`, `NCED`, `OP`, `ED`, `MENU`, `PV`, `CM`, `TRAILER`, `TV SPOT`, `SP`, `OVA`, `OAD`, `EVENT`, `IV`, `INTERVIEW`, `LOGO`, `PRODUCER LOGO`, `BEHIND THE SCENES`, `FEATURETTE` 等）。
2. 若匹配为特典/附加文件：
   - 记录一条提示级别的日志：`logger.info(f"文件 {fileitem.path} 未识别到文件集数，识别为特典/附加视频文件，跳过正片集数整理")`
   - 将结果置为成功 (`success=True`) 且关闭错误推送通知 (`need_notify=False`)。

### 影响范围与测试 (Testing & Safety)

- **影响范围**：仅影响 `MediaType.TV` 且 `begin_episode is None` 的无集数文件分支。正常的正片集数整理逻辑保持完全一致。
- **测试验证**：已在实际 BD-BOX（如《妄想学生会》、《天国大魔境》、《无头骑士异闻录》、《忍者杀手》等包含几十个 NCOP/NCED/Menu/Event 的实际打包样本）中验证，有效地消除了无意义的报错通知弹窗。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at b732cad32ad8dd48739c8f2f6a936d0fb4f4a166

- 识别无集数的剧集特典视频
- 跳过正片整理并抑制失败通知
- 以 INFO 日志记录处理结果
- 未新增自动化测试；正则可能误匹配
<!-- pr-agent-summary:end -->
