### PR TITLE
fix(v3): 修复 Docker 资源下载分支

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -104,11 +104,11 @@ RUN FRONTEND_VERSION=$(sed -n "s/^FRONTEND_VERSION\s*=\s*'\([^']*\)'/\1/p" /app/
     && mv -f /tmp/MoviePilot-Plugins-main/plugins.v2/* /app/app/plugins/ \
     && cat /tmp/MoviePilot-Plugins-main/package.json | jq -r 'to_entries[] | select(.value.v2 == true) | .key' | awk '{print tolower($0)}' | \
     while read -r i; do if [ ! -d "/app/app/plugins/$i" ]; then mv "/tmp/MoviePilot-Plugins-main/plugins/$i" "/app/app/plugins/"; else echo "跳过 $i"; fi; done \
-    && curl -fsSL "https://raw.githubusercontent.com/jxxghp/MoviePilot-Resources/v3/resources.v3/user.sites.v3.bin" -o /app/app/helper/user.sites.v3.bin \
+    && curl -fsSL "https://raw.githubusercontent.com/jxxghp/MoviePilot-Resources/main/resources.v3/user.sites.v3.bin" -o /app/app/helper/user.sites.v3.bin \
     && python_ver=$(python3 -c 'import sys; print(f"cpython-{sys.version_info.major}{sys.version_info.minor}")') \
     && ARCH=$(uname -m) \
     && if [ "$ARCH" = "aarch64" ]; then SUFFIX="aarch64-linux-gnu"; else SUFFIX="x86_64-linux-gnu"; fi \
-    && curl -fsSL "https://raw.githubusercontent.com/jxxghp/MoviePilot-Resources/v3/resources.v3/sites.${python_ver}-${SUFFIX}.so" -o "/app/app/helper/sites.${python_ver}-${SUFFIX}.so"
+    && curl -fsSL "https://raw.githubusercontent.com/jxxghp/MoviePilot-Resources/main/resources.v3/sites.${python_ver}-${SUFFIX}.so" -o "/app/app/helper/sites.${python_ver}-${SUFFIX}.so"
 
 # final 阶段: 安装运行时依赖和配置最终镜像
 FROM prepare_package AS final


### PR DESCRIPTION
## 修改内容

- 将 V3 Dockerfile 中两处 MoviePilot-Resources 下载地址由 `v3/resources.v3` 调整为实际已经发布的 `main/resources.v3`。
- 修复 V3 Docker 镜像构建时下载站点资源返回 HTTP 404 的问题。

## 问题原因

当前 `MoviePilot/v3` 分支的 Dockerfile 从以下地址下载资源：

- `MoviePilot-Resources/v3/resources.v3/user.sites.v3.bin`
- `MoviePilot-Resources/v3/resources.v3/sites.*.so`

但 `MoviePilot-Resources` 仓库目前只有 `main` 分支，V3 资源实际发布在 `main/resources.v3`。因此 `build-v3` 工作流在执行 `curl -fsSL` 时收到 HTTP 404，并以退出码 22 终止。

失败的构建记录：<https://github.com/jxxghp/MoviePilot/actions/runs/31243554428>

## 影响

该问题会阻断完整 V3 Docker 镜像的构建和发布，使按照 V3 Docker 文档部署的用户无法获得包含前端与后端的完整镜像。

## 分支策略说明

本修改沿用 V2 Dockerfile 的现有方式，从 `MoviePilot-Resources/main` 下的版本化目录下载资源。

如果维护计划是为 `MoviePilot-Resources` 单独建立并长期维护 `v3` 分支，也可以保留当前 Dockerfile 地址，并在资源仓库补建对应分支。烦请维护者确认后续希望采用的资源版本管理方式。

## 验证

- 确认 `main/resources.v3` 下所需的 amd64 资源文件均可正常下载。
- 使用修改后的 Dockerfile 成功完成 `linux/amd64` 完整镜像构建。
- 镜像内 CLI、后端和前端服务版本均为 `v3.0.0`。
- 容器健康检查通过，前端首页及 `/api/v1/login/wallpapers` 接口均可正常访问。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 1cdb159329985d005f7a4bac8e3fb0f5e6eb6146

- 修正 Docker 构建资源下载分支
- 从 `main/resources.v3` 获取 V3 资源
- 恢复站点数据及架构模块下载
- 未新增自动化测试；需验证镜像构建
<!-- pr-agent-summary:end -->
