### PR TITLE
fix: 修复源码运行时 app.env 路径解析

### DIFF
--- a/app/adapters/system/host.py
+++ b/app/adapters/system/host.py
@@ -902,7 +902,7 @@ class SystemUtils:
         elif SystemUtils.is_frozen():
             return Path(sys.executable).parent / "config"
         else:
-            return Path(__file__).parents[2] / "config"
+            return Path(__file__).resolve().parents[3] / "config"
 
     @staticmethod
     def get_env_path() -> Path:

--- a/tests/test_system_utils.py
+++ b/tests/test_system_utils.py
@@ -17,6 +17,42 @@ from app.adapters.system.host import SystemUtils
 
 class SystemUtilsTest(TestCase):
 
+    def test_get_config_path_uses_repository_config_for_source_runtime(self):
+        """源码运行时应从项目根目录读取配置，不能随适配器目录层级偏移。"""
+        expected = Path(__file__).resolve().parents[1] / "config"
+
+        with patch.dict(os.environ, {}, clear=True), \
+                patch.object(SystemUtils, "is_docker", return_value=False), \
+                patch.object(SystemUtils, "is_frozen", return_value=False):
+            self.assertEqual(SystemUtils.get_config_path(), expected)
+            self.assertEqual(SystemUtils.get_env_path(), expected / "app.env")
+
+    def test_get_config_path_preserves_explicit_config_dir(self):
+        """显式配置目录始终优先于运行环境推导。"""
+        explicit_path = Path("/custom/moviepilot-config")
+
+        with patch.dict(os.environ, {"CONFIG_DIR": "/ignored"}, clear=True), \
+                patch.object(SystemUtils, "is_docker", return_value=True):
+            self.assertEqual(
+                SystemUtils.get_config_path(str(explicit_path)),
+                explicit_path,
+            )
+
+    def test_get_config_path_preserves_runtime_specific_defaults(self):
+        """容器和冻结程序继续使用各自稳定的配置目录。"""
+        with patch.dict(os.environ, {}, clear=True), \
+                patch.object(SystemUtils, "is_docker", return_value=True):
+            self.assertEqual(SystemUtils.get_config_path(), Path("/config"))
+
+        with patch.dict(os.environ, {}, clear=True), \
+                patch.object(SystemUtils, "is_docker", return_value=False), \
+                patch.object(SystemUtils, "is_frozen", return_value=True), \
+                patch("app.adapters.system.host.sys.executable", "/opt/moviepilot/moviepilot"):
+            self.assertEqual(
+                SystemUtils.get_config_path(),
+                Path("/opt/moviepilot/config"),
+            )
+
     def test_execute_with_subprocess_keeps_stdout_when_command_fails(self):
         """
         命令失败时如果原因只写入 stdout，也需要回传给调用方用于错误提示。


### PR DESCRIPTION
后端模块边界重组后，`SystemUtils` 的源码位置加深了一层，但源码运行时配置目录仍沿用原来的 `parents[2]` 计算，导致 `app.env` 被错误解析到 `app/config/app.env`。因此项目根 `config/app.env` 中的 `DEV`、`DEBUG` 等设置不会生效。

将源码运行模式的配置根修正为项目根目录，并增加回归测试覆盖：

- 源码运行时读取项目根 `config/app.env`
- 显式 `CONFIG_DIR` 继续保持最高优先级
- Docker `/config` 与冻结程序配置路径保持不变

验证：

- 聚焦测试：`45 passed`
- 后端全量测试：`4716 passed, 3 skipped`
- `pylint app`：`10.00/10`
- `git diff --check`：通过
