### PR TITLE
fix(emby): 优先按 Provider ID 查询媒体

### DIFF
--- a/app/helper/mediaserver.py
+++ b/app/helper/mediaserver.py
@@ -40,6 +40,48 @@ class MediaServerIdentityHelper:
                     return media_source, str(value).strip()
         return None, None
 
+    @classmethod
+    def to_provider_id(
+            cls,
+            media_source: Optional[MediaSource | str],
+            media_id: Optional[str],
+    ) -> tuple[Optional[str], Optional[str]]:
+        """将统一媒体身份转换为媒体服务器 ProviderIds 的规范键值。"""
+        normalized_source, normalized_id = resolve_media_identity(
+            media_source=media_source,
+            media_id=media_id,
+        )
+        if not normalized_source or not normalized_id:
+            return None, None
+        for provider_source, keys in cls._provider_keys:
+            if provider_source == normalized_source:
+                return keys[0], normalized_id
+        return None, None
+
+    @classmethod
+    def matches_provider_ids(
+            cls,
+            provider_ids: Optional[Mapping[str, Any]],
+            media_source: Optional[MediaSource | str],
+            media_id: Optional[str],
+    ) -> bool:
+        """判断 ProviderIds 是否包含与目标完全一致的媒体身份。"""
+        normalized_source, normalized_id = resolve_media_identity(
+            media_source=media_source,
+            media_id=media_id,
+        )
+        if not isinstance(provider_ids, Mapping) or not normalized_source or not normalized_id:
+            return False
+        for provider_source, keys in cls._provider_keys:
+            if provider_source != normalized_source:
+                continue
+            return any(
+                value is not None and str(value).strip() == normalized_id
+                for key in keys
+                if (value := provider_ids.get(key)) is not None
+            )
+        return False
+
     @staticmethod
     def are_compatible(
             left_source: Optional[MediaSource | str],

--- a/app/modules/emby/emby.py
+++ b/app/modules/emby/emby.py
@@ -377,6 +377,70 @@ class Emby:
             return None
         return ""
 
+    def __get_emby_items_by_provider_id(
+            self,
+            item_type: str,
+            media_source: Optional[MediaSource],
+            media_id: Optional[str],
+    ) -> List[dict]:
+        """
+        按媒体来源原生ID精确查询Emby条目
+
+        :param item_type: Emby条目类型
+        :param media_source: 媒体来源
+        :param media_id: 媒体来源原生ID
+        :return: 身份完全匹配的Emby原始条目列表
+        """
+        if not self._host or not self._apikey:
+            return []
+        provider_key, provider_id = MediaServerIdentityHelper.to_provider_id(
+            media_source, media_id
+        )
+        if not provider_key or not provider_id:
+            return []
+        url = f"{self._host}emby/Items"
+        params = {
+            "IncludeItemTypes": item_type,
+            "Fields": "ProviderIds,OriginalTitle,ProductionYear,Path,"
+                      "UserDataPlayCount,UserDataLastPlayedDate,ParentId",
+            "StartIndex": 0,
+            "Recursive": "true",
+            "AnyProviderIdEquals": f"{provider_key}.{provider_id}",
+            "Limit": 10,
+            "IncludeSearchTypes": "false",
+            "api_key": self._apikey,
+        }
+        try:
+            res = RequestUtils().get_res(url, params)
+            if not res:
+                return []
+            items = res.json().get("Items") or []
+            return [
+                item for item in items
+                if item and MediaServerIdentityHelper.matches_provider_ids(
+                    item.get("ProviderIds"), media_source, media_id
+                )
+            ]
+        except Exception as e:
+            logger.error(f"按Provider ID连接Items出错：{str(e)}")
+            return []
+
+    def __get_emby_series_id(
+            self,
+            name: str,
+            year: str,
+            media_source: Optional[MediaSource],
+            media_id: Optional[str],
+    ) -> Optional[str]:
+        """优先按Provider ID查询剧集，未命中时回退标题和年份。"""
+        provider_items = self.__get_emby_items_by_provider_id(
+            "Series", media_source, media_id
+        )
+        for item in provider_items:
+            if item.get("Id"):
+                return item.get("Id")
+        return self.__get_emby_series_id_by_name(name, year)
+
     def get_movies(self,
                    title: str,
                    year: Optional[str] = None,
@@ -392,6 +456,15 @@ class Emby:
         """
         if not self._host or not self._apikey:
             return None
+        provider_items = self.__get_emby_items_by_provider_id(
+            "Movie", media_source, media_id
+        )
+        provider_movies = [
+            item for item in (self.__format_item_info(item) for item in provider_items)
+            if item
+        ]
+        if provider_movies:
+            return provider_movies
         url = f"{self._host}emby/Items"
         params = {
             "IncludeItemTypes": "Movie",
@@ -477,7 +550,9 @@ class Emby:
         cached_item_id = item_id
         # 电视剧
         if not item_id:
-            item_id = self.__get_emby_series_id_by_name(title, year)
+            item_id = self.__get_emby_series_id(
+                title, year, media_source, media_id
+            )
             if item_id is None:
                 return None, None
             if not item_id:
@@ -487,7 +562,9 @@ class Emby:
         if not item_info and cached_item_id and title:
             # 媒体删除后重新入库会导致缓存ID失效，回退到标题搜索避免误判整部剧缺失。
             logger.warning(f"Emby缓存的电视剧媒体ID {cached_item_id} 已失效，尝试按标题重新搜索：{title}")
-            item_id = self.__get_emby_series_id_by_name(title, year)
+            item_id = self.__get_emby_series_id(
+                title, year, media_source, media_id
+            )
             if item_id is None:
                 return None, None
             if not item_id:

--- a/tests/test_emby_provider_id_lookup.py
+++ b/tests/test_emby_provider_id_lookup.py
@@ -1,0 +1,142 @@
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock, patch
+
+from app.modules.emby.emby import Emby
+from app.schemas.types import MediaSource
+
+
+class _FakeResponse:
+    """提供 Emby 接口响应的最小 JSON 封装。"""
+
+    def __init__(self, payload: Any):
+        self._payload = payload
+
+    def json(self) -> Any:
+        return self._payload
+
+
+def _build_client() -> Emby:
+    client = Emby.__new__(Emby)
+    client._host = "http://emby.local/"
+    client._apikey = "api-key"
+    client.user = "user-id"
+    return client
+
+
+def test_get_movies_prefers_provider_id_when_titles_are_aliases():
+    """Provider ID 相同时应识别标题不同的 Emby 电影条目。"""
+    client = _build_client()
+    provider_item = {
+        "Id": "movie-id",
+        "Name": "电影别名",
+        "ProductionYear": 2026,
+        "Type": "Movie",
+        "ProviderIds": {"Tmdb": "12345"},
+    }
+
+    with patch("app.modules.emby.emby.RequestUtils") as request_utils_cls:
+        request_utils = request_utils_cls.return_value
+        request_utils.get_res.return_value = _FakeResponse({"Items": [provider_item]})
+
+        movies = client.get_movies(
+            title="电影主标题",
+            year="2026",
+            media_source=MediaSource.TMDB,
+            media_id="12345",
+        )
+
+    assert [movie.item_id for movie in movies] == ["movie-id"]
+    params = request_utils.get_res.call_args.args[1]
+    assert params["AnyProviderIdEquals"] == "Tmdb.12345"
+    assert "SearchTerm" not in params
+
+
+def test_get_tv_episodes_prefers_provider_id_when_titles_are_aliases():
+    """Provider ID 相同时应通过别名剧集返回已入库季集。"""
+    client = _build_client()
+    client.get_iteminfo = Mock(
+        return_value=SimpleNamespace(
+            media_source=MediaSource.TMDB,
+            media_id="37854",
+        )
+    )
+    provider_item = {
+        "Id": "series-id",
+        "Name": "海贼王",
+        "ProductionYear": 1999,
+        "Type": "Series",
+        "ProviderIds": {"Tmdb": "37854"},
+    }
+
+    with patch("app.modules.emby.emby.RequestUtils") as request_utils_cls:
+        request_utils = request_utils_cls.return_value
+        request_utils.get_res.side_effect = [
+            _FakeResponse({"Items": [provider_item]}),
+            _FakeResponse({
+                "Items": [
+                    {"ParentIndexNumber": 1, "IndexNumber": 1},
+                    {"ParentIndexNumber": 2, "IndexNumber": 3},
+                ]
+            }),
+        ]
+
+        item_id, episodes = client.get_tv_episodes(
+            title="航海王",
+            year="1999",
+            media_source=MediaSource.TMDB,
+            media_id="37854",
+        )
+
+    assert item_id == "series-id"
+    assert episodes == {1: [1], 2: [3]}
+    first_params = request_utils.get_res.call_args_list[0].args[1]
+    assert first_params["AnyProviderIdEquals"] == "Tmdb.37854"
+    assert "SearchTerm" not in first_params
+
+
+def test_get_tv_episodes_falls_back_to_exact_title_when_provider_id_misses():
+    """Provider ID 未命中时应保留原有标题和年份查找。"""
+    client = _build_client()
+    client.get_iteminfo = Mock(
+        return_value=SimpleNamespace(
+            media_source=MediaSource.TMDB,
+            media_id="37854",
+        )
+    )
+
+    with patch("app.modules.emby.emby.RequestUtils") as request_utils_cls:
+        request_utils = request_utils_cls.return_value
+        request_utils.get_res.side_effect = [
+            _FakeResponse({
+                "Items": [{
+                    "Id": "wrong-series-id",
+                    "Name": "同名错误条目",
+                    "ProductionYear": 1999,
+                    "ProviderIds": {"Tmdb": "99999"},
+                }]
+            }),
+            _FakeResponse({
+                "Items": [{
+                    "Id": "series-id",
+                    "Name": "航海王",
+                    "ProductionYear": 1999,
+                }]
+            }),
+            _FakeResponse({
+                "Items": [{"ParentIndexNumber": 1, "IndexNumber": 1}]
+            }),
+        ]
+
+        item_id, episodes = client.get_tv_episodes(
+            title="航海王",
+            year="1999",
+            media_source=MediaSource.TMDB,
+            media_id="37854",
+        )
+
+    assert item_id == "series-id"
+    assert episodes == {1: [1]}
+    title_params = request_utils.get_res.call_args_list[1].args[1]
+    assert title_params["SearchTerm"] == "航海王"
+    assert "AnyProviderIdEquals" not in title_params


### PR DESCRIPTION
## 问题

Emby 媒体库存在性检查目前先按标题和年份搜索，再校验媒体身份。媒体元数据标题与 Emby 展示标题存在别名或本地化差异时，即使双方 TMDB ID 一致也会返回未入库，例如 `航海王` 与 `海贼王`（TMDB 37854）。

## 修复

- 将统一媒体身份转换为 Emby `ProviderIds` 规范键值。
- 电影和电视剧优先通过 `AnyProviderIdEquals` 精确查询，并校验返回条目的 Provider ID。
- Provider ID 不可用、未命中或返回身份不符时，保留原有标题/年份精确匹配回退。
- 增加电影别名、电视剧别名和错误 Provider ID 回退的离线回归测试。

## 验证

- `pytest -q tests/test_emby_provider_id_lookup.py tests/test_mediaserver_tv_stale_itemid.py tests/test_emby_user_resolution.py tests/test_emby_dashboard_links.py`: 19 passed
- `pylint app/helper/mediaserver.py app/modules/emby/emby.py`: 10.00/10
- `python tests/run.py`: 3985 passed, 3 skipped, 2 failed

全量测试的两个失败均已在未修改的 `upstream/v3@557cc0e2` 上独立复现：

- `tests/test_bluray.py::BluRayTest::test`
- `tests/test_workflow_actions.py::test_workflow_manager_list_actions_exposes_contract`

它们不经过本次修改路径。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at c34488d9b1a71bdd496107129f4d807c639b0f7e

- 优先用 Provider ID 查询 Emby 媒体
- 校验返回条目身份，防止错误匹配
- 未命中时回退标题与年份检索
- 覆盖电影、剧集别名及回退场景
<!-- pr-agent-summary:end -->
