### PR TITLE
fix(runtime): 严格校验 Capability canonical entrypoint

### DIFF
--- a/app/runtime/capabilities/runtime.py
+++ b/app/runtime/capabilities/runtime.py
@@ -433,8 +433,16 @@ class CapabilityRuntime:
         module_name, symbol_name = spec.entrypoint.split(":", maxsplit=1)
         module = sys.modules.get(module_name)
         namespace = getattr(module, "__dict__", None) if module is not None else None
-        if not isinstance(namespace, dict) or symbol_name not in namespace:
-            return implementation
+        if not isinstance(namespace, dict):
+            raise CapabilityAdapterContractError(
+                f"adapter 返回 {spec.id} 的 implementation 后，"
+                f"canonical 模块 {module_name} 未加载"
+            )
+        if symbol_name not in namespace:
+            raise CapabilityAdapterContractError(
+                f"adapter 返回 {spec.id} 的 implementation 后，"
+                f"canonical 符号 {spec.entrypoint} 不存在"
+            )
         canonical = namespace[symbol_name]
         if implementation is not canonical:
             raise CapabilityAdapterContractError(
@@ -579,8 +587,8 @@ class CapabilityRuntime:
                         state.pending_cleanup_error = pending_error
                     raise
             if implementation is None:
-                implementation = self._sync_callback(adapter, "materialize", state.spec)
-                implementation = self._canonical_implementation(state.spec, implementation)
+                materialized = self._sync_callback(adapter, "materialize", state.spec)
+                implementation = self._canonical_implementation(state.spec, materialized)
             candidate = self._sync_callback(
                 adapter,
                 "create",
@@ -766,8 +774,8 @@ class CapabilityRuntime:
                         state.pending_cleanup_error = pending_error
                     raise
             if implementation is None:
-                implementation = await self._async_callback(adapter, "materialize", state.spec)
-                implementation = self._canonical_implementation(state.spec, implementation)
+                materialized = await self._async_callback(adapter, "materialize", state.spec)
+                implementation = self._canonical_implementation(state.spec, materialized)
             candidate = await self._async_callback(
                 adapter,
                 "create",

--- a/tests/test_capability_runtime.py
+++ b/tests/test_capability_runtime.py
@@ -4,10 +4,11 @@ import asyncio
 import sys
 import threading
 import types
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -62,6 +63,32 @@ class _Candidate:
     stopped: bool = False
 
 
+class _SampleCapability:
+    pass
+
+
+@pytest.fixture(autouse=True)
+def isolate_sample_entrypoints() -> Iterator[None]:
+    """隔离合成 adapter 在 sys.modules 中公开的 canonical entrypoint。"""
+    module_names = ("sample_implementation", "other_implementation")
+    previous = {name: sys.modules[name] for name in module_names if name in sys.modules}
+    for name in module_names:
+        sys.modules.pop(name, None)
+    yield
+    for name in module_names:
+        sys.modules.pop(name, None)
+        if name in previous:
+            sys.modules[name] = previous[name]
+
+
+def _materialize_sample(spec) -> type[_SampleCapability]:
+    module_name, symbol_name = spec.entrypoint.split(":", maxsplit=1)
+    module = types.ModuleType(module_name)
+    setattr(module, symbol_name, _SampleCapability)
+    sys.modules[module_name] = module
+    return _SampleCapability
+
+
 class _SyncAdapter:
     execution_mode = AdapterExecutionMode.SYNC
 
@@ -84,7 +111,7 @@ class _SyncAdapter:
         self.materialize_calls += 1
         if self.fail_materialize:
             raise RuntimeError("materialize failed")
-        return object()
+        return _materialize_sample(spec)
 
     def create(self, spec, implementation: object, generation: int, previous: Any = None) -> _Candidate:
         self.create_calls += 1
@@ -139,7 +166,7 @@ class _AsyncAdapter:
         await asyncio.sleep(0)
         if self.fail_materialize:
             raise RuntimeError("async materialize failed")
-        return object()
+        return _materialize_sample(spec)
 
     async def create(self, spec, implementation: object, generation: int, previous: Any = None) -> _Candidate:
         self.create_calls += 1
@@ -208,6 +235,107 @@ def test_materialize_failure_does_not_claim_resource_lifecycle_failure(tmp_path:
     assert snapshot.materialization is CapabilityMaterializationState.FAILED
     assert snapshot.lifecycle is CapabilityLifecycleState.DISCOVERED
     assert snapshot.visible is False
+
+
+def test_materialize_rejects_missing_canonical_module(
+    tmp_path: Path,
+) -> None:
+    """adapter 未加载 manifest 指定模块时不得发布替代实现。"""
+    adapter = _SyncAdapter()
+    runtime = CapabilityRuntime(
+        _registry(tmp_path),
+        adapters={"sample": adapter},
+    )
+
+    with patch.object(adapter, "materialize", return_value=_SampleCapability), pytest.raises(
+        CapabilityOperationError,
+        match="canonical 模块.*未加载",
+    ):
+        runtime.materialize("sample.capability", reason="invalid_adapter")
+
+    snapshot = runtime.snapshot("sample.capability")
+    assert snapshot.materialization is CapabilityMaterializationState.FAILED
+    assert snapshot.lifecycle is CapabilityLifecycleState.DISCOVERED
+
+
+def test_materialize_rejects_missing_canonical_symbol(
+    tmp_path: Path,
+) -> None:
+    """adapter 未公开 manifest 指定符号时不得发布替代实现。"""
+    sys.modules["sample_implementation"] = types.ModuleType("sample_implementation")
+    adapter = _SyncAdapter()
+    runtime = CapabilityRuntime(
+        _registry(tmp_path),
+        adapters={"sample": adapter},
+    )
+
+    with patch.object(adapter, "materialize", return_value=_SampleCapability), pytest.raises(
+        CapabilityOperationError,
+        match="canonical 符号.*不存在",
+    ):
+        runtime.materialize("sample.capability", reason="invalid_adapter")
+
+    snapshot = runtime.snapshot("sample.capability")
+    assert snapshot.materialization is CapabilityMaterializationState.FAILED
+    assert snapshot.lifecycle is CapabilityLifecycleState.DISCOVERED
+
+
+def test_activate_revalidates_missing_canonical_module_on_retry(tmp_path: Path) -> None:
+    """同步激活的物化合同失败不得被记为已解析并在重试时绕过。"""
+    adapter = _SyncAdapter()
+    runtime = CapabilityRuntime(
+        _registry(tmp_path),
+        adapters={"sample": adapter},
+    )
+
+    with patch.object(
+        adapter,
+        "materialize",
+        return_value=_SampleCapability,
+    ) as materialize:
+        with pytest.raises(CapabilityOperationError, match="canonical 模块.*未加载"):
+            runtime.activate("sample.capability", reason="invalid_adapter")
+        with pytest.raises(CapabilityOperationError, match="canonical 模块.*未加载"):
+            runtime.activate(
+                "sample.capability",
+                reason="invalid_adapter_retry",
+                retry=True,
+            )
+
+    snapshot = runtime.snapshot("sample.capability")
+    assert snapshot.materialization is CapabilityMaterializationState.FAILED
+    assert snapshot.lifecycle is CapabilityLifecycleState.FAILED
+    assert adapter.create_calls == 0
+    assert materialize.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_activate_async_revalidates_missing_canonical_module_on_retry(
+    tmp_path: Path,
+) -> None:
+    """异步激活的物化合同失败不得被记为已解析并在重试时绕过。"""
+    adapter = _AsyncAdapter()
+    runtime = CapabilityRuntime(
+        _registry(tmp_path),
+        adapters={"sample": adapter},
+    )
+    materialize = AsyncMock(return_value=_SampleCapability)
+
+    with patch.object(adapter, "materialize", new=materialize):
+        with pytest.raises(CapabilityOperationError, match="canonical 模块.*未加载"):
+            await runtime.activate_async("sample.capability", reason="invalid_adapter")
+        with pytest.raises(CapabilityOperationError, match="canonical 模块.*未加载"):
+            await runtime.activate_async(
+                "sample.capability",
+                reason="invalid_adapter_retry",
+                retry=True,
+            )
+
+    snapshot = runtime.snapshot("sample.capability")
+    assert snapshot.materialization is CapabilityMaterializationState.FAILED
+    assert snapshot.lifecycle is CapabilityLifecycleState.FAILED
+    assert adapter.create_calls == 0
+    assert materialize.await_count == 2
 
 
 def test_state_read_calibrates_consumer_import_without_importing_new_module(tmp_path: Path) -> None:


### PR DESCRIPTION
## 问题

Capability Runtime 在 adapter 返回 implementation 后，如果 manifest 指定的 canonical 模块尚未加载或符号不存在，会直接接受该返回值。同步和异步激活路径还会在校验失败后保留这个无效对象并标记为已解析，使后续 `retry=True` 能跳过 canonical 校验并启动与声明不一致的实现。

## 调整

- 对缺失 canonical 模块、缺失符号和对象 identity 不一致统一按 adapter 合同错误处理。
- 同步与异步激活仅在 canonical 校验成功后保存 implementation，失败重试必须重新物化并再次校验。
- 测试 adapter 改为公开真实 canonical entrypoint，并隔离其 `sys.modules` 状态；补充缺模块、缺符号及同步/异步重试回归。

旧插件先显式导入 canonical symbol 时使用的 consumer-import 校准路径保持不变。

## 验证

- `python tests/run.py`：`4702 passed, 3 skipped`，零真实出站。
- Runtime、Host Module、Managed Resource、Agent 聚焦测试：`63 passed`。
- 改动文件 Pylint：`10.00/10`。
- `git diff --check`：通过。

全量 `pylint app` 在当前 `v3` 基线上仍有 4 个既有 E0611：`app/chain/_messaging.py` 与 `app/agent/callback/__init__.py` 引用 `app.schemas.message` 中已移除的 `ChannelCapability*`。相关文件与本 PR 无差异。
