### PR TITLE
Fix EAC3 audio codec detection

### DIFF
--- a/app/core/meta/metavideo.py
+++ b/app/core/meta/metavideo.py
@@ -90,7 +90,7 @@ class MetaVideo(MetaBase):
     _resources_pix_re = r"^[SBUHD]*(\d{3,4}[PI]+)|\d{3,4}X(\d{3,4})"
     _resources_pix_re2 = r"(^[248]+K)"
     _video_encode_re = r"^(H26[45])$|^(x26[45])$|^AVC$|^HEVC$|^VC\d?$|^MPEG\d?$|^Xvid$|^DivX$|^AV1$|^HDR\d*$|^AVS(\+|[23])$"
-    _audio_encode_re = r"^DTS\d?$|^DTSHD$|^DTSHDMA$|^Atmos$|^TrueHD\d?$|^AC3$|^\dAudios?$|^DDP\d?$|^DD\+\d?$|^DD\d?$|^LPCM\d?$|^AAC\d?$|^FLAC\d?$|^HD\d?$|^MA\d?$|^HR\d?$|^Opus\d?$|^Vorbis\d?$|^AV[3S]A$"
+    _audio_encode_re = r"^DTS\d?$|^DTSHD$|^DTSHDMA$|^Atmos$|^TrueHD\d?$|^AC3$|^EAC3\d?$|^\dAudios?$|^DDP\d?$|^DD\+\d?$|^DD\d?$|^LPCM\d?$|^AAC\d?$|^FLAC\d?$|^HD\d?$|^MA\d?$|^HR\d?$|^Opus\d?$|^Vorbis\d?$|^AV[3S]A$"
     _fps_re = r"(\d{2,3})(?=FPS)"
     _season_pattern = re.compile(_season_re, re.IGNORECASE)
     _episode_pattern = re.compile(_episode_re, re.IGNORECASE)
@@ -809,7 +809,7 @@ class MetaVideo(MetaBase):
             if self.audio_encode:
                 if self._last_token.isdigit():
                     self.audio_encode = "%s.%s" % (self.audio_encode, token)
-                elif self.audio_encode[-1].isdigit():
+                elif self.audio_encode[-1].isdigit() and self.audio_encode.upper() not in {"AC3", "EAC3"}:
                     self.audio_encode = "%s %s.%s" % (self.audio_encode[:-1], self.audio_encode[-1], token)
                 else:
                     self.audio_encode = "%s %s" % (self.audio_encode, token)

--- a/tests/test_metainfo.py
+++ b/tests/test_metainfo.py
@@ -171,6 +171,16 @@ def test_python_metainfo_fallback_preserves_xxx_movie_title():
     assert meta.audio_encode == "DDP 5.1"
 
 
+def test_python_metainfo_fallback_recognizes_eac3_audio_codec():
+    """Python 兜底解析应识别 EAC3 及其声道信息。"""
+    with patch("app.core.metainfo.rust_accel.parse_metainfo", return_value=None):
+        meta = MetaInfo("Test.Movie.2026.1080p.BluRay.x264.EAC3.5.1-GROUP")
+
+    assert meta.resource_pix == "1080p"
+    assert meta.video_encode == "x264"
+    assert meta.audio_encode == "EAC3 5.1"
+
+
 RESOURCE_TYPE_CASES = [
     (
         "They.Will.Kill.You.2026.2160p.UHD.BluRay.Remux."


### PR DESCRIPTION
Fixes #6275

## Summary
- Recognize `EAC3` as a movie/TV audio codec token.
- Keep `AC3`/`EAC3` intact when appending channel suffixes such as `5.1`, instead of splitting the codec digit into `EAC 3.5.1`.
- Add a Python fallback metadata parsing regression for `EAC3.5.1`.

## Tests
- `python3 -m py_compile app/core/meta/metavideo.py tests/test_metainfo.py`
- `python3` AST/regex smoke for EAC3 + channel suffix assembly
- `git diff --check`

Note: I attempted `pytest tests/test_metainfo.py -q -k 'eac3 or xxx_movie'`, but the local cron environment is missing the project test dependencies (first `pytest`, then `sqlalchemy` through `tests/conftest.py`).

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at f72eee15a6869be6d6619f0a202a2d4fe511a60c

- 识别 `EAC3` 音频编码及声道信息
- 修正 `EAC3.5.1` 的编码数字拼接
- 保持现有 `AC3` 解析行为兼容
- 新增 Python 兜底解析回归测试
<!-- pr-agent-summary:end -->
