### PR TITLE
修复登录响应不兼容功能级权限

### DIFF
--- a/app/schemas/token.py
+++ b/app/schemas/token.py
@@ -2,6 +2,8 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
+from app.schemas.user import UserPermissions
+
 
 class MfaChallenge(BaseModel):
     """密码认证通过后需要继续完成的二次验证信息。"""
@@ -28,7 +30,7 @@ class Token(BaseModel):
     # 权限级别
     level: int = 1
     # 详细权限
-    permissions: Optional[dict[str, bool]] = Field(default_factory=dict)
+    permissions: Optional[UserPermissions] = Field(default_factory=dict)
     # 是否显示配置向导
     wizard: Optional[bool] = None
 

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,8 +1,20 @@
 from typing import Optional
 
 from pydantic import BaseModel, Field, ConfigDict
+from typing_extensions import TypedDict
 
 from app.schemas.common import JsonData
+
+
+class UserPermissions(TypedDict, total=False):
+    """用户分类权限及可动态扩展的功能级权限。"""
+
+    discovery: bool  # 发现功能分类权限
+    search: bool  # 资源搜索分类权限
+    subscribe: bool  # 订阅管理分类权限
+    manage: bool  # 系统管理分类权限
+    admin: bool  # 管理员入口标识，实际授权仍由超级用户身份决定
+    features: dict[str, bool]  # 功能键到启用状态的映射
 
 
 # Shared properties
@@ -22,7 +34,7 @@ class UserBase(BaseModel):
     # 是否开启二次验证
     is_otp: Optional[bool] = False
     # 权限
-    permissions: Optional[dict[str, bool]] = Field(default_factory=dict)
+    permissions: Optional[UserPermissions] = Field(default_factory=dict)
     # 个性化设置
     settings: Optional[dict[str, JsonData]] = Field(default_factory=dict)
 
@@ -37,7 +49,7 @@ class UserCreate(UserBase):
     email: Optional[str] = None
     password: Optional[str] = None
     settings: Optional[dict[str, JsonData]] = Field(default_factory=dict)
-    permissions: Optional[dict[str, bool]] = Field(default_factory=dict)
+    permissions: Optional[UserPermissions] = Field(default_factory=dict)
 
 
 # Properties to receive via API on update
@@ -49,7 +61,7 @@ class UserUpdate(UserBase):
     email: Optional[str] = None
     password: Optional[str] = None
     settings: Optional[dict[str, JsonData]] = Field(default_factory=dict)
-    permissions: Optional[dict[str, bool]] = Field(default_factory=dict)
+    permissions: Optional[UserPermissions] = Field(default_factory=dict)
 
 
 class UserInDBBase(UserBase):

--- a/tests/test_api_authorization.py
+++ b/tests/test_api_authorization.py
@@ -174,7 +174,7 @@ def test_login_sets_resource_token_cookie(monkeypatch):
                 name=username,
                 is_superuser=False,
                 avatar="",
-                permissions={"discovery": True},
+                permissions={"discovery": True, "features": {}},
             )
 
     class FakeSystemConfigOper:
@@ -198,7 +198,7 @@ def test_login_sets_resource_token_cookie(monkeypatch):
     )
 
     assert token.user_id == 1
-    assert token.permissions == {"discovery": True}
+    assert token.permissions == {"discovery": True, "features": {}}
     assert "set-cookie" in response.headers
 
     resource_cookie = response.headers["set-cookie"].split("=", 1)[1].split(";", 1)[0]

--- a/tests/test_explicit_response_models.py
+++ b/tests/test_explicit_response_models.py
@@ -10,7 +10,7 @@ from app.schemas.subscribe import Subscribe
 from app.schemas.tmdb import TmdbEpisode
 from app.schemas.token import Token
 from app.schemas.types import MediaSource
-from app.schemas.user import User
+from app.schemas.user import User, UserCreate, UserUpdate
 
 
 def _nonnull_branch(schema: dict) -> dict:
@@ -80,8 +80,12 @@ def test_site_and_subscribe_legacy_values_remain_compatible():
 
 
 def test_permissions_and_extension_json_keep_values_but_have_explicit_schemas():
-    """权限映射应为布尔值，扩展数据应通过递归 JSON Schema 展示合法类型。"""
-    permissions = {"manage": True, "search": False}
+    """权限分类和功能映射应保持原值，扩展数据应展示合法 JSON 类型。"""
+    permissions = {
+        "manage": True,
+        "search": False,
+        "features": {"search.resource": False},
+    }
     token = Token(
         access_token="token",
         token_type="bearer",
@@ -95,6 +99,8 @@ def test_permissions_and_extension_json_keep_values_but_have_explicit_schemas():
         permissions=permissions,
         settings={"nickname": "测试", "layout": {"dense": True}},
     )
+    user_create = UserCreate(name="created", permissions={"features": {}})
+    user_update = UserUpdate(id=1, name="updated", permissions=permissions)
     plugin = Plugin(history={"v1.0.0": "首次发布"})
     dashboard = PluginDashboard(
         attrs={"class": ["pa-2", {"active": True}]},
@@ -103,14 +109,24 @@ def test_permissions_and_extension_json_keep_values_but_have_explicit_schemas():
     )
 
     assert token.model_dump()["permissions"] == permissions
+    assert user.model_dump()["permissions"] == permissions
+    assert user_create.model_dump()["permissions"] == {"features": {}}
+    assert user_update.model_dump()["permissions"] == permissions
     assert user.model_dump()["settings"]["layout"] == {"dense": True}
     assert plugin.model_dump()["history"] == {"v1.0.0": "首次发布"}
     assert dashboard.model_dump()["elements"][0]["component"] == "VAlert"
 
     user_schema = User.model_json_schema()
     permission_schema = _nonnull_branch(user_schema["properties"]["permissions"])
+    permission_schema = user_schema["$defs"][permission_schema["$ref"].rsplit("/", 1)[-1]]
     settings_schema = _nonnull_branch(user_schema["properties"]["settings"])
-    assert permission_schema["additionalProperties"] == {"type": "boolean"}
+    assert permission_schema["properties"]["manage"] == {
+        "title": "Manage",
+        "type": "boolean",
+    }
+    assert permission_schema["properties"]["features"]["additionalProperties"] == {
+        "type": "boolean"
+    }
     assert settings_schema["additionalProperties"]["$ref"].endswith("/JsonData")
 
 


### PR DESCRIPTION
## 问题

用户权限已支持 `features` 功能级权限映射，但 Token 和用户响应 Schema 将整个 `permissions` 声明为 `dict[str, bool]`。当已有用户包含 `permissions.features = {}` 时，密码认证虽然成功，登录接口仍会在构造 Token 响应时触发 Pydantic `bool_type` 校验错误并返回 500。

## 改动

- 新增结构化 `UserPermissions`，分类权限保持布尔值，`features` 明确为动态的 `dict[str, bool]`。
- Token、用户新增、更新和响应模型复用同一权限契约。
- 保留历史部分权限映射的原始键集合，不自动补写默认权限。
- 增加登录 Token、用户模型和 OpenAPI Schema 回归覆盖。

## 验证

- 认证及响应模型相关测试：28 passed。
- `pylint app`：10.00/10。
- `git diff --check`：通过。
- 全量测试完成 3983 passed、3 skipped；另有 7 个 teardown 错误，均为后台模块真实出站被测试网络守卫拦截。干净 `upstream/v3` 基线可复现同类错误，相关 7 个用例隔离运行全部通过。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at d1c709c9caa1b6bec32da2a3cbbda1418654942a

- 支持嵌套的 `permissions.features` 功能权限
- 统一 Token 与用户模型权限契约
- 修复登录响应的 Pydantic 校验错误
- 补充登录、模型及 OpenAPI 回归测试
<!-- pr-agent-summary:end -->
