### PR TITLE
test(agent): 隔离任务查询测试中的调度器

### DIFF
--- a/tests/test_agent_task_runs.py
+++ b/tests/test_agent_task_runs.py
@@ -313,10 +313,15 @@ async def test_query_task_returns_owner_scoped_ten_recent_runs(monkeypatch) -> N
     assert other_run
     assert oper.finish_run(other_run.run_id, success=True, result="其他用户")
 
-    monkeypatch.setattr(
-        "app.scheduler.Scheduler.get_agent_task_next_run",
-        lambda _self, _task_id: None,
-    )
+    class _SchedulerStub:
+        """为查询工具提供下一次触发时间，避免启动真实 APScheduler。"""
+
+        @staticmethod
+        def get_agent_task_next_run(_task_id):
+            """返回测试任务不需要的下一次触发时间。"""
+            return None
+
+    monkeypatch.setattr("app.scheduler.Scheduler", _SchedulerStub)
     detail = json.loads(await _build_query_tool(task.user_id).run(task_id=task.id))
     assert detail["total"] == 1
     assert [run["run_id"] for run in detail["tasks"][0]["recent_runs"]] == expected[:10]


### PR DESCRIPTION
## 问题

任务查询测试只替换了 `get_agent_task_next_run` 方法，但查询工具会创建 `Scheduler()`。测试因此启动了真实 APScheduler，后台定时任务在测试结束后继续运行，导致后续用例触发真实出站请求并被网络守卫拦截。

## 修复

在该测试中替换 `app.scheduler.Scheduler` 为轻量 stub，保留任务查询断言，同时避免初始化真实调度器。生产调度器和业务逻辑不变。

## 验证

- 后端全量测试：`3983 passed, 3 skipped`
- `pylint app`：`10.00/10`
- `git diff --check`：通过

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 1a3c42031bd21f8ecb2d7a8a1a85a5e44892181c

- 隔离任务查询测试中的真实调度器
- 使用 stub 阻止 APScheduler 后台任务启动
- 保留下一次执行时间与运行记录断言
<!-- pr-agent-summary:end -->
