### PR TITLE
fix(agent): preserve episode lock on unchanged totals

### DIFF
--- a/app/agent/tools/impl/query_subscribes.py
+++ b/app/agent/tools/impl/query_subscribes.py
@@ -213,6 +213,8 @@ class QuerySubscribesTool(MoviePilotTool):
                     ).model_dump(
                         include=set(QUERY_SUBSCRIBE_OUTPUT_FIELDS), exclude_none=True
                     )
+                    # 手动总集数是运行锁状态，不属于公共订阅写入 Schema，查询时直接从实体读取。
+                    payload["manual_total_episode"] = subscribe.manual_total_episode or 0
                     payload["type"] = media_type_to_agent(payload.get("type"))
                     if payload["type"] == "music" and not payload.get("music_type"):
                         payload["music_type"] = "recording"

--- a/app/agent/tools/impl/update_subscribe.py
+++ b/app/agent/tools/impl/update_subscribe.py
@@ -221,7 +221,7 @@ class UpdateSubscribeTool(MoviePilotTool):
                 subscribe_dict["season"] = season
 
             # 集数相关
-            if total_episode is not None:
+            if total_episode is not None and total_episode != subscribe.total_episode:
                 subscribe_dict["total_episode"] = total_episode
                 # 如果总集数增加，缺失集数也要相应增加
                 if total_episode > (subscribe.total_episode or 0):
@@ -346,6 +346,7 @@ class UpdateSubscribeTool(MoviePilotTool):
                     "season": updated_subscribe.season,
                     "state": updated_subscribe.state,
                     "total_episode": updated_subscribe.total_episode,
+                    "manual_total_episode": updated_subscribe.manual_total_episode,
                     "lack_episode": updated_subscribe.lack_episode,
                     "start_episode": updated_subscribe.start_episode,
                     "quality": updated_subscribe.quality,

--- a/tests/test_agent_query_subscribes.py
+++ b/tests/test_agent_query_subscribes.py
@@ -1,0 +1,35 @@
+import asyncio
+import json
+from unittest.mock import patch
+
+from app.agent.tools.impl.query_subscribes import QuerySubscribesTool
+from app.db.models.subscribe import Subscribe
+from app.schemas.types import MediaType
+
+
+def test_agent_query_subscribes_returns_manual_total_episode():
+    """订阅查询应返回手动总集数标记，供 Agent 判断元数据是否可自动刷新。"""
+    subscribe = Subscribe(
+        id=160,
+        name="测试剧集",
+        type=MediaType.TV.value,
+        tmdbid=224839,
+        season=1,
+        total_episode=175,
+        manual_total_episode=1,
+        state="P",
+    )
+
+    with patch(
+        "app.agent.tools.impl.query_subscribes.SubscribeOper.async_list",
+        return_value=[subscribe],
+    ):
+        result = asyncio.run(
+            QuerySubscribesTool(session_id="session-1", user_id="10001").run(
+                tmdb_id=224839,
+            )
+        )
+
+    _, result_json = result.split("\n\n", maxsplit=1)
+    payload = json.loads(result_json)
+    assert payload[0]["manual_total_episode"] == 1

--- a/tests/test_agent_update_subscribe.py
+++ b/tests/test_agent_update_subscribe.py
@@ -3,7 +3,7 @@ import json
 from unittest.mock import AsyncMock, patch
 
 from app.agent.tools.impl.update_subscribe import UpdateSubscribeTool
-from app.schemas.types import EventType
+from app.schemas.types import EventType, MediaType
 
 
 def test_agent_update_subscribe_sends_modified_event_payload_with_agent_scene():
@@ -39,6 +39,120 @@ def test_agent_update_subscribe_sends_modified_event_payload_with_agent_scene():
     assert event_payload["fields"] == ["name", "state"]
     assert event_payload["old_subscribe_info"]["name"] == "旧标题"
     assert event_payload["subscribe_info"]["name"] == "新标题"
+
+
+def test_agent_update_subscribe_ignores_unchanged_total_episode():
+    """Agent 回传相同总集数时，不应产生数据库写入或订阅调整事件。"""
+    subscribe = _AgentSubscribe(
+        id=160,
+        name="测试剧集",
+        type=MediaType.TV.value,
+        state="R",
+        total_episode=175,
+        lack_episode=0,
+        manual_total_episode=0,
+    )
+    oper = _SubscribeOperStub(subscribe)
+
+    with patch(
+        "app.agent.tools.impl.update_subscribe.SubscribeOper",
+        return_value=oper,
+    ), patch(
+        "app.agent.tools.impl.update_subscribe.eventmanager.async_send_event",
+        new=AsyncMock(),
+    ) as send_event:
+        result = asyncio.run(
+            UpdateSubscribeTool(session_id="session-1", user_id="10001").run(
+                subscribe_id=160,
+                total_episode=175,
+            )
+        )
+
+    payload = json.loads(result)
+    assert payload == {"success": False, "message": "没有提供要更新的字段"}
+    assert oper.updates == []
+    send_event.assert_not_awaited()
+
+
+def test_agent_update_subscribe_only_updates_other_fields_with_unchanged_total_episode():
+    """Agent 同时回传相同总集数和洗版设置时，只更新实际请求的其他字段。"""
+    subscribe = _AgentSubscribe(
+        id=160,
+        name="测试剧集",
+        type=MediaType.TV.value,
+        state="R",
+        total_episode=175,
+        lack_episode=0,
+        manual_total_episode=0,
+        best_version=0,
+    )
+    oper = _SubscribeOperStub(subscribe)
+
+    with patch(
+        "app.agent.tools.impl.update_subscribe.SubscribeOper",
+        return_value=oper,
+    ), patch(
+        "app.agent.tools.impl.update_subscribe.eventmanager.async_send_event",
+        new=AsyncMock(),
+    ) as send_event:
+        result = asyncio.run(
+            UpdateSubscribeTool(session_id="session-1", user_id="10001").run(
+                subscribe_id=160,
+                total_episode=175,
+                best_version=1,
+            )
+        )
+
+    payload = json.loads(result)
+    assert payload["success"] is True
+    assert payload["updated_fields"] == ["best_version"]
+    assert payload["subscribe"]["manual_total_episode"] == 0
+    assert oper.updates == [(160, {"best_version": 1})]
+    send_event.assert_awaited_once()
+    _, event_payload = send_event.await_args.args
+    assert event_payload["fields"] == ["best_version"]
+
+
+def test_agent_update_subscribe_marks_changed_total_episode_as_manual():
+    """Agent 真正修改总集数时，保持 Web API 的手动总集数语义。"""
+    subscribe = _AgentSubscribe(
+        id=160,
+        name="测试剧集",
+        type=MediaType.TV.value,
+        state="R",
+        total_episode=175,
+        lack_episode=0,
+        manual_total_episode=0,
+    )
+    oper = _SubscribeOperStub(subscribe)
+
+    with patch(
+        "app.agent.tools.impl.update_subscribe.SubscribeOper",
+        return_value=oper,
+    ), patch(
+        "app.agent.tools.impl.update_subscribe.eventmanager.async_send_event",
+        new=AsyncMock(),
+    ):
+        result = asyncio.run(
+            UpdateSubscribeTool(session_id="session-1", user_id="10001").run(
+                subscribe_id=160,
+                total_episode=190,
+            )
+        )
+
+    payload = json.loads(result)
+    assert payload["success"] is True
+    assert payload["subscribe"]["manual_total_episode"] == 1
+    assert oper.updates == [
+        (
+            160,
+            {
+                "total_episode": 190,
+                "lack_episode": 15,
+                "manual_total_episode": 1,
+            },
+        )
+    ]
 
 
 class _AgentSubscribe:


### PR DESCRIPTION
## 问题与背景

Agent 更新订阅洗版等设置时，可能同时回传数据库中已有的 `total_episode`。普通 Web API 只有在总集数实际变化时才标记手动总集数，但 Agent 工具此前只要收到该参数，就会写入 `manual_total_episode=1`，导致原本跟随元数据刷新的订阅被意外锁定。

同时，Agent 的订阅查询和更新结果没有返回 `manual_total_episode`，无法核对当前锁定状态或操作后的最终值。

## 原因分析

`update_subscribe` 只判断 `total_episode` 是否传入，没有像 Web API 一样比较新旧值。因此，相同总集数也会进入写入分支，并附带设置手动标记。

`query_subscribes` 和 `update_subscribe` 的输出字段均遗漏了数据库中已有的手动总集数状态。

## 解决方案

- 仅当 `total_episode` 与当前订阅值不同时，才更新总集数、调整缺失集数并设置 `manual_total_episode=1`。
- 相同总集数与其他设置一起提交时，只更新其他设置；没有其他更新字段时，不写数据库，也不发送订阅调整事件。
- 在订阅查询和更新结果中返回最终的 `manual_total_episode`，保留数据库原始值用于诊断。
- 增加回归测试，覆盖相同总集数、洗版联动、真实总集数变更和查询输出。

## 影响与风险

改动仅影响 Agent 订阅工具。真正修改总集数时仍保持原有行为，会同步调整缺失集数并进入手动总集数模式；普通 Web API、订阅刷新链路、数据库结构和插件均不受影响。

现有历史锁值不会被自动清理，不需要数据迁移或配置变更。

## 验证

- `python tests/run.py`：2896 passed, 1 skipped
- `python -m pylint app`：10.00/10
- Agent 工具测试：402 passed
- `git diff --check`：通过

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 496256c426849053cb7eb855e02a2cb189eb84af

- 相同总集数不再锁定手动集数
- 查询和更新返回锁定状态
- 补充 Agent 订阅回归测试
- 兼容既有订阅与事件行为
<!-- pr-agent-summary:end -->
