### PR TITLE
feat: 支持配置音乐封面代理地址

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -226,6 +226,10 @@ class ConfigModel(BaseModel):
     # TMDB API Key
     TMDB_API_KEY: str = "db55323b8d3e4154498498a75642b381"
 
+    # ==================== 音乐配置 ====================
+    # 音乐封面代理地址（用于解决 coverartarchive.org 无法访问导致的封面不显示问题，留空则使用官方地址）
+    MUSIC_COVER_PROXY: str = ""
+
     # ==================== TVDB配置 ====================
     # TVDB API Key
     TVDB_V4_API_KEY: str = "ed2aa66b-7899-4677-92a7-67bc9ce3d93a"

--- a/app/modules/listenbrainz/__init__.py
+++ b/app/modules/listenbrainz/__init__.py
@@ -243,7 +243,7 @@ class ListenBrainzModule(_ModuleBase):
             album_artist=artist_name or None,
             album_id=str(media_id),
             cover_url=cls._release_cover(release_group.get("caa_release_mbid"))
-            or f"{cls._release_group_cover_url}/{media_id}/front-500",
+            or cls._release_group_cover(media_id),
             names=[str(title)],
             detail_link=f"{cls._album_detail_url}/{media_id}",
             listen_count=cls._optional_int(release_group.get("listen_count")),
@@ -277,7 +277,7 @@ class ListenBrainzModule(_ModuleBase):
             year=cls._year(release_date),
             release_date=release_date,
             cover_url=cls._release_cover(release.get("caa_release_mbid"))
-            or f"{cls._release_group_cover_url}/{media_id}/front-500",
+            or cls._release_group_cover(media_id),
             category=" / ".join(str(part) for part in category_parts if part),
             genres=[str(tag) for tag in release.get("release_tags") or [] if tag],
             names=[str(title)],
@@ -289,7 +289,20 @@ class ListenBrainzModule(_ModuleBase):
     @classmethod
     def _release_cover(cls, release_mbid: Any) -> Optional[str]:
         """根据发行版本 ID 构造 Cover Art Archive 封面地址。"""
-        return f"{cls._release_cover_url}/{release_mbid}/front-500" if release_mbid else None
+        if not release_mbid:
+            return None
+        # 支持配置音乐封面代理地址，解决 coverartarchive.org 无法访问的问题
+        base = settings.MUSIC_COVER_PROXY or "https://coverartarchive.org"
+        return f"{base}/release/{release_mbid}/front-500"
+
+    @classmethod
+    def _release_group_cover(cls, release_group_id: Any) -> Optional[str]:
+        """根据 Release Group ID 构造 Cover Art Archive 封面地址。"""
+        if not release_group_id:
+            return None
+        # 支持配置音乐封面代理地址，解决 coverartarchive.org 无法访问的问题
+        base = settings.MUSIC_COVER_PROXY or "https://coverartarchive.org"
+        return f"{base}/release-group/{release_group_id}/front-500"
 
     @staticmethod
     def _primary_artist_ids(artist_mbids: Any) -> list[str]:

--- a/app/modules/listenbrainz/__init__.py
+++ b/app/modules/listenbrainz/__init__.py
@@ -292,7 +292,7 @@ class ListenBrainzModule(_ModuleBase):
         if not release_mbid:
             return None
         # 支持配置音乐封面代理地址，解决 coverartarchive.org 无法访问的问题
-        base = settings.MUSIC_COVER_PROXY or "https://coverartarchive.org"
+        base = (settings.MUSIC_COVER_PROXY or "https://coverartarchive.org").rstrip("/")
         return f"{base}/release/{release_mbid}/front-500"
 
     @classmethod
@@ -301,7 +301,7 @@ class ListenBrainzModule(_ModuleBase):
         if not release_group_id:
             return None
         # 支持配置音乐封面代理地址，解决 coverartarchive.org 无法访问的问题
-        base = settings.MUSIC_COVER_PROXY or "https://coverartarchive.org"
+        base = (settings.MUSIC_COVER_PROXY or "https://coverartarchive.org").rstrip("/")
         return f"{base}/release-group/{release_group_id}/front-500"
 
     @staticmethod

--- a/app/modules/musicbrainz/__init__.py
+++ b/app/modules/musicbrainz/__init__.py
@@ -675,7 +675,9 @@ class MusicBrainzModule(_ModuleBase):
         """根据 Release Group ID 构造 Cover Art Archive 封面地址。"""
         if not release_group_id:
             return None
-        return f"{cls._cover_url}/{release_group_id}/front-500"
+        # 支持配置音乐封面代理地址，解决 coverartarchive.org 无法访问的问题
+        base = settings.MUSIC_COVER_PROXY or "https://coverartarchive.org"
+        return f"{base}/release-group/{release_group_id}/front-500"
 
     @classmethod
     def _wait_for_rate_limit(cls) -> None:

--- a/app/modules/musicbrainz/__init__.py
+++ b/app/modules/musicbrainz/__init__.py
@@ -676,7 +676,7 @@ class MusicBrainzModule(_ModuleBase):
         if not release_group_id:
             return None
         # 支持配置音乐封面代理地址，解决 coverartarchive.org 无法访问的问题
-        base = settings.MUSIC_COVER_PROXY or "https://coverartarchive.org"
+        base = (settings.MUSIC_COVER_PROXY or "https://coverartarchive.org").rstrip("/")
         return f"{base}/release-group/{release_group_id}/front-500"
 
     @classmethod


### PR DESCRIPTION
新增 MUSIC_COVER_PROXY 配置项，用于解决 coverartarchive.org 无法访问导致的音乐探索封面不显示问题。

## 改动内容
- `config.py`: 新增 MUSIC_COVER_PROXY 配置项（音乐封面代理地址）
- `musicbrainz`: 封面 URL 生成时读取 MUSIC_COVER_PROXY
- `listenbrainz`: 封面 URL 生成时读取 MUSIC_COVER_PROXY

## 说明
- 未配置时使用默认的 coverartarchive.org 地址
- 配置后使用自定义代理地址加载音乐封面
- 参考 TMDB_IMAGE_DOMAIN 的配置方式

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 8d0cc9cf857db74c378fe1ea885ace16f9664e6d

- 新增音乐封面代理配置项
- MusicBrainz 和 ListenBrainz 使用代理地址
- 统一发行版与发行组封面路径
- 自动移除代理地址尾部斜杠
- 未新增测试；代理可用性待验证
<!-- pr-agent-summary:end -->
