### PR TITLE
test(music): isolate external calls in workflow tests

### DIFF
--- a/tests/test_music_scrape.py
+++ b/tests/test_music_scrape.py
@@ -80,14 +80,27 @@ def test_album_directory_scrape_processes_each_track_and_reuses_cover() -> None:
     )
     album = _album_info()
 
-    success, message = chain.scrape_music_metadata(
-        FileItem(storage="local", path="/music/叶惠美", type="dir", name="叶惠美"),
-        mediainfo=album,
-    )
+    with patch(
+        "app.chain.scraping.MediaChain.get_music_album",
+        return_value=None,
+    ) as get_music_album:
+        success, message = chain.scrape_music_metadata(
+            FileItem(
+                storage="local",
+                path="/music/叶惠美",
+                type="dir",
+                name="叶惠美",
+            ),
+            mediainfo=album,
+        )
 
     assert success is True
     assert message == "已刮削 2 个音频文件"
     chain._download_music_cover.assert_called_once_with(album.cover_url)
+    get_music_album.assert_called_once_with(
+        media_source=album.media_source,
+        media_id=album.media_id,
+    )
     assert chain._scrape_music_file.call_count == 2
     assert all(
         call.args[1] is album and call.kwargs["cover"] == (b"cover", "image/jpeg")

--- a/tests/test_music_workflows.py
+++ b/tests/test_music_workflows.py
@@ -361,7 +361,8 @@ def test_media_chain_default_recognition_only_queries_musicbrainz(monkeypatch):
     recognize_source = Mock(return_value=expected)
     monkeypatch.setattr(chain, "recognize_music_from_source", recognize_source)
 
-    result = chain.recognize_media(meta=meta)
+    with patch("app.chain.MoviePilotServerHelper.report_recognize_share"):
+        result = chain.recognize_media(meta=meta)
 
     assert result is expected
     recognize_source.assert_called_once_with(
@@ -408,7 +409,11 @@ def test_default_recognition_does_not_fallback_after_musicbrainz_miss(monkeypatc
     recognize_source = Mock(return_value=None)
     monkeypatch.setattr(chain, "recognize_music_from_source", recognize_source)
 
-    assert chain.recognize_media(meta=meta) is None
+    with patch(
+        "app.chain.MoviePilotServerHelper.query_recognize_share",
+        return_value=None,
+    ):
+        assert chain.recognize_media(meta=meta) is None
     recognize_source.assert_called_once()
     assert recognize_source.call_args.kwargs["media_source"] == MediaSource.MusicBrainz
 


### PR DESCRIPTION
## 问题与背景

最新 `v3` 的音乐测试会在执行过程中访问 MusicBrainz 与 MoviePilot Server，触发测试套件的零真实出站保护，导致三个与网络无关的业务用例失败。

## 原因分析

相关生产路径增加了专辑详情查询、识别结果上报和共享识别查询，但原测试仍只 mock 旧有的核心调用。测试关注的是目录逐曲刮削、封面复用以及默认 MusicBrainz 路由，不应依赖外部服务。

## 解决方案

- 专辑目录刮削测试隔离专辑详情查询，并断言同一专辑只查询一次且身份参数正确。
- 同步音乐识别测试分别隔离共享结果上报与共享查询未命中路径。
- 保留原有逐曲处理、封面复用、默认来源和返回结果断言。

## 影响与风险

仅修改测试，不改变生产代码或运行时行为。Mock 限定在各用例上下文内，不会污染其他测试；共享识别行为仍由其专门测试覆盖。

## 验证

- 三个回归用例：`3 passed`
- 后端全量测试：`3462 passed, 1 skipped`
- `python -m pylint app`：`10.00/10`
- `python -m py_compile tests/test_music_scrape.py tests/test_music_workflows.py`
- `git diff --check`

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 684de08a887aaa025acfe9b7747511c747642e5f

- 隔离音乐工作流的外部服务调用
- Mock 专辑详情与共享识别接口
- 补充调用参数及次数断言
- 不改变生产代码和运行时行为
<!-- pr-agent-summary:end -->
