### PR TITLE
feat(transfer): 添加分类与目录路由预览

### DIFF
--- a/app/api/endpoints/transfer.py
+++ b/app/api/endpoints/transfer.py
@@ -8,6 +8,7 @@ from app import schemas
 from app.api.response import ResponseAPIRouter
 from app.chain.media import MediaChain
 from app.chain.transfer import TransferChain
+from app.chain.directory_route import DirectoryRouteChain
 from app.platform.config import settings, global_vars
 from app.security.access import verify_token, verify_apitoken
 from app.db import get_db
@@ -16,6 +17,7 @@ from app.db.models.transferhistory import TransferHistory
 from app.db.user_oper import (
     get_current_active_manage_user,
     get_current_active_superuser,
+    get_current_active_superuser_async,
 )
 from app.services.directory import DirectoryHelper
 from app.platform.log import logger
@@ -27,6 +29,32 @@ from app.schemas import (
 )
 
 router = ResponseAPIRouter()
+
+
+@router.get(
+    "/route/settings",
+    summary="查询目录路由设置",
+    response_model=schemas.Response[schemas.DirectoryRouteSettings],
+)
+def query_route_settings(
+    _: User = Depends(get_current_active_manage_user),
+) -> Any:
+    """返回目录配置及当前候选选择模式。"""
+    return schemas.Response(success=True, data=DirectoryRouteChain.get_settings())
+
+
+@router.post(
+    "/route/settings",
+    summary="更新目录路由设置",
+    response_model=schemas.Response[schemas.DirectoryRouteSettings],
+)
+async def update_route_settings(
+    route_settings: schemas.DirectoryRouteSettings,
+    _: User = Depends(get_current_active_superuser_async),
+) -> Any:
+    """原子更新目录配置及候选选择模式。"""
+    saved_settings = await DirectoryRouteChain.save_settings(route_settings)
+    return schemas.Response(success=True, data=saved_settings)
 
 
 @router.post(
@@ -45,7 +73,7 @@ def preview_transfer_route(
     :param _: 用户鉴权
     :return: 路由预览结果
     """
-    result = TransferChain.preview_route(request)
+    result = DirectoryRouteChain.preview(request)
     return schemas.Response(success=True, data=result.model_dump())
 
 

--- a/app/api/endpoints/transfer.py
+++ b/app/api/endpoints/transfer.py
@@ -29,6 +29,26 @@ from app.schemas import (
 router = ResponseAPIRouter()
 
 
+@router.post(
+    "/route/preview",
+    summary="预览分类与目录路由",
+    response_model=schemas.Response[schemas.TransferRoutePreviewResponse],
+)
+def preview_transfer_route(
+    request: schemas.TransferRoutePreviewRequest,
+    _: User = Depends(get_current_active_manage_user),
+) -> Any:
+    """
+    使用已识别媒体快照预览分类和目录候选，不执行媒体识别或文件整理。
+
+    :param request: 路由预览请求
+    :param _: 用户鉴权
+    :return: 路由预览结果
+    """
+    result = TransferChain.preview_route(request)
+    return schemas.Response(success=True, data=result.model_dump())
+
+
 @router.get(
     "/name",
     summary="查询整理后的名称",

--- a/app/chain/directory_route.py
+++ b/app/chain/directory_route.py
@@ -1,0 +1,135 @@
+from pathlib import Path
+
+from app import schemas
+from app.chain import ChainBase
+from app.db.systemconfig_oper import SystemConfigOper
+from app.domain.context import MediaInfo
+from app.modules.themoviedb.category import CategoryHelper
+from app.platform.events import eventmanager
+from app.schemas import ConfigChangeEventData
+from app.schemas.types import (
+    DirectoryMatchMode,
+    EventType,
+    MediaType,
+    SystemConfigKey,
+)
+from app.services.directory import DirectoryHelper
+
+
+class DirectoryRouteChain(ChainBase):
+    """分类诊断、目录路由预览及其设置的业务编排。"""
+
+    @staticmethod
+    def get_settings() -> schemas.DirectoryRouteSettings:
+        """从同一缓存快照读取目录配置及候选选择模式。"""
+        snapshot = SystemConfigOper().get_many((
+            SystemConfigKey.Directories,
+            SystemConfigKey.DirectoryMatchMode,
+        ))
+        directories = snapshot[SystemConfigKey.Directories.value]
+        match_mode = snapshot[SystemConfigKey.DirectoryMatchMode.value]
+        return schemas.DirectoryRouteSettings(
+            directories=directories or [],
+            match_mode=DirectoryHelper.get_match_mode(match_mode),
+        )
+
+    @staticmethod
+    async def save_settings(
+            route_settings: schemas.DirectoryRouteSettings,
+    ) -> schemas.DirectoryRouteSettings:
+        """原子保存目录配置和候选选择模式，并广播一次配置变更。"""
+        values = {
+            SystemConfigKey.Directories: [
+                directory.model_dump(mode="json", exclude_none=True)
+                for directory in route_settings.directories
+            ] or None,
+            SystemConfigKey.DirectoryMatchMode: route_settings.match_mode.value,
+        }
+        changed_keys = await SystemConfigOper().async_set_many(values)
+        if changed_keys:
+            await eventmanager.async_send_event(
+                etype=EventType.ConfigChanged,
+                data=ConfigChangeEventData(
+                    key=changed_keys,
+                    value={key.value: value for key, value in values.items()},
+                    change_type="update",
+                ),
+            )
+        return route_settings
+
+    @staticmethod
+    def preview(
+            request: schemas.TransferRoutePreviewRequest,
+    ) -> schemas.TransferRoutePreviewResponse:
+        """
+        使用已识别媒体快照预览分类与目录路由，不发起外部识别请求。
+
+        :param request: 路由预览请求
+        :return: 分类诊断、当前模式路由及两种模式对比
+        """
+        category_config = request.category_config or CategoryHelper().load()
+        if request.media.type == MediaType.MOVIE:
+            category_rules = category_config.movie or {}
+        elif request.media.type == MediaType.TV:
+            category_rules = category_config.tv or {}
+        else:
+            category_rules = {}
+
+        category_decision = CategoryHelper.evaluate_category(
+            categorys=category_rules,
+            tmdb_info=request.metadata,
+        )
+        provided_category = (request.media.category or "").strip()
+        category_decision.provided_category = provided_category
+        if provided_category:
+            if (
+                    category_decision.automatic_category
+                    and category_decision.automatic_category != provided_category
+            ):
+                category_decision.warnings.append(schemas.RouteDiagnosticWarning(
+                    code="provided_category_conflict",
+                    message="显式类别与自动分类结果不一致，路由使用显式类别",
+                ))
+            category_decision.selected_category = provided_category
+            category_decision.source = "provided"
+
+        media = MediaInfo(
+            type=request.media.type,
+            title=request.media.title,
+            year=request.media.year,
+            category=category_decision.selected_category,
+        )
+        directory_helper = DirectoryHelper()
+        directories = (
+            directory_helper.get_dirs()
+            if request.directories is None
+            else request.directories
+        )
+        effective_mode = directory_helper.get_match_mode(request.match_mode)
+        route_kwargs = {
+            "media": media,
+            "directories": directories,
+            "include_unsorted": request.include_unsorted,
+            "storage": request.storage,
+            "src_path": Path(request.src_path) if request.src_path else None,
+            "target_storage": request.target_storage,
+            "dest_path": Path(request.dest_path) if request.dest_path else None,
+            "valid_categories": list(category_rules.keys()),
+        }
+        comparisons = [
+            directory_helper.evaluate_route(**route_kwargs, match_mode=mode)
+            for mode in (
+                DirectoryMatchMode.SEQUENTIAL,
+                DirectoryMatchMode.SPECIFICITY,
+            )
+        ]
+        route = next(
+            decision for decision in comparisons if decision.mode == effective_mode
+        )
+        return schemas.TransferRoutePreviewResponse(
+            media=request.media,
+            metadata=request.metadata,
+            category=category_decision,
+            route=route,
+            comparisons=comparisons,
+        )

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -30,12 +30,16 @@ from app.db.transferpending_oper import TransferPendingOper
 from app.db.transferhistory_oper import TransferHistoryOper
 from app.services.directory import DirectoryHelper
 from app.services.audio import AudioMetadataHelper
+from app.services.history import (
+    clear_transfer_failures,
+    describe_history_gate,
+    evaluate_history_gate,
+    is_skip_action,
+    record_transfer_failure,
+    resolve_history,
+)
 from app.services.formatting import EpisodeFormatRuleHelper, FormatParser
 from app.platform.progress import ProgressHelper
-from app.services.history import (clear_transfer_failures, describe_history_gate,
-from app.modules.themoviedb.category import CategoryHelper
-                                        evaluate_history_gate, is_skip_action,
-                                        record_transfer_failure, resolve_history)
 from app.platform.log import logger
 from app.schemas import StorageOperSelectionEventData
 from app.schemas import (
@@ -61,7 +65,6 @@ from app.schemas.types import (
     SystemConfigKey,
     ChainEventType,
     ContentType,
-    DirectoryMatchMode,
     MUSIC_ENTITY_ALBUM,
     MUSIC_ENTITY_RECORDING,
     MediaSource,
@@ -980,86 +983,6 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
     CONFIG_WATCH = {
         "TRANSFER_THREADS",
     }
-
-    @staticmethod
-    def preview_route(
-            request: schemas.TransferRoutePreviewRequest,
-    ) -> schemas.TransferRoutePreviewResponse:
-        """
-        使用已识别媒体快照预览分类与目录路由，不发起外部识别请求。
-
-        :param request: 路由预览请求
-        :return: 分类诊断、当前模式路由及两种模式对比
-        """
-        category_config = request.category_config or CategoryHelper().load()
-        if request.media.type == MediaType.MOVIE:
-            category_rules = category_config.movie or {}
-        elif request.media.type == MediaType.TV:
-            category_rules = category_config.tv or {}
-        else:
-            category_rules = {}
-
-        category_decision = CategoryHelper.evaluate_category(
-            categorys=category_rules,
-            tmdb_info=request.metadata,
-        )
-        provided_category = (request.media.category or "").strip()
-        category_decision.provided_category = provided_category
-        if provided_category:
-            if (
-                    category_decision.automatic_category
-                    and category_decision.automatic_category != provided_category
-            ):
-                category_decision.warnings.append(schemas.RouteDiagnosticWarning(
-                    code="provided_category_conflict",
-                    message="显式类别与自动分类结果不一致，路由使用显式类别",
-                ))
-            category_decision.selected_category = provided_category
-            category_decision.source = "provided"
-
-        media = MediaInfo(
-            type=request.media.type,
-            title=request.media.title,
-            year=request.media.year,
-            category=category_decision.selected_category,
-        )
-        directory_helper = DirectoryHelper()
-        directories = (
-            directory_helper.get_dirs()
-            if request.directories is None
-            else request.directories
-        )
-        effective_mode = directory_helper.get_match_mode(request.match_mode)
-        route_kwargs = {
-            "media": media,
-            "directories": directories,
-            "include_unsorted": request.include_unsorted,
-            "storage": request.storage,
-            "src_path": Path(request.src_path) if request.src_path else None,
-            "target_storage": request.target_storage,
-            "dest_path": Path(request.dest_path) if request.dest_path else None,
-            "valid_categories": list(category_rules.keys()),
-        }
-        comparisons = [
-            directory_helper.evaluate_route(
-                **route_kwargs,
-                match_mode=mode,
-            )
-            for mode in (
-                DirectoryMatchMode.SEQUENTIAL,
-                DirectoryMatchMode.SPECIFICITY,
-            )
-        ]
-        route = next(
-            decision for decision in comparisons if decision.mode == effective_mode
-        )
-        return schemas.TransferRoutePreviewResponse(
-            media=request.media,
-            metadata=request.metadata,
-            category=category_decision,
-            route=route,
-            comparisons=comparisons,
-        )
 
     @staticmethod
     def _requires_automatic_category(task: TransferTask) -> bool:

--- a/app/chain/transfer.py
+++ b/app/chain/transfer.py
@@ -33,6 +33,7 @@ from app.services.audio import AudioMetadataHelper
 from app.services.formatting import EpisodeFormatRuleHelper, FormatParser
 from app.platform.progress import ProgressHelper
 from app.services.history import (clear_transfer_failures, describe_history_gate,
+from app.modules.themoviedb.category import CategoryHelper
                                         evaluate_history_gate, is_skip_action,
                                         record_transfer_failure, resolve_history)
 from app.platform.log import logger
@@ -60,6 +61,7 @@ from app.schemas.types import (
     SystemConfigKey,
     ChainEventType,
     ContentType,
+    DirectoryMatchMode,
     MUSIC_ENTITY_ALBUM,
     MUSIC_ENTITY_RECORDING,
     MediaSource,
@@ -978,6 +980,86 @@ class TransferChain(ChainBase, ConfigReloadMixin, metaclass=Singleton):
     CONFIG_WATCH = {
         "TRANSFER_THREADS",
     }
+
+    @staticmethod
+    def preview_route(
+            request: schemas.TransferRoutePreviewRequest,
+    ) -> schemas.TransferRoutePreviewResponse:
+        """
+        使用已识别媒体快照预览分类与目录路由，不发起外部识别请求。
+
+        :param request: 路由预览请求
+        :return: 分类诊断、当前模式路由及两种模式对比
+        """
+        category_config = request.category_config or CategoryHelper().load()
+        if request.media.type == MediaType.MOVIE:
+            category_rules = category_config.movie or {}
+        elif request.media.type == MediaType.TV:
+            category_rules = category_config.tv or {}
+        else:
+            category_rules = {}
+
+        category_decision = CategoryHelper.evaluate_category(
+            categorys=category_rules,
+            tmdb_info=request.metadata,
+        )
+        provided_category = (request.media.category or "").strip()
+        category_decision.provided_category = provided_category
+        if provided_category:
+            if (
+                    category_decision.automatic_category
+                    and category_decision.automatic_category != provided_category
+            ):
+                category_decision.warnings.append(schemas.RouteDiagnosticWarning(
+                    code="provided_category_conflict",
+                    message="显式类别与自动分类结果不一致，路由使用显式类别",
+                ))
+            category_decision.selected_category = provided_category
+            category_decision.source = "provided"
+
+        media = MediaInfo(
+            type=request.media.type,
+            title=request.media.title,
+            year=request.media.year,
+            category=category_decision.selected_category,
+        )
+        directory_helper = DirectoryHelper()
+        directories = (
+            directory_helper.get_dirs()
+            if request.directories is None
+            else request.directories
+        )
+        effective_mode = directory_helper.get_match_mode(request.match_mode)
+        route_kwargs = {
+            "media": media,
+            "directories": directories,
+            "include_unsorted": request.include_unsorted,
+            "storage": request.storage,
+            "src_path": Path(request.src_path) if request.src_path else None,
+            "target_storage": request.target_storage,
+            "dest_path": Path(request.dest_path) if request.dest_path else None,
+            "valid_categories": list(category_rules.keys()),
+        }
+        comparisons = [
+            directory_helper.evaluate_route(
+                **route_kwargs,
+                match_mode=mode,
+            )
+            for mode in (
+                DirectoryMatchMode.SEQUENTIAL,
+                DirectoryMatchMode.SPECIFICITY,
+            )
+        ]
+        route = next(
+            decision for decision in comparisons if decision.mode == effective_mode
+        )
+        return schemas.TransferRoutePreviewResponse(
+            media=request.media,
+            metadata=request.metadata,
+            category=category_decision,
+            route=route,
+            comparisons=comparisons,
+        )
 
     @staticmethod
     def _requires_automatic_category(task: TransferTask) -> bool:

--- a/app/db/systemconfig_oper.py
+++ b/app/db/systemconfig_oper.py
@@ -1,9 +1,11 @@
 import asyncio
 import copy
 import threading
-from typing import Any, Optional, Union
+from typing import Any, Iterable, Mapping, Optional, Set, Union
 
-from app.db import DbOper
+from sqlalchemy import select
+
+from app.db import AsyncSessionFactory, DbOper
 from app.db.models.systemconfig import SystemConfig
 from app.schemas.types import SystemConfigKey
 from app.foundation.singleton import Singleton
@@ -87,6 +89,47 @@ class SystemConfigOper(DbOper, metaclass=Singleton):
                 self.__SYSTEMCONF[key] = copy.deepcopy(value)
             return True
 
+    async def async_set_many(
+            self,
+            values: Mapping[Union[str, SystemConfigKey], Any],
+    ) -> Set[str]:
+        """在同一事务中更新多个系统配置，并在提交后同步内存缓存。"""
+        normalized_values = {
+            key.value if isinstance(key, SystemConfigKey) else key: copy.deepcopy(value)
+            for key, value in values.items()
+        }
+        if not normalized_values:
+            return set()
+
+        async with self._alock:
+            async with AsyncSessionFactory() as db:
+                try:
+                    result = await db.execute(
+                        select(SystemConfig).where(
+                            SystemConfig.key.in_(normalized_values.keys())
+                        )
+                    )
+                    records = {item.key: item for item in result.scalars().all()}
+                    changed_keys = set()
+                    for key, value in normalized_values.items():
+                        record = records.get(key)
+                        if record:
+                            if record.value == value:
+                                continue
+                            record.value = value
+                        else:
+                            db.add(SystemConfig(key=key, value=value))
+                        changed_keys.add(key)
+                    await db.commit()
+                except Exception:
+                    await db.rollback()
+                    raise
+
+            with self._rlock:
+                for key, value in normalized_values.items():
+                    self.__SYSTEMCONF[key] = copy.deepcopy(value)
+            return changed_keys
+
     def get(self, key: Union[str, SystemConfigKey] = None) -> Any:
         """
         获取系统设置
@@ -98,6 +141,21 @@ class SystemConfigOper(DbOper, metaclass=Singleton):
         with self._rlock:
             # 避免将__SYSTEMCONF内的值引用出去，会导致set时误判没有变动
             return copy.deepcopy(self.__SYSTEMCONF.get(key))
+
+    def get_many(
+            self,
+            keys: Iterable[Union[str, SystemConfigKey]],
+    ) -> dict[str, Any]:
+        """在同一缓存快照中读取多个系统配置。"""
+        normalized_keys = [
+            key.value if isinstance(key, SystemConfigKey) else key
+            for key in keys
+        ]
+        with self._rlock:
+            return {
+                key: copy.deepcopy(self.__SYSTEMCONF.get(key))
+                for key in normalized_keys
+            }
 
     def increment(self, key: SystemConfigKey, step: int = 1) -> int:
         """

--- a/app/modules/themoviedb/category.py
+++ b/app/modules/themoviedb/category.py
@@ -7,7 +7,13 @@ from ruamel.yaml import CommentedMap
 
 from app.platform.config import settings
 from app.platform.log import logger
-from app.schemas.category import CategoryConfig
+from app.schemas.category import (
+    CategoryConditionDecision,
+    CategoryConfig,
+    CategoryRouteDecision,
+    CategoryRuleDecision,
+    RouteDiagnosticWarning,
+)
 from app.foundation.singleton import WeakSingleton
 
 HEADER_COMMENTS = """####### 配置说明 #######
@@ -153,73 +159,163 @@ class CategoryHelper(metaclass=WeakSingleton):
         :param tmdb_info: TMDB信息
         :return: 分类的名称
         """
-        if not tmdb_info:
-            return ""
-        if not categorys:
-            return ""
+        return CategoryHelper.evaluate_category(categorys, tmdb_info).automatic_category
 
-        for key, item in categorys.items():
-            if not item:
-                return key
-            match_flag = True
-            for attr, value in item.items():
-                if not value:
-                    continue
-                if attr == "release_year":
-                    # 发行年份
-                    info_value = tmdb_info.get("release_date") or tmdb_info.get("first_air_date")
-                    if info_value:
-                        info_value = str(info_value)[:4]
-                else:
-                    info_value = tmdb_info.get(attr)
-                if not info_value:
-                    match_flag = False
-                    continue
-                elif attr == "production_countries":
-                    # 制片国家
-                    info_values = [str(val.get("iso_3166_1")).upper() for val in info_value]  # type: ignore
-                else:
-                    if isinstance(info_value, list):
-                        info_values = [str(val).upper() for val in info_value]
-                    else:
-                        info_values = [str(info_value).upper()]
+    @staticmethod
+    def evaluate_category(
+            categorys: Union[dict, CommentedMap],
+            tmdb_info: dict,
+    ) -> CategoryRouteDecision:
+        """
+        求值全部分类规则并保留第一条命中的现有语义。
 
-                values = []
-                invert_values = []
+        :param categorys: 分类配置
+        :param tmdb_info: 已获取的 TMDB 元数据快照
+        :return: 分类规则决策与非阻断警告
+        """
+        if not tmdb_info or not categorys:
+            return CategoryRouteDecision()
 
-                # 如果有 "," 进行分割
-                values = [str(val) for val in value.split(",") if val]
+        rule_decisions = []
+        fallback_indices = []
+        for index, (category, raw_rule) in enumerate(categorys.items()):
+            if hasattr(raw_rule, "model_dump"):
+                rule = raw_rule.model_dump(exclude_none=True)
+            else:
+                rule = raw_rule
+            if not rule:
+                fallback_indices.append(index)
+                rule_decisions.append(
+                    CategoryRuleDecision(
+                        index=index,
+                        category=category,
+                        matched=True,
+                    )
+                )
+                continue
 
-                expanded_values = []
-                for v in values:
-                    if "-" not in v:
-                        expanded_values.append(v)
-                        continue
+            conditions = [
+                CategoryHelper._evaluate_condition(attr, value, tmdb_info)
+                for attr, value in rule.items()
+                if value
+            ]
+            rule_decisions.append(
+                CategoryRuleDecision(
+                    index=index,
+                    category=category,
+                    matched=all(condition.matched for condition in conditions),
+                    conditions=conditions,
+                )
+            )
 
-                    # - 表示范围
-                    value_begin, value_end = v.split("-", 1)
+        matched_indices = [rule.index for rule in rule_decisions if rule.matched]
+        selected_index = matched_indices[0] if matched_indices else None
+        if selected_index is not None:
+            rule_decisions[selected_index].selected = True
+            for rule in rule_decisions[selected_index + 1:]:
+                rule.reachable = False
 
-                    prefix = ""
-                    if value_begin.startswith('!'):
-                        prefix = '!'
-                        value_begin = value_begin[1:]
+        warnings = []
+        invalid_fallbacks = [
+            index for index in fallback_indices if index < len(rule_decisions) - 1
+        ]
+        if invalid_fallbacks:
+            warnings.append(
+                RouteDiagnosticWarning(
+                    code="unconditional_category_not_last",
+                    message="无条件兜底分类不是最后一项，后续规则在实际分类中不可达",
+                    related_indices=invalid_fallbacks,
+                )
+            )
+        if len(matched_indices) > 1:
+            warnings.append(
+                RouteDiagnosticWarning(
+                    code="multiple_category_matches",
+                    message="当前媒体同时匹配多条分类规则，实际分类采用第一条",
+                    related_indices=matched_indices,
+                )
+            )
 
-                    if value_begin.isdigit() and value_end.isdigit():
-                        # 数字范围
-                        expanded_values.extend(f"{prefix}{val}" for val in range(int(value_begin), int(value_end) + 1))
-                    else:
-                        # 字符串范围
-                        expanded_values.extend([f"{prefix}{value_begin}", f"{prefix}{value_end}"])
+        selected_category = (
+            rule_decisions[selected_index].category
+            if selected_index is not None
+            else ""
+        )
+        return CategoryRouteDecision(
+            automatic_category=selected_category,
+            selected_category=selected_category,
+            source="automatic" if selected_category else "none",
+            rules=rule_decisions,
+            warnings=warnings,
+        )
 
-                values = list(map(str.upper, expanded_values))
+    @staticmethod
+    def _evaluate_condition(
+            attr: str,
+            value: str,
+            tmdb_info: dict,
+    ) -> CategoryConditionDecision:
+        """求值单个分类条件并返回可展示原因。"""
+        if attr == "release_year":
+            info_value = tmdb_info.get("release_date") or tmdb_info.get("first_air_date")
+            if info_value:
+                info_value = str(info_value)[:4]
+        else:
+            info_value = tmdb_info.get(attr)
+        if not info_value:
+            return CategoryConditionDecision(
+                field=attr,
+                expected=value,
+                actual=info_value,
+                matched=False,
+                message="元数据缺少该字段",
+            )
 
-                invert_values = [val[1:] for val in values if val.startswith('!')]
-                values = [val for val in values if not val.startswith('!')]
+        if attr == "production_countries":
+            info_values = [
+                str(item.get("iso_3166_1")).upper()
+                for item in info_value
+            ]
+        elif isinstance(info_value, list):
+            info_values = [str(item).upper() for item in info_value]
+        else:
+            info_values = [str(info_value).upper()]
 
-                if values and not set(values).intersection(set(info_values)):
-                    match_flag = False
-                if invert_values and set(invert_values).intersection(set(info_values)):
-                    match_flag = False
-            if match_flag:
-                return key
-        return ""
+        values = [item for item in str(value).split(",") if item]
+        expanded_values = []
+        for expected in values:
+            if "-" not in expected:
+                expanded_values.append(expected)
+                continue
+            value_begin, value_end = expected.split("-", 1)
+            prefix = ""
+            if value_begin.startswith("!"):
+                prefix = "!"
+                value_begin = value_begin[1:]
+            if value_begin.isdigit() and value_end.isdigit():
+                expanded_values.extend(
+                    f"{prefix}{item}"
+                    for item in range(int(value_begin), int(value_end) + 1)
+                )
+            else:
+                expanded_values.extend([
+                    f"{prefix}{value_begin}",
+                    f"{prefix}{value_end}",
+                ])
+
+        normalized_values = [item.upper() for item in expanded_values]
+        inverted_values = [item[1:] for item in normalized_values if item.startswith("!")]
+        included_values = [item for item in normalized_values if not item.startswith("!")]
+        included_match = (
+            not included_values
+            or bool(set(included_values).intersection(info_values))
+        )
+        excluded_match = bool(set(inverted_values).intersection(info_values))
+        matched = included_match and not excluded_match
+        return CategoryConditionDecision(
+            field=attr,
+            expected=value,
+            actual=info_value,
+            matched=matched,
+            message="条件匹配" if matched else "元数据值不满足条件",
+        )

--- a/app/modules/themoviedb/category.py
+++ b/app/modules/themoviedb/category.py
@@ -183,7 +183,12 @@ class CategoryHelper(metaclass=WeakSingleton):
                 rule = raw_rule.model_dump(exclude_none=True)
             else:
                 rule = raw_rule
-            if not rule:
+            rule_items = [
+                (attr, value)
+                for attr, value in rule.items()
+                if value
+            ] if rule else []
+            if not rule_items:
                 fallback_indices.append(index)
                 rule_decisions.append(
                     CategoryRuleDecision(
@@ -196,8 +201,7 @@ class CategoryHelper(metaclass=WeakSingleton):
 
             conditions = [
                 CategoryHelper._evaluate_condition(attr, value, tmdb_info)
-                for attr, value in rule.items()
-                if value
+                for attr, value in rule_items
             ]
             rule_decisions.append(
                 CategoryRuleDecision(

--- a/app/schemas/category.py
+++ b/app/schemas/category.py
@@ -1,6 +1,6 @@
-from typing import Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, RootModel
+from pydantic import BaseModel, ConfigDict, Field, RootModel
 
 
 class CategoryRule(BaseModel):
@@ -33,3 +33,43 @@ class CategoryConfig(BaseModel):
 
 class MediaCategoryMap(RootModel[Dict[str, list[str]]]):
     """媒体类型与自动分类名称列表的映射。"""
+
+
+class RouteDiagnosticWarning(BaseModel):
+    """不阻断路由决策的结构化警告。"""
+
+    code: str
+    message: str
+    related_indices: list[int] = Field(default_factory=list)
+
+
+class CategoryConditionDecision(BaseModel):
+    """单个分类条件的求值结果。"""
+
+    field: str
+    expected: Any = None
+    actual: Any = None
+    matched: bool = False
+    message: str = ""
+
+
+class CategoryRuleDecision(BaseModel):
+    """单条分类规则的求值结果。"""
+
+    index: int
+    category: str
+    matched: bool = False
+    selected: bool = False
+    reachable: bool = True
+    conditions: list[CategoryConditionDecision] = Field(default_factory=list)
+
+
+class CategoryRouteDecision(BaseModel):
+    """分类规则求值与最终类别来源。"""
+
+    automatic_category: str = ""
+    provided_category: str = ""
+    selected_category: str = ""
+    source: Literal["automatic", "provided", "none"] = "none"
+    rules: list[CategoryRuleDecision] = Field(default_factory=list)
+    warnings: list[RouteDiagnosticWarning] = Field(default_factory=list)

--- a/app/schemas/transfer.py
+++ b/app/schemas/transfer.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Any, Callable, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from app.schemas.common import JsonData
 from app.schemas.media import OptionalMediaIdentityMixin
@@ -147,6 +147,21 @@ class DirectoryRouteDecision(BaseModel):
     selected_directory: Optional[TransferDirectoryConf] = None
     candidates: list[DirectoryRouteCandidate] = Field(default_factory=list)
     warnings: list[RouteDiagnosticWarning] = Field(default_factory=list)
+
+
+class DirectoryRouteSettings(BaseModel):
+    """目录配置及其候选选择模式。"""
+
+    directories: list[TransferDirectoryConf] = Field(default_factory=list)
+    match_mode: DirectoryMatchMode = DirectoryMatchMode.SEQUENTIAL
+
+    @model_validator(mode="after")
+    def validate_unique_names(self) -> "DirectoryRouteSettings":
+        """拒绝名称重复的目录，避免保存后无法稳定引用。"""
+        names = [directory.name for directory in self.directories]
+        if len(names) != len(set(names)):
+            raise ValueError("目录名称不能重复")
+        return self
 
 
 class TransferRouteMediaSnapshot(BaseModel):

--- a/app/schemas/transfer.py
+++ b/app/schemas/transfer.py
@@ -1,10 +1,12 @@
 from pathlib import Path
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Callable, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 
+from app.schemas.common import JsonData
 from app.schemas.media import OptionalMediaIdentityMixin
-from app.schemas.types import MediaSource, MusicTargetEntityType
+from app.schemas.category import CategoryConfig, CategoryRouteDecision, RouteDiagnosticWarning
+from app.schemas.types import DirectoryMatchMode, MediaSource, MusicTargetEntityType
 
 from app.schemas.context import MetaInfo, MediaInfo
 from app.schemas.music import MusicInfo, MusicMeta
@@ -116,6 +118,72 @@ class TransferTask(OptionalMediaIdentityMixin, BaseModel):
         dicts["mediainfo"] = self.mediainfo.model_dump() if self.mediainfo else None
         dicts["target_directory"] = self.target_directory.model_dump() if self.target_directory else None
         return dicts
+
+
+class RouteDiagnosticReason(BaseModel):
+    """路由候选或规则的结构化诊断原因。"""
+
+    code: str
+    message: str
+
+
+class DirectoryRouteCandidate(BaseModel):
+    """单条目录配置的候选求值结果。"""
+
+    index: int
+    directory: TransferDirectoryConf
+    eligible: bool = False
+    selected: bool = False
+    match_level: Literal["none", "wildcard", "media_type", "category"] = "none"
+    same_source: Optional[bool] = None
+    reasons: list[RouteDiagnosticReason] = Field(default_factory=list)
+
+
+class DirectoryRouteDecision(BaseModel):
+    """给定目录匹配模式下的完整路由决策。"""
+
+    mode: DirectoryMatchMode
+    selected_index: Optional[int] = None
+    selected_directory: Optional[TransferDirectoryConf] = None
+    candidates: list[DirectoryRouteCandidate] = Field(default_factory=list)
+    warnings: list[RouteDiagnosticWarning] = Field(default_factory=list)
+
+
+class TransferRouteMediaSnapshot(BaseModel):
+    """路由预览使用的已识别媒体快照。"""
+
+    type: MediaType
+    title: Optional[str] = None
+    year: Optional[str] = None
+    media_source: Optional[MediaSource] = None
+    media_id: Optional[str] = None
+    tmdb_id: Optional[int] = None
+    category: Optional[str] = None
+
+
+class TransferRoutePreviewRequest(BaseModel):
+    """分类与目录路由预览请求。"""
+
+    media: TransferRouteMediaSnapshot
+    metadata: dict[str, JsonData] = Field(default_factory=dict)
+    category_config: Optional[CategoryConfig] = None
+    directories: Optional[list[TransferDirectoryConf]] = None
+    match_mode: Optional[DirectoryMatchMode] = None
+    include_unsorted: bool = False
+    storage: Optional[str] = None
+    src_path: Optional[str] = None
+    target_storage: Optional[str] = None
+    dest_path: Optional[str] = None
+
+
+class TransferRoutePreviewResponse(BaseModel):
+    """分类与目录路由预览结果。"""
+
+    media: TransferRouteMediaSnapshot
+    metadata: dict[str, JsonData] = Field(default_factory=dict)
+    category: CategoryRouteDecision
+    route: DirectoryRouteDecision
+    comparisons: list[DirectoryRouteDecision] = Field(default_factory=list)
 
 
 class TransferJobTask(BaseModel):

--- a/app/schemas/types.py
+++ b/app/schemas/types.py
@@ -325,6 +325,8 @@ class SystemConfigKey(Enum):
     NotificationSwitchs = "NotificationSwitchs"
     # 目录配置
     Directories = "Directories"
+    # 目录匹配模式
+    DirectoryMatchMode = "DirectoryMatchMode"
     # 挂载型本地盘是否删除空目录
     MountedLocalDiskDeleteEmptyDirs = "MountedLocalDiskDeleteEmptyDirs"
     # 存储配置
@@ -395,6 +397,13 @@ class SystemConfigKey(Enum):
     UgreenSessionCache = "UgreenSessionCache"
     # 共享媒体识别成功次数
     MediaRecognizeShareCount = "MediaRecognizeShareCount"
+
+
+class DirectoryMatchMode(str, Enum):
+    """目录候选的选择模式。"""
+
+    SEQUENTIAL = "sequential"
+    SPECIFICITY = "specificity"
 
 
 # 处理进度Key字典

--- a/app/services/directory.py
+++ b/app/services/directory.py
@@ -6,12 +6,18 @@ from app import schemas
 from app.domain.context import MediaInfo
 from app.db.systemconfig_oper import SystemConfigOper
 from app.platform.log import logger
-from app.schemas.types import MediaType, StorageSchema, SystemConfigKey
+from app.schemas.types import (
+    DirectoryMatchMode,
+    MediaType,
+    StorageSchema,
+    SystemConfigKey,
+)
 from app.infrastructure.system import SystemUtils
 
 JINJA2_VAR_PATTERN = re.compile(r"\{\{.*?}}", re.DOTALL)
 WINDOWS_DRIVE_PATTERN = re.compile(r"^[A-Za-z]:[\\/]")
 WINDOWS_DRIVE_PREFIX_PATTERN = re.compile(r"^[A-Za-z]:")
+DIRECTORY_MATCH_LEVEL_SCORES = {"wildcard": 0, "media_type": 1, "category": 2}
 
 
 class DirectoryHelper:
@@ -45,6 +51,7 @@ class DirectoryHelper:
             self,
             media: Optional[MediaInfo],
             save_path: str,
+            match_mode: Optional[DirectoryMatchMode] = None,
     ) -> Optional[schemas.TransferDirectoryConf]:
         """
         按媒体信息和精确保存根路径匹配下载目录配置。
@@ -53,6 +60,7 @@ class DirectoryHelper:
 
         :param media: 媒体信息
         :param save_path: 已选择的下载保存目录，支持本地路径或远端 FileURI
+        :param match_mode: 目录候选选择模式，未传入时读取系统配置
         :return: 匹配的下载目录配置
         """
         value = str(save_path or "").strip()
@@ -62,7 +70,7 @@ class DirectoryHelper:
         except ValueError:
             return None
 
-        media_type = media.type.value if media else None
+        matched_dirs = []
         for dir_info in self.get_download_dirs():
             root = _normalize_download_root(dir_info)
             if not root:
@@ -70,13 +78,13 @@ class DirectoryHelper:
             root_storage, root_style, root_path = root
             if storage != root_storage or target_style != root_style or target_path != root_path:
                 continue
-            if not media_type or not dir_info.media_type:
-                return dir_info
-            if dir_info.media_type == media_type and not dir_info.media_category:
-                return dir_info
-            if dir_info.media_type == media_type and dir_info.media_category == media.category:
-                return dir_info
-        return None
+            matched_dirs.append(dir_info)
+        return self.evaluate_route(
+            media=media,
+            directories=matched_dirs,
+            include_unsorted=True,
+            match_mode=match_mode,
+        ).selected_directory
 
     def get_library_dirs(self) -> List[schemas.TransferDirectoryConf]:
         """
@@ -92,7 +100,8 @@ class DirectoryHelper:
 
     def get_dir(self, media: Optional[MediaInfo], include_unsorted: Optional[bool] = False,
                 storage: Optional[str] = None, src_path: Path = None,
-                target_storage: Optional[str] = None, dest_path: Path = None
+                target_storage: Optional[str] = None, dest_path: Path = None,
+                match_mode: Optional[DirectoryMatchMode] = None,
                 ) -> Optional[schemas.TransferDirectoryConf]:
         """
         根据媒体信息获取下载目录、媒体库目录配置
@@ -102,53 +111,271 @@ class DirectoryHelper:
         :param target_storage: 目标存储类型
         :param src_path: 源目录，有值时直接匹配
         :param dest_path: 目标目录，有值时直接匹配
+        :param match_mode: 目录候选选择模式，未传入时读取系统配置
         """
-        # 电影/电视剧
-        media_type = media.type.value if media else None
-        dirs = self.get_dirs()
+        return self.evaluate_route(
+            media=media,
+            include_unsorted=include_unsorted,
+            storage=storage,
+            src_path=src_path,
+            target_storage=target_storage,
+            dest_path=dest_path,
+            match_mode=match_mode,
+        ).selected_directory
 
-        # 如果存在源目录，并源目录为任一下载目录的子目录时，则进行源目录匹配，否则，允许源目录按同盘优先的逻辑匹配
-        matching_dirs = [d for d in dirs if src_path.is_relative_to(d.download_path)] if src_path else []
-        # 根据是否有匹配的源目录，决定要考虑的目录集合
-        dirs_to_consider = matching_dirs if matching_dirs else dirs
+    @staticmethod
+    def get_match_mode(
+            match_mode: Optional[DirectoryMatchMode] = None,
+    ) -> DirectoryMatchMode:
+        """
+        获取有效目录匹配模式，缺失或非法配置回退为顺序模式。
 
-        # 已匹配的目录
-        matched_dirs: List[schemas.TransferDirectoryConf] = []
-        # 按照配置顺序查找
-        for d in dirs_to_consider:
-            # 没有启用整理的目录
-            if not d.monitor_type and not include_unsorted:
-                continue
-            # 源存储类型不匹配
-            if storage and d.storage != storage:
-                continue
-            # 目标存储类型不匹配
-            if target_storage and d.library_storage != target_storage:
-                continue
-            # 有目标目录时，目标目录不匹配媒体库目录
-            if dest_path and dest_path != Path(d.library_path):
-                continue
-            # 目录类型为全部的，符合条件
-            if not media_type or not d.media_type:
-                matched_dirs.append(d)
-                continue
-            # 目录类型相等，目录类别为全部，符合条件
-            if d.media_type == media_type and not d.media_category:
-                matched_dirs.append(d)
-                continue
-            # 目录类型相等，目录类别相等，符合条件
-            if d.media_type == media_type and d.media_category == media.category:
-                matched_dirs.append(d)
-                continue
-        if matched_dirs:
-            if src_path:
-                # 优先源目录同盘
-                for matched_dir in matched_dirs:
-                    matched_path = Path(matched_dir.download_path)
-                    if self._is_same_source((src_path, storage or "local"), (matched_path, matched_dir.library_storage)):
-                        return matched_dir
-            return matched_dirs[0]
-        return None
+        :param match_mode: 调用方显式指定的匹配模式
+        :return: 有效匹配模式
+        """
+        value = match_mode
+        if value is None:
+            value = SystemConfigOper().get(SystemConfigKey.DirectoryMatchMode)
+        try:
+            return DirectoryMatchMode(value or DirectoryMatchMode.SEQUENTIAL)
+        except (TypeError, ValueError):
+            return DirectoryMatchMode.SEQUENTIAL
+
+    def evaluate_route(
+            self,
+            media: Optional[MediaInfo],
+            directories: Optional[List[schemas.TransferDirectoryConf]] = None,
+            include_unsorted: Optional[bool] = False,
+            storage: Optional[str] = None,
+            src_path: Path = None,
+            target_storage: Optional[str] = None,
+            dest_path: Path = None,
+            match_mode: Optional[DirectoryMatchMode] = None,
+            valid_categories: Optional[List[str]] = None,
+    ) -> schemas.DirectoryRouteDecision:
+        """
+        求值目录候选并按指定模式返回完整路由决策。
+
+        :param media: 媒体信息
+        :param directories: 可选目录配置草稿，未传入时读取当前配置
+        :param include_unsorted: 包含未启用监控整理的目录
+        :param storage: 源存储类型
+        :param src_path: 源路径
+        :param target_storage: 目标存储类型
+        :param dest_path: 显式目标路径
+        :param match_mode: 目录候选选择模式
+        :param valid_categories: 当前媒体类型可用的分类名称
+        :return: 目录候选、排除原因、警告和最终选择
+        """
+        mode = self.get_match_mode(match_mode)
+        dirs = self.get_dirs() if directories is None else list(directories)
+        media_type = self._media_type_value(media)
+
+        source_match_indices = []
+        if src_path:
+            source_match_indices = [
+                index
+                for index, directory in enumerate(dirs)
+                if directory.download_path
+                and src_path.is_relative_to(Path(directory.download_path))
+            ]
+        source_match_set = set(source_match_indices)
+
+        candidates = []
+        for index, directory in enumerate(dirs):
+            reasons = []
+            if source_match_set and index not in source_match_set:
+                reasons.append(schemas.RouteDiagnosticReason(
+                    code="source_path_scope_mismatch",
+                    message="源路径已命中其它下载目录",
+                ))
+            if not directory.monitor_type and not include_unsorted:
+                reasons.append(schemas.RouteDiagnosticReason(
+                    code="monitor_disabled",
+                    message="目录未启用整理监控",
+                ))
+            if storage and directory.storage != storage:
+                reasons.append(schemas.RouteDiagnosticReason(
+                    code="source_storage_mismatch",
+                    message="源存储类型不匹配",
+                ))
+            if target_storage and directory.library_storage != target_storage:
+                reasons.append(schemas.RouteDiagnosticReason(
+                    code="target_storage_mismatch",
+                    message="目标存储类型不匹配",
+                ))
+            if dest_path and (
+                    not directory.library_path
+                    or dest_path != Path(directory.library_path)
+            ):
+                reasons.append(schemas.RouteDiagnosticReason(
+                    code="destination_path_mismatch",
+                    message="显式目标路径不匹配",
+                ))
+
+            match_level = self._media_match_level(directory, media)
+            if not reasons and match_level == "none":
+                reasons.append(schemas.RouteDiagnosticReason(
+                    code="media_rule_mismatch",
+                    message="媒体类型或类别不匹配",
+                ))
+            eligible = not reasons
+            same_source = None
+            if eligible and src_path:
+                same_source = bool(
+                    directory.download_path
+                    and self._is_same_source(
+                        (src_path, storage or "local"),
+                        (Path(directory.download_path), directory.library_storage),
+                    )
+                )
+            candidates.append(schemas.DirectoryRouteCandidate(
+                index=index,
+                directory=directory,
+                eligible=eligible,
+                match_level=match_level,
+                same_source=same_source,
+                reasons=reasons,
+            ))
+
+        eligible_candidates = [candidate for candidate in candidates if candidate.eligible]
+        same_source_candidates = [
+            candidate for candidate in eligible_candidates if candidate.same_source
+        ]
+        selection_pool = same_source_candidates or eligible_candidates
+        selected = self._select_candidate(selection_pool, mode, bool(media_type))
+        if selected:
+            selected.selected = True
+
+        warnings = self._directory_warnings(
+            dirs=dirs,
+            selection_pool=selection_pool,
+            selected=selected,
+            mode=mode,
+            valid_categories=valid_categories,
+            media_type=media_type,
+        )
+        return schemas.DirectoryRouteDecision(
+            mode=mode,
+            selected_index=selected.index if selected else None,
+            selected_directory=selected.directory if selected else None,
+            candidates=candidates,
+            warnings=warnings,
+        )
+
+    @staticmethod
+    def _media_type_value(media: Optional[MediaInfo]) -> Optional[str]:
+        """获取兼容枚举和字符串的媒体类型值。"""
+        if not media or not media.type:
+            return None
+        return media.type.value if isinstance(media.type, MediaType) else str(media.type)
+
+    @classmethod
+    def _media_match_level(
+            cls,
+            directory: schemas.TransferDirectoryConf,
+            media: Optional[MediaInfo],
+    ) -> str:
+        """返回目录规则对媒体的匹配精确度。"""
+        media_type = cls._media_type_value(media)
+        if not media_type or not directory.media_type:
+            return "wildcard"
+        if directory.media_type != media_type:
+            return "none"
+        if not directory.media_category:
+            return "media_type"
+        if directory.media_category == media.category:
+            return "category"
+        return "none"
+
+    @staticmethod
+    def _select_candidate(
+            candidates: List[schemas.DirectoryRouteCandidate],
+            mode: DirectoryMatchMode,
+            has_media_type: bool,
+    ) -> Optional[schemas.DirectoryRouteCandidate]:
+        """在硬约束候选池中选择最终目录。"""
+        if not candidates:
+            return None
+        if mode == DirectoryMatchMode.SEQUENTIAL or not has_media_type:
+            return candidates[0]
+        highest_score = max(
+            DIRECTORY_MATCH_LEVEL_SCORES[candidate.match_level]
+            for candidate in candidates
+        )
+        return next(
+            candidate
+            for candidate in candidates
+            if DIRECTORY_MATCH_LEVEL_SCORES[candidate.match_level] == highest_score
+        )
+
+    @staticmethod
+    def _directory_warnings(
+            dirs: List[schemas.TransferDirectoryConf],
+            selection_pool: List[schemas.DirectoryRouteCandidate],
+            selected: Optional[schemas.DirectoryRouteCandidate],
+            mode: DirectoryMatchMode,
+            valid_categories: Optional[List[str]],
+            media_type: Optional[str],
+    ) -> List[schemas.RouteDiagnosticWarning]:
+        """生成目录配置与当前选择的非阻断警告。"""
+        warnings = []
+        if not selected:
+            warnings.append(schemas.RouteDiagnosticWarning(
+                code="no_matching_directory",
+                message="没有目录满足当前硬约束和媒体规则",
+            ))
+        elif mode == DirectoryMatchMode.SEQUENTIAL and any(
+                DIRECTORY_MATCH_LEVEL_SCORES[candidate.match_level]
+                > DIRECTORY_MATCH_LEVEL_SCORES[selected.match_level]
+                for candidate in selection_pool
+        ):
+            warnings.append(schemas.RouteDiagnosticWarning(
+                code="generic_before_specific",
+                message="顺序模式下通用目录先于更精确的类别目录命中",
+                related_indices=[candidate.index for candidate in selection_pool],
+            ))
+
+        if valid_categories is not None:
+            invalid_indices = [
+                index
+                for index, directory in enumerate(dirs)
+                if directory.media_category
+                and (
+                    not directory.media_type
+                    or directory.media_type == media_type
+                )
+                and directory.media_category not in valid_categories
+            ]
+            if invalid_indices:
+                warnings.append(schemas.RouteDiagnosticWarning(
+                    code="unknown_media_category",
+                    message="目录引用了当前分类配置中不存在的二级分类",
+                    related_indices=invalid_indices,
+                ))
+
+        duplicate_indices = []
+        conditions = {}
+        for index, directory in enumerate(dirs):
+            condition = (
+                directory.storage,
+                directory.download_path,
+                directory.media_type,
+                directory.media_category,
+            )
+            target = (directory.library_storage, directory.library_path)
+            previous = conditions.get(condition)
+            if previous and previous[1] != target:
+                duplicate_indices.extend([previous[0], index])
+            else:
+                conditions[condition] = (index, target)
+        if duplicate_indices:
+            warnings.append(schemas.RouteDiagnosticWarning(
+                code="duplicate_directory_conditions",
+                message="多个相同目录条件指向不同目标路径",
+                related_indices=sorted(set(duplicate_indices)),
+            ))
+        return warnings
 
     @staticmethod
     def _is_same_source(src: Tuple[Path, str],  tar: Tuple[Path, str]) -> bool:

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -143,11 +143,13 @@ FastAPI 的 HTTP 异常和参数校验异常统一使用 `message`，不再返�
 | GET | `/api/v1/media/{media_id}` | 按原生 ID 查询媒体详情；必填参数：`media_source`、`type_name`，其中 `media_source` 与路径中的 `media_id` 组成统一媒体身份 |
 | POST | `/api/v1/media/scrape/{storage}` | 刮削媒体元数据；请求体为 `FileItem`，可选查询参数 `media_source`、`media_id`、`type_name`（电影/电视剧/音乐）。音乐会按策略处理音频标签、封面和歌词 |
 | POST | `/api/v1/transfer/route/preview` | 使用已识别媒体快照预览分类与目录路由；请求可携带尚未保存的分类和目录草稿，接口不访问 TMDB、不执行整理，并同时返回 `sequential` 与 `specificity` 两种目录模式的候选、排除原因、冲突警告和最终选择 |
+| GET | `/api/v1/transfer/route/settings` | 一次读取目录配置和当前目录匹配模式 |
+| POST | `/api/v1/transfer/route/settings` | 在同一数据库事务中保存目录配置和目录匹配模式，避免两个独立设置请求产生部分更新 |
 | POST | `/api/v1/transfer/manual/target-path` | 按源文件与目录配置匹配手动整理目标路径；请求体为 `ManualTransferItem`，该接口不执行媒体识别 |
 | POST | `/api/v1/transfer/manual/history` | 查询文件、批量文件或目录命中的成功整理历史摘要，用于进入手动整理界面时显示重新整理状态 |
 | POST | `/api/v1/transfer/manual` | 手动整理；请求体可用 `media_source` + `media_id` 指定本次识别与刮削数据源；命中失败历史时自动清理旧目标和记录后重试，`reorganize=true` 时清理命中的成功历史和非移动模式旧目标后重新整理 |
 
-目录路由默认使用 `SystemConfigKey.DirectoryMatchMode=sequential`，保持按目录配置顺序选择的现有行为。管理员可通过通用系统设置接口将其显式设为 `specificity`；该模式只在通过监控状态、源路径、源/目标存储、显式目标路径和同源优先等约束后的候选池中应用“精确类别 > 媒体类型 > 通配”排序，同一精确度仍保持原配置顺序。分类规则始终按 `category.yaml` 顺序采用第一条命中，不受目录匹配模式影响。
+目录路由默认使用 `SystemConfigKey.DirectoryMatchMode=sequential`，保持按目录配置顺序选择的现有行为。管理员通过 `/transfer/route/settings` 将目录与模式作为一个设置契约保存；`specificity` 只在通过监控状态、源路径、源/目标存储、显式目标路径和同源优先等约束后的候选池中应用“精确类别 > 媒体类型 > 通配”排序，同一精确度仍保持原配置顺序。分类规则始终按 `category.yaml` 顺序采用第一条命中，不受目录匹配模式影响。
 
 #### 站点
 

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -142,9 +142,12 @@ FastAPI 的 HTTP 异常和参数校验异常统一使用 `message`，不再返�
 | GET | `/api/v1/media/recognize_file` | 识别文件路径，参数：`path`，可选 `media_source` |
 | GET | `/api/v1/media/{media_id}` | 按原生 ID 查询媒体详情；必填参数：`media_source`、`type_name`，其中 `media_source` 与路径中的 `media_id` 组成统一媒体身份 |
 | POST | `/api/v1/media/scrape/{storage}` | 刮削媒体元数据；请求体为 `FileItem`，可选查询参数 `media_source`、`media_id`、`type_name`（电影/电视剧/音乐）。音乐会按策略处理音频标签、封面和歌词 |
+| POST | `/api/v1/transfer/route/preview` | 使用已识别媒体快照预览分类与目录路由；请求可携带尚未保存的分类和目录草稿，接口不访问 TMDB、不执行整理，并同时返回 `sequential` 与 `specificity` 两种目录模式的候选、排除原因、冲突警告和最终选择 |
 | POST | `/api/v1/transfer/manual/target-path` | 按源文件与目录配置匹配手动整理目标路径；请求体为 `ManualTransferItem`，该接口不执行媒体识别 |
 | POST | `/api/v1/transfer/manual/history` | 查询文件、批量文件或目录命中的成功整理历史摘要，用于进入手动整理界面时显示重新整理状态 |
 | POST | `/api/v1/transfer/manual` | 手动整理；请求体可用 `media_source` + `media_id` 指定本次识别与刮削数据源；命中失败历史时自动清理旧目标和记录后重试，`reorganize=true` 时清理命中的成功历史和非移动模式旧目标后重新整理 |
+
+目录路由默认使用 `SystemConfigKey.DirectoryMatchMode=sequential`，保持按目录配置顺序选择的现有行为。管理员可通过通用系统设置接口将其显式设为 `specificity`；该模式只在通过监控状态、源路径、源/目标存储、显式目标路径和同源优先等约束后的候选池中应用“精确类别 > 媒体类型 > 通配”排序，同一精确度仍保持原配置顺序。分类规则始终按 `category.yaml` 顺序采用第一条命中，不受目录匹配模式影响。
 
 #### 站点
 

--- a/skills/moviepilot-api/SKILL.md
+++ b/skills/moviepilot-api/SKILL.md
@@ -355,6 +355,7 @@ Streaming search sends `{"type":"heartbeat"}` every 15 seconds without business 
 | GET | `/api/v1/transfer/queue` | Transfer queue |
 | DELETE | `/api/v1/transfer/queue` | Remove from transfer queue. Body: FileItem JSON |
 | POST | `/api/v1/transfer/manual/target-path` | Match the manual transfer target from source path and directory configuration. Body: ManualTransferItem JSON; this endpoint does not recognize media |
+| POST | `/api/v1/transfer/route/preview` | Preview category and directory routing from an already recognized media snapshot. Optional request drafts override current category/directory config; returns sequential and specificity comparisons without external recognition or file operations |
 | POST | `/api/v1/transfer/manual/history` | Query successful transfer-history summary for selected files or directories. Body: ManualTransferItem JSON |
 | POST | `/api/v1/transfer/manual` | Manual transfer. Params: `background`. Body: ManualTransferItem JSON; optional `media_source` + `media_id` select recognition and scraping source; matching failed history is cleared automatically, while `reorganize=true` removes matched successful history and old non-move targets before retrying |
 | GET | `/api/v1/transfer/now` | Run immediate transfer |

--- a/skills/moviepilot-api/SKILL.md
+++ b/skills/moviepilot-api/SKILL.md
@@ -347,7 +347,7 @@ Streaming search sends `{"type":"heartbeat"}` every 15 seconds without business 
 | POST | `/api/v1/storage/save/{name}` | Save storage config. Body: JSON object |
 | GET | `/api/v1/storage/reset/{name}` | Reset storage config |
 
-### Transfer (7 endpoints)
+### Transfer (10 endpoints)
 
 | Method | Path | Description |
 |--------|------|-------------|
@@ -356,6 +356,8 @@ Streaming search sends `{"type":"heartbeat"}` every 15 seconds without business 
 | DELETE | `/api/v1/transfer/queue` | Remove from transfer queue. Body: FileItem JSON |
 | POST | `/api/v1/transfer/manual/target-path` | Match the manual transfer target from source path and directory configuration. Body: ManualTransferItem JSON; this endpoint does not recognize media |
 | POST | `/api/v1/transfer/route/preview` | Preview category and directory routing from an already recognized media snapshot. Optional request drafts override current category/directory config; returns sequential and specificity comparisons without external recognition or file operations |
+| GET | `/api/v1/transfer/route/settings` | Read directory configuration and its match mode as one settings contract |
+| POST | `/api/v1/transfer/route/settings` | Atomically save directory configuration and its match mode |
 | POST | `/api/v1/transfer/manual/history` | Query successful transfer-history summary for selected files or directories. Body: ManualTransferItem JSON |
 | POST | `/api/v1/transfer/manual` | Manual transfer. Params: `background`. Body: ManualTransferItem JSON; optional `media_source` + `media_id` select recognition and scraping source; matching failed history is cleared automatically, while `reorganize=true` removes matched successful history and old non-move targets before retrying |
 | GET | `/api/v1/transfer/now` | Run immediate transfer |

--- a/tests/test_category_route_diagnostics.py
+++ b/tests/test_category_route_diagnostics.py
@@ -59,6 +59,27 @@ def test_unconditional_category_before_end_emits_unreachable_warning() -> None:
     assert any(warning.code == "unconditional_category_not_last" for warning in decision.warnings)
 
 
+def test_empty_category_conditions_are_treated_as_unconditional_fallback() -> None:
+    """仅含空值条件的规则也应按无条件兜底规则诊断。"""
+    rules = {
+        "空值兜底": CategoryRule(genre_ids=""),
+        "综艺": CategoryRule(genre_ids="10764"),
+    }
+
+    decision = CategoryHelper.evaluate_category(
+        categorys=rules,
+        tmdb_info={"genre_ids": [10764]},
+    )
+
+    assert decision.selected_category == "空值兜底"
+    assert decision.rules[1].matched is True
+    assert decision.rules[1].reachable is False
+    assert any(
+        warning.code == "unconditional_category_not_last" and warning.related_indices == [0]
+        for warning in decision.warnings
+    )
+
+
 def test_category_range_and_exclusion_keep_existing_semantics() -> None:
     """年份范围与排除条件在诊断重构后必须保持现有结果。"""
     rules = {

--- a/tests/test_category_route_diagnostics.py
+++ b/tests/test_category_route_diagnostics.py
@@ -1,0 +1,78 @@
+from app.modules.themoviedb.category import CategoryHelper
+from app.schemas.category import CategoryRule
+
+
+def test_category_diagnostics_preserve_first_match_and_explain_later_matches() -> None:
+    """分类诊断可展示多条匹配，但实际结果仍采用第一条。"""
+    rules = {
+        "动漫": CategoryRule(genre_ids="16"),
+        "欧美剧": CategoryRule(origin_country="US"),
+    }
+
+    decision = CategoryHelper.evaluate_category(
+        categorys=rules,
+        tmdb_info={"genre_ids": [16], "origin_country": ["US"]},
+    )
+
+    assert decision.selected_category == "动漫"
+    assert [rule.matched for rule in decision.rules] == [True, True]
+    assert decision.rules[0].selected is True
+    assert decision.rules[1].reachable is False
+    assert any(warning.code == "multiple_category_matches" for warning in decision.warnings)
+    assert CategoryHelper.get_category(rules, {"genre_ids": [16], "origin_country": ["US"]}) == "动漫"
+
+
+def test_category_diagnostics_explain_failed_animation_region_rules() -> None:
+    """美国动画应展示国漫、日番失败原因并继续命中欧美剧。"""
+    rules = {
+        "国漫": CategoryRule(genre_ids="16", origin_country="CN"),
+        "日番": CategoryRule(genre_ids="16", origin_country="JP"),
+        "欧美剧": CategoryRule(origin_country="US"),
+    }
+
+    decision = CategoryHelper.evaluate_category(
+        categorys=rules,
+        tmdb_info={"genre_ids": [16], "origin_country": ["US"]},
+    )
+
+    assert decision.selected_category == "欧美剧"
+    assert decision.rules[0].conditions[1].matched is False
+    assert decision.rules[1].conditions[1].matched is False
+    assert decision.rules[2].selected is True
+
+
+def test_unconditional_category_before_end_emits_unreachable_warning() -> None:
+    """中途兜底规则应保持命中语义并产生不可达诊断。"""
+    rules = {
+        "兜底": None,
+        "综艺": CategoryRule(genre_ids="10764"),
+    }
+
+    decision = CategoryHelper.evaluate_category(
+        categorys=rules,
+        tmdb_info={"genre_ids": [10764]},
+    )
+
+    assert decision.selected_category == "兜底"
+    assert decision.rules[1].matched is True
+    assert decision.rules[1].reachable is False
+    assert any(warning.code == "unconditional_category_not_last" for warning in decision.warnings)
+
+
+def test_category_range_and_exclusion_keep_existing_semantics() -> None:
+    """年份范围与排除条件在诊断重构后必须保持现有结果。"""
+    rules = {
+        "近期非美国": CategoryRule(release_year="2024-2026", origin_country="!US"),
+    }
+
+    matched = CategoryHelper.evaluate_category(
+        categorys=rules,
+        tmdb_info={"first_air_date": "2025-01-01", "origin_country": ["CN"]},
+    )
+    excluded = CategoryHelper.evaluate_category(
+        categorys=rules,
+        tmdb_info={"first_air_date": "2025-01-01", "origin_country": ["US"]},
+    )
+
+    assert matched.selected_category == "近期非美国"
+    assert excluded.selected_category == ""

--- a/tests/test_directory_route.py
+++ b/tests/test_directory_route.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
-from app.core.context import MediaInfo
-from app.helper.directory import DirectoryHelper
+from app.domain.context import MediaInfo
+from app.services.directory import DirectoryHelper
 from app.schemas import TransferDirectoryConf
 from app.schemas.types import DirectoryMatchMode, MediaType, SystemConfigKey
 
@@ -43,7 +43,7 @@ def test_sequential_mode_preserves_first_eligible_directory(monkeypatch) -> None
     ]
     monkeypatch.setattr(helper, "get_dirs", lambda: directories)
     monkeypatch.setattr(
-        "app.helper.directory.SystemConfigOper",
+        "app.services.directory.SystemConfigOper",
         lambda: type("Config", (), {"get": lambda _self, key: None})(),
     )
 
@@ -194,7 +194,7 @@ def test_get_dir_uses_persisted_specificity_mode(monkeypatch) -> None:
             return self.value
 
     config = Config()
-    monkeypatch.setattr("app.helper.directory.SystemConfigOper", lambda: config)
+    monkeypatch.setattr("app.services.directory.SystemConfigOper", lambda: config)
 
     assert helper.get_dir(media=_variety_media()).name == "综艺"
     config.value = "invalid"

--- a/tests/test_directory_route.py
+++ b/tests/test_directory_route.py
@@ -1,0 +1,304 @@
+from pathlib import Path
+
+from app.core.context import MediaInfo
+from app.helper.directory import DirectoryHelper
+from app.schemas import TransferDirectoryConf
+from app.schemas.types import DirectoryMatchMode, MediaType, SystemConfigKey
+
+
+def _directory(
+        name: str,
+        *,
+        media_type: str | None = None,
+        media_category: str | None = None,
+        storage: str = "local",
+        library_storage: str = "local",
+        download_path: str = "/downloads",
+        library_path: str | None = None,
+) -> TransferDirectoryConf:
+    """构造目录路由测试配置。"""
+    return TransferDirectoryConf(
+        name=name,
+        storage=storage,
+        library_storage=library_storage,
+        download_path=download_path,
+        library_path=library_path or f"/library/{name}",
+        media_type=media_type,
+        media_category=media_category,
+        monitor_type="monitor",
+    )
+
+
+def _variety_media() -> MediaInfo:
+    """构造已分类的综艺媒体。"""
+    return MediaInfo(type=MediaType.TV, title="测试综艺", category="综艺")
+
+
+def test_sequential_mode_preserves_first_eligible_directory(monkeypatch) -> None:
+    """默认顺序模式必须保持通用目录先命中的现有行为。"""
+    helper = DirectoryHelper()
+    directories = [
+        _directory("通用电视剧", media_type=MediaType.TV.value),
+        _directory("综艺", media_type=MediaType.TV.value, media_category="综艺"),
+    ]
+    monkeypatch.setattr(helper, "get_dirs", lambda: directories)
+    monkeypatch.setattr(
+        "app.helper.directory.SystemConfigOper",
+        lambda: type("Config", (), {"get": lambda _self, key: None})(),
+    )
+
+    decision = helper.evaluate_route(media=_variety_media())
+
+    assert decision.mode == DirectoryMatchMode.SEQUENTIAL
+    assert decision.selected_index == 0
+    assert decision.selected_directory.name == "通用电视剧"
+    assert decision.candidates[0].selected is True
+    assert decision.candidates[1].match_level == "category"
+    assert any(warning.code == "generic_before_specific" for warning in decision.warnings)
+    assert helper.get_dir(media=_variety_media()).name == "通用电视剧"
+
+
+def test_specificity_mode_prefers_exact_category_and_keeps_tie_order(monkeypatch) -> None:
+    """精确模式按类别、类型、通配排序，同级仍保持用户顺序。"""
+    helper = DirectoryHelper()
+    directories = [
+        _directory("通用电视剧", media_type=MediaType.TV.value),
+        _directory("综艺一", media_type=MediaType.TV.value, media_category="综艺"),
+        _directory("综艺二", media_type=MediaType.TV.value, media_category="综艺"),
+    ]
+    monkeypatch.setattr(helper, "get_dirs", lambda: directories)
+
+    decision = helper.evaluate_route(
+        media=_variety_media(),
+        match_mode=DirectoryMatchMode.SPECIFICITY,
+    )
+
+    assert decision.selected_index == 1
+    assert decision.selected_directory.name == "综艺一"
+    assert helper.get_dir(
+        media=_variety_media(),
+        match_mode=DirectoryMatchMode.SPECIFICITY,
+    ).name == "综艺一"
+
+
+def test_specificity_applies_after_storage_and_destination_constraints() -> None:
+    """精确度不得越过源存储、目标存储和显式目标路径约束。"""
+    helper = DirectoryHelper()
+    directories = [
+        _directory(
+            "错误源存储精确目录",
+            media_type=MediaType.TV.value,
+            media_category="综艺",
+            storage="alist",
+        ),
+        _directory(
+            "错误目标精确目录",
+            media_type=MediaType.TV.value,
+            media_category="综艺",
+            library_storage="u115",
+        ),
+        _directory(
+            "正确通用目录",
+            media_type=MediaType.TV.value,
+            library_path="/library/target",
+        ),
+    ]
+
+    decision = helper.evaluate_route(
+        media=_variety_media(),
+        directories=directories,
+        storage="local",
+        target_storage="local",
+        dest_path=Path("/library/target"),
+        match_mode=DirectoryMatchMode.SPECIFICITY,
+    )
+
+    assert decision.selected_directory.name == "正确通用目录"
+    assert decision.candidates[0].eligible is False
+    assert decision.candidates[0].reasons[0].code == "source_storage_mismatch"
+    assert decision.candidates[1].reasons[0].code == "target_storage_mismatch"
+
+
+def test_same_source_preference_precedes_specificity(monkeypatch) -> None:
+    """同源候选池必须先于媒体精确度选择。"""
+    helper = DirectoryHelper()
+    directories = [
+        _directory(
+            "另一存储精确目录",
+            media_type=MediaType.TV.value,
+            media_category="综艺",
+            download_path="/other",
+        ),
+        _directory(
+            "同源通用目录",
+            media_type=MediaType.TV.value,
+            download_path="/downloads",
+        ),
+    ]
+    monkeypatch.setattr(
+        helper,
+        "_is_same_source",
+        lambda _src, target: target[0] == Path("/downloads"),
+    )
+
+    decision = helper.evaluate_route(
+        media=_variety_media(),
+        directories=directories,
+        src_path=Path("/unmanaged/input/file.mkv"),
+        match_mode=DirectoryMatchMode.SPECIFICITY,
+    )
+
+    assert decision.selected_directory.name == "同源通用目录"
+    assert decision.candidates[1].same_source is True
+
+
+def test_media_none_keeps_all_eligible_directories_in_original_order() -> None:
+    """无媒体信息的手动整理不得因精确模式改变既有顺序。"""
+    helper = DirectoryHelper()
+    directories = [
+        _directory("电影目录", media_type=MediaType.MOVIE.value),
+        _directory("电视剧目录", media_type=MediaType.TV.value),
+    ]
+
+    decision = helper.evaluate_route(
+        media=None,
+        directories=directories,
+        match_mode=DirectoryMatchMode.SPECIFICITY,
+    )
+
+    assert decision.selected_index == 0
+    assert decision.selected_directory.name == "电影目录"
+    assert [candidate.match_level for candidate in decision.candidates] == [
+        "wildcard",
+        "wildcard",
+    ]
+
+
+def test_get_dir_uses_persisted_specificity_mode(monkeypatch) -> None:
+    """未显式传入模式时应读取持久化配置，非法值回退顺序模式。"""
+    helper = DirectoryHelper()
+    directories = [
+        _directory("通用电视剧", media_type=MediaType.TV.value),
+        _directory("综艺", media_type=MediaType.TV.value, media_category="综艺"),
+    ]
+    monkeypatch.setattr(helper, "get_dirs", lambda: directories)
+
+    class Config:
+        """返回测试中的目录匹配模式。"""
+
+        value = DirectoryMatchMode.SPECIFICITY.value
+
+        def get(self, key):
+            """读取匹配模式配置。"""
+            assert key is SystemConfigKey.DirectoryMatchMode
+            return self.value
+
+    config = Config()
+    monkeypatch.setattr("app.helper.directory.SystemConfigOper", lambda: config)
+
+    assert helper.get_dir(media=_variety_media()).name == "综艺"
+    config.value = "invalid"
+    assert helper.get_dir(media=_variety_media()).name == "通用电视剧"
+
+
+def test_download_save_root_uses_same_specificity_order(monkeypatch) -> None:
+    """精确保存根目录存在多条规则时应与最终目录使用同一精确度语义。"""
+    helper = DirectoryHelper()
+    directories = [
+        _directory("通用电视剧", media_type=MediaType.TV.value),
+        _directory("综艺", media_type=MediaType.TV.value, media_category="综艺"),
+    ]
+    monkeypatch.setattr(helper, "get_download_dirs", lambda: directories)
+
+    selected = helper.get_download_dir_by_save_path(
+        media=_variety_media(),
+        save_path="/downloads",
+        match_mode=DirectoryMatchMode.SPECIFICITY,
+    )
+
+    assert selected.name == "综艺"
+
+
+def test_route_diagnostics_report_all_hard_constraint_failures() -> None:
+    """单个候选同时违反多项硬约束时应完整返回所有原因。"""
+    helper = DirectoryHelper()
+    directory = _directory(
+        "错误目录",
+        media_type=MediaType.TV.value,
+        storage="alist",
+        library_storage="u115",
+        library_path="/library/other",
+    )
+    directory.monitor_type = None
+
+    decision = helper.evaluate_route(
+        media=_variety_media(),
+        directories=[directory],
+        storage="local",
+        target_storage="local",
+        dest_path=Path("/library/target"),
+    )
+
+    assert [reason.code for reason in decision.candidates[0].reasons] == [
+        "monitor_disabled",
+        "source_storage_mismatch",
+        "target_storage_mismatch",
+        "destination_path_mismatch",
+    ]
+
+
+def test_route_diagnostics_warn_for_unknown_duplicate_and_no_match() -> None:
+    """目录草稿中的无效类别、冲突条件和空候选应同时提示。"""
+    helper = DirectoryHelper()
+    directories = [
+        _directory(
+            "错误一",
+            media_type=MediaType.TV.value,
+            media_category="不存在的分类",
+            library_path="/library/one",
+        ),
+        _directory(
+            "错误二",
+            media_type=MediaType.TV.value,
+            media_category="不存在的分类",
+            library_path="/library/two",
+        ),
+    ]
+
+    decision = helper.evaluate_route(
+        media=_variety_media(),
+        directories=directories,
+        valid_categories=["综艺"],
+    )
+
+    warning_codes = {warning.code for warning in decision.warnings}
+    assert warning_codes == {
+        "no_matching_directory",
+        "unknown_media_category",
+        "duplicate_directory_conditions",
+    }
+    assert all(candidate.eligible is False for candidate in decision.candidates)
+
+
+def test_unknown_category_warning_ignores_other_media_types() -> None:
+    """当前电视剧预览不得误报电影目录使用的电影分类。"""
+    helper = DirectoryHelper()
+    directories = [
+        _directory(
+            "电影分类",
+            media_type=MediaType.MOVIE.value,
+            media_category="华语电影",
+        ),
+        _directory("综艺", media_type=MediaType.TV.value, media_category="综艺"),
+    ]
+
+    decision = helper.evaluate_route(
+        media=_variety_media(),
+        directories=directories,
+        valid_categories=["综艺"],
+    )
+
+    assert not any(
+        warning.code == "unknown_media_category"
+        for warning in decision.warnings
+    )

--- a/tests/test_systemconfig_oper.py
+++ b/tests/test_systemconfig_oper.py
@@ -67,6 +67,50 @@ def test_increment_supports_custom_step(monkeypatch):
     assert stored_value["value"] == 7
 
 
+def test_get_many_reads_one_locked_cache_snapshot():
+    """并发更新多个键时，批量读取不得返回新旧值混合的快照。"""
+    first_key = _unique_key()
+    second_key = _unique_key()
+    first_read = threading.Event()
+    writer_attempted = threading.Event()
+
+    class CoordinatedCache(dict):
+        """在首键读取后让写线程尝试获得同一把缓存锁。"""
+
+        def get(self, key, default=None):
+            value = super().get(key, default)
+            if key == first_key:
+                first_read.set()
+                assert writer_attempted.wait(timeout=1)
+            return value
+
+    oper = object.__new__(SystemConfigOper)
+    oper._rlock = threading.RLock()
+    oper._SystemConfigOper__SYSTEMCONF = CoordinatedCache({
+        first_key: "old",
+        second_key: "old",
+    })
+
+    def update_snapshot() -> None:
+        assert first_read.wait(timeout=1)
+        writer_attempted.set()
+        with oper._rlock:
+            oper._SystemConfigOper__SYSTEMCONF[first_key] = "new"
+            oper._SystemConfigOper__SYSTEMCONF[second_key] = "new"
+
+    writer = threading.Thread(target=update_snapshot)
+    writer.start()
+    snapshot = oper.get_many((first_key, second_key))
+    writer.join(timeout=1)
+
+    assert not writer.is_alive()
+    assert snapshot == {first_key: "old", second_key: "old"}
+    assert oper.get_many((first_key, second_key)) == {
+        first_key: "new",
+        second_key: "new",
+    }
+
+
 def test_set_creates_record_for_falsy_value():
     """无记录时写入假值应创建记录，而不是丢弃配置。"""
     key = _unique_key()
@@ -109,6 +153,40 @@ async def test_async_set_creates_record_for_falsy_value():
     assert await oper.async_set(key, 0) is True
     assert oper.get(key) == 0
     assert SystemConfig.get_by_key(oper._db, key).value == 0
+
+
+@pytest.mark.asyncio
+async def test_async_set_many_commits_values_together():
+    """批量设置应在一次成功事务后同时更新数据库和缓存。"""
+    first_key = _unique_key()
+    second_key = _unique_key()
+    oper = _fresh_oper()
+
+    changed = await oper.async_set_many({first_key: [1], second_key: "specificity"})
+
+    assert changed == {first_key, second_key}
+    assert oper.get(first_key) == [1]
+    assert oper.get(second_key) == "specificity"
+    assert SystemConfig.get_by_key(oper._db, first_key).value == [1]
+    assert SystemConfig.get_by_key(oper._db, second_key).value == "specificity"
+
+
+@pytest.mark.asyncio
+async def test_async_set_many_rolls_back_every_value_on_failure():
+    """任一配置无法持久化时不得留下部分数据库或缓存更新。"""
+    first_key = _unique_key()
+    second_key = _unique_key()
+    oper = _fresh_oper()
+    oper.set(first_key, "before-first")
+    oper.set(second_key, "before-second")
+
+    with pytest.raises(Exception):
+        await oper.async_set_many({first_key: "after", second_key: object()})
+
+    assert oper.get(first_key) == "before-first"
+    assert oper.get(second_key) == "before-second"
+    assert SystemConfig.get_by_key(oper._db, first_key).value == "before-first"
+    assert SystemConfig.get_by_key(oper._db, second_key).value == "before-second"
 
 
 def test_delete_removes_record_explicitly():

--- a/tests/test_transfer_route_preview.py
+++ b/tests/test_transfer_route_preview.py
@@ -1,0 +1,129 @@
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from app.api.endpoints import transfer as transfer_endpoint
+from app.chain.transfer import TransferChain
+from app.db.user_oper import get_current_active_manage_user
+from app.schemas import (
+    CategoryConfig,
+    CategoryRule,
+    TransferDirectoryConf,
+    TransferRouteMediaSnapshot,
+    TransferRoutePreviewRequest,
+)
+from app.schemas.types import DirectoryMatchMode, MediaType
+
+
+def _preview_request(category: str | None = None) -> TransferRoutePreviewRequest:
+    """构造无外部依赖的目录路由预览请求。"""
+    return TransferRoutePreviewRequest(
+        media=TransferRouteMediaSnapshot(
+            type=MediaType.TV,
+            title="测试综艺",
+            year="2026",
+            category=category,
+        ),
+        metadata={"genre_ids": [10764], "origin_country": ["CN"]},
+        category_config=CategoryConfig(
+            tv={"综艺": CategoryRule(genre_ids="10764")},
+        ),
+        directories=[
+            TransferDirectoryConf(
+                name="通用电视剧",
+                media_type=MediaType.TV.value,
+                monitor_type="monitor",
+                storage="local",
+                library_storage="local",
+                download_path="/downloads",
+                library_path="/library/tv",
+            ),
+            TransferDirectoryConf(
+                name="综艺",
+                media_type=MediaType.TV.value,
+                media_category="综艺",
+                monitor_type="monitor",
+                storage="local",
+                library_storage="local",
+                download_path="/downloads",
+                library_path="/library/variety",
+            ),
+        ],
+        match_mode=DirectoryMatchMode.SPECIFICITY,
+    )
+
+
+def test_transfer_chain_preview_compares_modes_without_network() -> None:
+    """路由预览应复用同一快照比较两种模式且不触发外部识别。"""
+    response = TransferChain.preview_route(_preview_request())
+
+    assert response.category.selected_category == "综艺"
+    assert response.metadata["genre_ids"] == [10764]
+    assert response.category.source == "automatic"
+    assert response.route.mode == DirectoryMatchMode.SPECIFICITY
+    assert response.route.selected_directory.name == "综艺"
+    decisions = {decision.mode: decision for decision in response.comparisons}
+    assert decisions[DirectoryMatchMode.SEQUENTIAL].selected_directory.name == "通用电视剧"
+    assert decisions[DirectoryMatchMode.SPECIFICITY].selected_directory.name == "综艺"
+
+
+def test_transfer_chain_preview_preserves_provided_category_and_warns_on_conflict() -> None:
+    """订阅或历史提供的类别优先于自动分类，并明确报告冲突。"""
+    response = TransferChain.preview_route(_preview_request(category="纪录片"))
+
+    assert response.category.automatic_category == "综艺"
+    assert response.category.selected_category == "纪录片"
+    assert response.category.source == "provided"
+    assert any(warning.code == "provided_category_conflict" for warning in response.category.warnings)
+
+
+def test_transfer_chain_preview_reads_current_configs_when_drafts_are_omitted(monkeypatch) -> None:
+    """未传草稿时只读取本地配置，不调用媒体识别或 TMDB。"""
+    request = _preview_request()
+    request.category_config = None
+    request.directories = None
+    category_config = CategoryConfig(tv={"综艺": CategoryRule(genre_ids="10764")})
+    directories = _preview_request().directories
+    monkeypatch.setattr(
+        "app.chain.transfer.CategoryHelper.load",
+        lambda _self: category_config,
+    )
+    monkeypatch.setattr(
+        "app.chain.transfer.DirectoryHelper.get_dirs",
+        lambda _self: directories,
+    )
+
+    with patch("app.chain.transfer.MediaChain") as media_chain:
+        response = TransferChain.preview_route(request)
+
+    media_chain.assert_not_called()
+    assert response.route.selected_directory.name == "综艺"
+
+
+@pytest.mark.anyio
+async def test_route_preview_endpoint_uses_typed_chain_contract() -> None:
+    """REST 入口应校验请求并把业务编排交给 TransferChain。"""
+    request = _preview_request()
+    expected = TransferChain.preview_route(request)
+    app = FastAPI()
+    app.include_router(transfer_endpoint.router, prefix="/api/v1/transfer")
+    app.dependency_overrides[get_current_active_manage_user] = lambda: Mock()
+
+    with patch.object(TransferChain, "preview_route", return_value=expected) as preview:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            response = await client.post(
+                "/api/v1/transfer/route/preview",
+                json=request.model_dump(mode="json"),
+            )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is True
+    assert body["data"]["route"]["selected_directory"]["name"] == "综艺"
+    preview.assert_called_once()
+    assert preview.call_args.args[0].media.type == MediaType.TV

--- a/tests/test_transfer_route_preview.py
+++ b/tests/test_transfer_route_preview.py
@@ -1,20 +1,24 @@
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
 from fastapi import FastAPI
 
 from app.api.endpoints import transfer as transfer_endpoint
-from app.chain.transfer import TransferChain
-from app.db.user_oper import get_current_active_manage_user
+from app.chain.directory_route import DirectoryRouteChain
+from app.db.user_oper import (
+    get_current_active_manage_user,
+    get_current_active_superuser_async,
+)
 from app.schemas import (
     CategoryConfig,
     CategoryRule,
     TransferDirectoryConf,
+    DirectoryRouteSettings,
     TransferRouteMediaSnapshot,
     TransferRoutePreviewRequest,
 )
-from app.schemas.types import DirectoryMatchMode, MediaType
+from app.schemas.types import DirectoryMatchMode, EventType, MediaType, SystemConfigKey
 
 
 def _preview_request(category: str | None = None) -> TransferRoutePreviewRequest:
@@ -55,9 +59,9 @@ def _preview_request(category: str | None = None) -> TransferRoutePreviewRequest
     )
 
 
-def test_transfer_chain_preview_compares_modes_without_network() -> None:
+def test_directory_route_chain_preview_compares_modes_without_network() -> None:
     """路由预览应复用同一快照比较两种模式且不触发外部识别。"""
-    response = TransferChain.preview_route(_preview_request())
+    response = DirectoryRouteChain.preview(_preview_request())
 
     assert response.category.selected_category == "综艺"
     assert response.metadata["genre_ids"] == [10764]
@@ -69,9 +73,9 @@ def test_transfer_chain_preview_compares_modes_without_network() -> None:
     assert decisions[DirectoryMatchMode.SPECIFICITY].selected_directory.name == "综艺"
 
 
-def test_transfer_chain_preview_preserves_provided_category_and_warns_on_conflict() -> None:
+def test_directory_route_chain_preview_preserves_provided_category_and_warns_on_conflict() -> None:
     """订阅或历史提供的类别优先于自动分类，并明确报告冲突。"""
-    response = TransferChain.preview_route(_preview_request(category="纪录片"))
+    response = DirectoryRouteChain.preview(_preview_request(category="纪录片"))
 
     assert response.category.automatic_category == "综艺"
     assert response.category.selected_category == "纪录片"
@@ -79,7 +83,7 @@ def test_transfer_chain_preview_preserves_provided_category_and_warns_on_conflic
     assert any(warning.code == "provided_category_conflict" for warning in response.category.warnings)
 
 
-def test_transfer_chain_preview_reads_current_configs_when_drafts_are_omitted(monkeypatch) -> None:
+def test_directory_route_chain_preview_reads_current_configs_when_drafts_are_omitted(monkeypatch) -> None:
     """未传草稿时只读取本地配置，不调用媒体识别或 TMDB。"""
     request = _preview_request()
     request.category_config = None
@@ -87,31 +91,29 @@ def test_transfer_chain_preview_reads_current_configs_when_drafts_are_omitted(mo
     category_config = CategoryConfig(tv={"综艺": CategoryRule(genre_ids="10764")})
     directories = _preview_request().directories
     monkeypatch.setattr(
-        "app.chain.transfer.CategoryHelper.load",
+        "app.chain.directory_route.CategoryHelper.load",
         lambda _self: category_config,
     )
     monkeypatch.setattr(
-        "app.chain.transfer.DirectoryHelper.get_dirs",
+        "app.chain.directory_route.DirectoryHelper.get_dirs",
         lambda _self: directories,
     )
 
-    with patch("app.chain.transfer.MediaChain") as media_chain:
-        response = TransferChain.preview_route(request)
+    response = DirectoryRouteChain.preview(request)
 
-    media_chain.assert_not_called()
     assert response.route.selected_directory.name == "综艺"
 
 
 @pytest.mark.anyio
 async def test_route_preview_endpoint_uses_typed_chain_contract() -> None:
-    """REST 入口应校验请求并把业务编排交给 TransferChain。"""
+    """REST 入口应校验请求并把业务编排交给 DirectoryRouteChain。"""
     request = _preview_request()
-    expected = TransferChain.preview_route(request)
+    expected = DirectoryRouteChain.preview(request)
     app = FastAPI()
     app.include_router(transfer_endpoint.router, prefix="/api/v1/transfer")
     app.dependency_overrides[get_current_active_manage_user] = lambda: Mock()
 
-    with patch.object(TransferChain, "preview_route", return_value=expected) as preview:
+    with patch.object(DirectoryRouteChain, "preview", return_value=expected) as preview:
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app),
             base_url="http://testserver",
@@ -127,3 +129,109 @@ async def test_route_preview_endpoint_uses_typed_chain_contract() -> None:
     assert body["data"]["route"]["selected_directory"]["name"] == "综艺"
     preview.assert_called_once()
     assert preview.call_args.args[0].media.type == MediaType.TV
+
+
+@pytest.mark.anyio
+async def test_route_settings_endpoint_saves_one_typed_contract() -> None:
+    """目录和匹配模式应通过同一后端契约保存。"""
+    route_settings = DirectoryRouteSettings(
+        directories=_preview_request().directories,
+        match_mode=DirectoryMatchMode.SPECIFICITY,
+    )
+    app = FastAPI()
+    app.include_router(transfer_endpoint.router, prefix="/api/v1/transfer")
+    app.dependency_overrides[get_current_active_superuser_async] = lambda: Mock()
+
+    with patch.object(
+        DirectoryRouteChain,
+        "save_settings",
+        new=AsyncMock(return_value=route_settings),
+    ) as save_settings:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            response = await client.post(
+                "/api/v1/transfer/route/settings",
+                json=route_settings.model_dump(mode="json"),
+            )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["match_mode"] == "specificity"
+    save_settings.assert_awaited_once()
+    assert save_settings.await_args.args[0] == route_settings
+
+
+@pytest.mark.anyio
+async def test_directory_route_chain_saves_settings_atomically(monkeypatch) -> None:
+    """业务链应批量持久化两个配置键并只广播一次变更。"""
+    route_settings = DirectoryRouteSettings(
+        directories=_preview_request().directories,
+        match_mode=DirectoryMatchMode.SPECIFICITY,
+    )
+    config_oper = Mock()
+    config_oper.async_set_many = AsyncMock(return_value={
+        SystemConfigKey.Directories.value,
+        SystemConfigKey.DirectoryMatchMode.value,
+    })
+    send_event = AsyncMock()
+    monkeypatch.setattr("app.chain.directory_route.SystemConfigOper", lambda: config_oper)
+    monkeypatch.setattr("app.chain.directory_route.eventmanager.async_send_event", send_event)
+
+    saved = await DirectoryRouteChain.save_settings(route_settings)
+
+    assert saved == route_settings
+    values = config_oper.async_set_many.await_args.args[0]
+    assert values[SystemConfigKey.DirectoryMatchMode] == "specificity"
+    assert values[SystemConfigKey.Directories][1]["media_category"] == "综艺"
+    send_event.assert_awaited_once()
+    assert send_event.await_args.kwargs["etype"] is EventType.ConfigChanged
+    assert send_event.await_args.kwargs["data"].key == {
+        SystemConfigKey.Directories.value,
+        SystemConfigKey.DirectoryMatchMode.value,
+    }
+
+
+def test_directory_route_chain_reads_settings_from_one_snapshot(monkeypatch) -> None:
+    """目录设置读取应通过一次多键快照构造完整响应。"""
+    config_oper = Mock()
+    config_oper.get_many.return_value = {
+        SystemConfigKey.Directories.value: [
+            directory.model_dump(mode="json", exclude_none=True)
+            for directory in _preview_request().directories
+        ],
+        SystemConfigKey.DirectoryMatchMode.value: "specificity",
+    }
+    monkeypatch.setattr("app.chain.directory_route.SystemConfigOper", lambda: config_oper)
+
+    settings = DirectoryRouteChain.get_settings()
+
+    assert settings.match_mode is DirectoryMatchMode.SPECIFICITY
+    assert settings.directories[1].name == "综艺"
+    config_oper.get_many.assert_called_once_with((
+        SystemConfigKey.Directories,
+        SystemConfigKey.DirectoryMatchMode,
+    ))
+
+
+@pytest.mark.anyio
+async def test_route_settings_endpoint_returns_current_atomic_contract() -> None:
+    """设置查询入口应一次返回目录和匹配模式。"""
+    route_settings = DirectoryRouteSettings(
+        directories=_preview_request().directories,
+        match_mode=DirectoryMatchMode.SPECIFICITY,
+    )
+    app = FastAPI()
+    app.include_router(transfer_endpoint.router, prefix="/api/v1/transfer")
+    app.dependency_overrides[get_current_active_manage_user] = lambda: Mock()
+
+    with patch.object(DirectoryRouteChain, "get_settings", return_value=route_settings):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            response = await client.get("/api/v1/transfer/route/settings")
+
+    assert response.status_code == 200
+    assert response.json()["data"]["match_mode"] == "specificity"
+    assert response.json()["data"]["directories"][1]["name"] == "综艺"


### PR DESCRIPTION
## 关联

- RFC：#6313
- 前端：jxxghp/MoviePilot-Frontend#678

## 变更

- 抽取分类规则与目录候选的统一求值结果，输出命中条件、排除原因和非阻断警告。
- 新增 `DirectoryMatchMode`：默认 `sequential` 完全保留现有顺序语义，用户可显式启用 `specificity`，按精确类别、媒体类型、通配目录选择候选。
- 让下载保存目录与最终媒体库目录复用同一候选选择逻辑，并保留存储、源路径、目标路径、同盘等现有硬约束。
- 新增 `DirectoryRouteChain`，集中编排目录设置、分类诊断与路由预览，避免继续扩张 `TransferChain`。
- 新增 `GET/POST /api/v1/transfer/route/settings`，在同一数据库事务中保存目录和匹配模式，并从同一缓存快照读取。
- 新增 `POST /api/v1/transfer/route/preview`，仅对传入的媒体与元数据快照求值，不访问 TMDB、不创建目录、不移动文件。
- 增加分类冲突、不可达兜底、通用目录抢先、未知类别、重复条件和无匹配目录等诊断。
- 补充 API/MCP 文档以及路由、配置原子性和并发回归测试。

## 兼容性

- 默认模式始终为 `sequential`，旧配置无需迁移，升级后不会静默改变整理路径。
- 分类规则继续保持第一条命中获胜，不按条件数量自动重排。
- `media=None`、显式目标路径和现有目录优先级保持原行为。
- `SystemConfig` 仍使用键值存储，不涉及数据库模型或 Alembic 迁移。

## 验证

- 路由、配置竞态、API 鉴权与架构相关测试：46 passed。
- 全量测试：4036 passed，3 skipped；4 个失败已在当前 `upstream/v3@7b3444c3` 基线确认：`BluRayTest.test`、`test_manifest_aliases_reuse_real_canonical_modules`、`test_main_script_does_not_shadow_stdlib_platform`、`test_workflow_manager_list_actions_exposes_contract`。
- 变更模块 pylint：10.00/10。
- 严格可维护性复审：APPROVED。
- `git diff --check` 与敏感信息扫描通过。
