### PR TITLE
fix(agent): 完善 AI Agent 设置分组查询

### DIFF
--- a/app/agent/tools/impl/_system_setting_utils.py
+++ b/app/agent/tools/impl/_system_setting_utils.py
@@ -226,13 +226,36 @@ GROUP_ALIASES = {
 }
 
 
+# 这些前缀共同组成可启动、推理和扩展 AI Agent 的同一业务配置域。
+AI_AGENT_CORE_SETTING_PREFIXES = (
+    "AI_AGENT_",
+    "LLM_",
+    "AUDIO_INPUT_",
+    "AUDIO_OUTPUT_",
+    "AI_RECOMMEND_",
+)
+
+
 def _normalize_token(value: str) -> str:
     return str(value).strip().lower().replace("-", "_")
 
 
+def _resolve_core_setting_group(key: str) -> str:
+    """根据基础设置的业务归属返回 Agent 可查询的分类。"""
+
+    if key.startswith(AI_AGENT_CORE_SETTING_PREFIXES):
+        return "ai_agent"
+    return "settings"
+
+
 def _build_specs() -> tuple[dict[str, SettingSpec], dict[str, SettingSpec]]:
     core_specs = {
-        key: SettingSpec(key=key, source="settings", group="settings", label=key)
+        key: SettingSpec(
+            key=key,
+            source="settings",
+            group=_resolve_core_setting_group(key),
+            label=key,
+        )
         for key in Settings.model_fields.keys()
     }
     system_specs = {}
@@ -263,7 +286,7 @@ SINGLE_KEY_GROUP_ALIASES = {
     _normalize_token(alias): next(
         (
             spec.key
-            for spec in SYSTEMCONFIG_SETTING_SPECS.values()
+            for spec in ALL_SETTING_SPECS.values()
             if spec.group == canonical_group
         ),
         None,
@@ -273,7 +296,7 @@ SINGLE_KEY_GROUP_ALIASES = {
     and len(
         [
             spec.key
-            for spec in SYSTEMCONFIG_SETTING_SPECS.values()
+            for spec in ALL_SETTING_SPECS.values()
             if spec.group == canonical_group
         ]
     )
@@ -324,7 +347,7 @@ def list_setting_specs(
     else:
         specs = [
             spec
-            for spec in SYSTEMCONFIG_SETTING_SPECS.values()
+            for spec in ALL_SETTING_SPECS.values()
             if spec.group == normalized_group
         ]
 

--- a/app/agent/tools/impl/query_system_settings.py
+++ b/app/agent/tools/impl/query_system_settings.py
@@ -28,7 +28,7 @@ class QuerySystemSettingsInput(BaseModel):
         description=(
             "Exact setting key to query. Supports Settings field names like 'APP_DOMAIN' or 'TMDB_API_KEY', "
             "SystemConfigKey values like 'Downloaders' or 'MediaServers', enum names, and some single-key aliases "
-            "such as 'downloaders', 'directories', 'search_sites', 'subscribe_sites', 'site_auth', 'ai_agent', "
+            "such as 'downloaders', 'directories', 'search_sites', 'subscribe_sites', 'site_auth', "
             "and 'custom_identifiers'."
         ),
     )

--- a/tests/test_agent_system_settings_tools.py
+++ b/tests/test_agent_system_settings_tools.py
@@ -3,10 +3,11 @@ import json
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from app.agent.tools.impl._system_setting_utils import list_setting_specs
 from app.agent.tools.impl.query_system_settings import QuerySystemSettingsTool
 from app.agent.tools.impl.update_system_settings import UpdateSystemSettingsTool
 from app.agent.tools.manager import MoviePilotToolsManager
-from app.core.config import settings
+from app.core.config import Settings, settings
 from app.schemas.types import SystemConfigKey
 
 
@@ -96,6 +97,61 @@ class TestAgentSystemSettingsTools(unittest.TestCase):
         self.assertTrue(payload["success"])
         self.assertFalse(payload["include_values"])
         self.assertGreater(payload["matched_count"], 1)
+
+    def test_settings_group_retains_all_basic_settings(self):
+        """settings 分组应继续完整列出基础 Settings 字段。"""
+        specs = list_setting_specs(group="settings")
+
+        self.assertSetEqual(
+            {spec.key for spec in specs},
+            set(Settings.model_fields),
+        )
+        self.assertTrue(all(spec.source == "settings" for spec in specs))
+
+    def test_query_system_settings_ai_agent_group_spans_both_setting_sources(self):
+        """AI Agent 分组应同时返回基础运行配置和 SystemConfig 扩展配置。"""
+        tool = QuerySystemSettingsTool(session_id="session-1", user_id="10001")
+        expected_values = {
+            "AI_AGENT_ENABLE": True,
+            "LLM_PROVIDER": "openai",
+            "LLM_MODEL": "gpt-test",
+            "LLM_THINKING_LEVEL": "high",
+            "LLM_API_KEY": "llm-secret",
+            "AUDIO_INPUT_PROVIDER": "openai",
+            "AUDIO_OUTPUT_PROVIDER": "openai",
+            "AI_RECOMMEND_ENABLED": True,
+            "AIAgentConfig": {"chatgpt": {"enabled": True}},
+            "AIAgentMcpServers": [],
+        }
+
+        with patch.object(
+            QuerySystemSettingsTool,
+            "_load_setting_value",
+            side_effect=lambda spec: expected_values.get(spec.key),
+        ):
+            result = asyncio.run(
+                tool.run(group="ai_agent", include_values=True)
+            )
+
+        payload = json.loads(result)
+        items = {
+            item["setting_key"]: item
+            for item in payload["settings"]
+        }
+
+        self.assertTrue(payload["success"])
+        self.assertEqual(items["AI_AGENT_ENABLE"]["source"], "settings")
+        self.assertIs(items["AI_AGENT_ENABLE"]["value"], True)
+        self.assertEqual(items["LLM_PROVIDER"]["value"], "openai")
+        self.assertEqual(items["LLM_MODEL"]["value"], "gpt-test")
+        self.assertEqual(items["LLM_THINKING_LEVEL"]["value"], "high")
+        self.assertTrue(items["LLM_API_KEY"]["redacted"])
+        self.assertEqual(items["LLM_API_KEY"]["value"], "***")
+        self.assertEqual(items["AUDIO_INPUT_PROVIDER"]["value"], "openai")
+        self.assertEqual(items["AUDIO_OUTPUT_PROVIDER"]["value"], "openai")
+        self.assertIs(items["AI_RECOMMEND_ENABLED"]["value"], True)
+        self.assertEqual(items["AIAgentConfig"]["source"], "systemconfig")
+        self.assertEqual(items["AIAgentMcpServers"]["source"], "systemconfig")
 
     def test_update_system_settings_merges_dict_and_emits_event(self):
         tool = UpdateSystemSettingsTool(session_id="session-1", user_id="10001")


### PR DESCRIPTION
## 问题与背景

Agent 在确认自身启用状态、LLM 提供商、模型和思考级别时，会使用 `query_system_settings` 的 `ai_agent` 分组。该分组此前只返回 `AIAgentConfig` 和 `AIAgentMcpServers`，未包含基础 Settings 中的 Agent、LLM、音频和 AI 推荐配置，导致 Agent 即使执行了正确的分组查询，仍可能把当前运行状态标记为“未验证”。

## 原因分析

基础 Settings 的设置定义全部固定归入 `settings`，而业务分类查询只从 SystemConfig 设置定义中筛选。因此 `ai_agent` 这类跨 Settings 与 SystemConfig 的业务分组无法返回完整配置。工具参数说明还将多键 `ai_agent` 分组列在单键别名示例中，与实际解析语义不一致。

## 解决方案

- 将 `AI_AGENT_*`、`LLM_*`、`AUDIO_INPUT_*`、`AUDIO_OUTPUT_*` 和 `AI_RECOMMEND_*` 基础设置归入 `ai_agent` 业务分类。
- 业务分类从全部设置定义中筛选，使同一分组可以跨 Settings 与 SystemConfig 返回结果。
- 单键分类别名基于全部设置定义判定，避免跨来源的多键分组被误当作单键。
- 保留 `group="settings"` 返回全部基础 Settings 的原有集合语义，并保持精确键查询、设置写入和脱敏逻辑不变。
- 修正 `setting_key` 参数说明，并增加跨来源、音频输入输出、敏感值脱敏和兼容语义回归测试。

## 影响与风险

改动仅影响系统设置查询工具的业务分组元数据和筛选范围。`ai_agent` 分组会返回更多与 Agent 运行直接相关的设置；精确键查询、SystemConfig 分组、设置写入、管理员权限和敏感值脱敏不变。无需配置迁移或数据迁移。

## 验证

- `python -m pytest tests/test_agent_system_settings_tools.py -q`：11 项通过。
- `tests/run.py`：2958 项通过，1 项跳过；测试期间无真实出站请求。
- `python -m pylint app`：10.00/10。
- `git diff --check`：通过。
- 只读 Agent 运行验证：一次 `ai_agent` 分组查询即可确认启用状态、提供商、模型和思考级别，敏感设置保持脱敏。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 075e487ada38bd9f18c425c61d04310b6f138aa9

- 扩展 `ai_agent` 分组覆盖核心运行设置
- 支持跨 `Settings` 与 `SystemConfig` 查询
- 保持 `settings` 分组完整兼容语义
- 增加脱敏与跨来源查询回归测试
<!-- pr-agent-summary:end -->
