### PR TITLE
fix(storage): u115 上传凭证过期时自动刷新重试，修复大文件入库反复失败

### DIFF
--- a/app/modules/filemanager/storages/u115.py
+++ b/app/modules/filemanager/storages/u115.py
@@ -751,6 +751,25 @@ class U115Pan(StorageBase, metaclass=WeakSingleton):
             object_name, params={"encoding-type": "url", "sequential": ""}
         ).upload_id
         parts = []
+
+        def refresh_upload_bucket() -> oss2.Bucket:
+            """
+            上传凭证过期时重新获取 115 上传凭证并重建 OSS Bucket。
+            """
+            token_resp = self._request_api("GET", "/open/upload/get_token", "data")
+            if not token_resp:
+                raise Exception("【115】重新获取上传凭证失败")
+            logger.info("【115】已重新获取上传凭证，继续上传")
+            return oss2.Bucket(
+                oss2.StsAuth(
+                    access_key_id=token_resp.get("AccessKeyId"),
+                    access_key_secret=token_resp.get("AccessKeySecret"),
+                    security_token=token_resp.get("SecurityToken"),
+                ),
+                token_resp.get("endpoint"),
+                bucket_name,
+            )
+
         # 逐个上传分片
         with open(local_path, "rb") as fileobj:
             part_number = 1
@@ -764,12 +783,28 @@ class U115Pan(StorageBase, metaclass=WeakSingleton):
                 logger.info(
                     f"【115】开始上传 {target_name} 分片 {part_number}: {offset} -> {offset + num_to_upload}"
                 )
-                result = bucket.upload_part(
-                    object_name,
-                    upload_id,
-                    part_number,
-                    data=SizedFileAdapter(fileobj, num_to_upload),
-                )
+                retries = 0
+                while True:
+                    try:
+                        # 失败重试时确保从分片起始位置重新读取
+                        fileobj.seek(offset)
+                        result = bucket.upload_part(
+                            object_name,
+                            upload_id,
+                            part_number,
+                            data=SizedFileAdapter(fileobj, num_to_upload),
+                        )
+                        break
+                    except oss2.exceptions.OssError as e:
+                        # 上传凭证过期时重新获取凭证并重试当前分片（最多重试 5 次）
+                        if e.status == 403 and e.code == "SecurityTokenExpired" and retries < 5:
+                            retries += 1
+                            logger.warn(
+                                f"【115】上传凭证已过期，重新获取凭证后重试 {target_name} 分片 {part_number}（第 {retries} 次）"
+                            )
+                            bucket = refresh_upload_bucket()
+                            continue
+                        raise
                 parts.append(PartInfo(part_number, result.etag))
                 logger.info(f"【115】{target_name} 分片 {part_number} 上传完成")
                 offset += num_to_upload
@@ -788,9 +823,23 @@ class U115Pan(StorageBase, metaclass=WeakSingleton):
             "x-oss-forbid-overwrite": "false",
         }
         try:
-            result = bucket.complete_multipart_upload(
-                object_name, upload_id, parts, headers=headers
-            )
+            retries = 0
+            while True:
+                try:
+                    result = bucket.complete_multipart_upload(
+                        object_name, upload_id, parts, headers=headers
+                    )
+                    break
+                except oss2.exceptions.OssError as e:
+                    # 上传凭证过期时重新获取凭证后重试完成上传（最多重试 5 次）
+                    if e.status == 403 and e.code == "SecurityTokenExpired" and retries < 5:
+                        retries += 1
+                        logger.warn(
+                            f"【115】上传凭证已过期，重新获取凭证后重试完成上传（第 {retries} 次）"
+                        )
+                        bucket = refresh_upload_bucket()
+                        continue
+                    raise
             if result.status != 200:
                 logger.warn(f"【115】{target_name} 上传失败，错误码: {result.status}")
                 return None


### PR DESCRIPTION
### 关联 Issue

Fixes #6295

### 问题描述

115 网盘存储上传大文件时，分片上传全程复用首次获取的 OSS 上传凭证（有效期约 30~60 分钟）。上传耗时超过凭证有效期后，剩余分片及 complete_multipart_upload 均返回 403 `SecurityTokenExpired`，导致大文件（如 30G+ BDMV 原盘）入库反复失败。

### 修复方案

1. 分片上传遇到 `SecurityTokenExpired` 时，重新调用 `/open/upload/get_token` 获取凭证并重建 OSS Bucket，从分片起始位置（`fileobj.seek(offset)`）重试当前分片，最多重试 5 次，避免文件位置错乱
2. `complete_multipart_upload` 凭证过期时同样刷新凭证后重试

### 验证

- `py_compile` 语法校验通过
- 补丁已在本地环境实际应用，30G+ BDMV 原盘经 MoviePilot copy 到 115 上传场景验证通过

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 553af12eacf87e3636c398bb05e52b4c7bd870ca

- 刷新过期的 115 OSS 上传凭证
- 重试失败分片并重置文件偏移
- 完成分片合并时同样重试
- 最多重试五次，保留原始错误
<!-- pr-agent-summary:end -->
