### PR TITLE
fix: 兼容 fpcalc 非致命解码退出码

### DIFF
--- a/app/modules/acoustid/__init__.py
+++ b/app/modules/acoustid/__init__.py
@@ -20,6 +20,8 @@ class AcoustIdModule(_ModuleBase):
     """通过 Chromaprint 本地指纹和 AcoustID API 识别 MusicBrainz Recording ID。"""
 
     _base_url = "https://api.acoustid.org/v2/lookup"
+    # 退出码 3 表示解码期间出现非致命错误，结果仍须通过 JSON 内容校验。
+    _usable_fpcalc_returncodes = frozenset({0, 3})
     _minimum_score = 0.9
     _request_interval = 0.34
     _fingerprint_timeout = 60
@@ -196,7 +198,7 @@ class AcoustIdModule(_ModuleBase):
         except (OSError, subprocess.TimeoutExpired) as err:
             logger.warning(f"生成音频指纹失败：{path} - {err}")
             return None
-        if result.returncode != 0:
+        if result.returncode not in self._usable_fpcalc_returncodes:
             logger.warning(
                 f"生成音频指纹失败：{path} - fpcalc 退出码 {result.returncode}"
             )
@@ -235,7 +237,7 @@ class AcoustIdModule(_ModuleBase):
         except OSError as err:
             logger.warning(f"生成音频指纹失败：{path} - {err}")
             return None
-        if process.returncode != 0:
+        if process.returncode not in self._usable_fpcalc_returncodes:
             logger.warning(
                 f"生成音频指纹失败：{path} - fpcalc 退出码 {process.returncode}"
             )

--- a/tests/test_acoustid_module.py
+++ b/tests/test_acoustid_module.py
@@ -93,6 +93,46 @@ def test_identify_music_by_fingerprint_queries_acoustid_and_caches_result(
     assert response.closed is True
 
 
+def test_generate_fingerprint_accepts_valid_output_on_nonfatal_exit(
+        tmp_path,
+        monkeypatch,
+):
+    """fpcalc 报告非致命解码错误时仍应使用通过校验的指纹。"""
+    audio_path = tmp_path / "track.mp3"
+    audio_path.write_bytes(b"audio")
+    module = AcoustIdModule()
+    module._fpcalc_path = "/usr/bin/fpcalc"
+    monkeypatch.setattr(
+        "app.modules.acoustid.subprocess.run",
+        Mock(return_value=SimpleNamespace(
+            returncode=3,
+            stdout=json.dumps({
+                "duration": 243.4,
+                "fingerprint": "AQADtM...",
+            }),
+        )),
+    )
+
+    assert module._generate_fingerprint(audio_path) == (243, "AQADtM...")
+
+
+def test_generate_fingerprint_rejects_invalid_output_on_nonfatal_exit(
+        tmp_path,
+        monkeypatch,
+):
+    """非致命退出码不能绕过时长和指纹内容校验。"""
+    audio_path = tmp_path / "track.mp3"
+    audio_path.write_bytes(b"audio")
+    module = AcoustIdModule()
+    module._fpcalc_path = "/usr/bin/fpcalc"
+    monkeypatch.setattr(
+        "app.modules.acoustid.subprocess.run",
+        Mock(return_value=SimpleNamespace(returncode=3, stdout="{}")),
+    )
+
+    assert module._generate_fingerprint(audio_path) is None
+
+
 def test_select_recording_id_requires_high_score_and_valid_uuid():
     """低置信结果和异常外部 ID 不得进入 MusicBrainz 详情查询。"""
     payload = {
@@ -190,9 +230,9 @@ def test_async_identify_music_by_fingerprint_uses_async_process_and_http(
     module._fpcalc_path = "/usr/bin/fpcalc"
 
     class FakeProcess:
-        """模拟已成功执行的异步 fpcalc 子进程。"""
+        """模拟返回有效指纹并报告非致命解码错误的 fpcalc 子进程。"""
 
-        returncode = 0
+        returncode = 3
 
         async def communicate(self):
             """返回 fpcalc JSON 标准输出和空错误输出。"""


### PR DESCRIPTION
MoviePilot V3 当前 Docker 基于 Debian Bookworm，其 `libchromaprint-tools 1.5.1-2+b1` 存在已知的 FFmpeg 5 解码结束处理问题：`fpcalc` 已输出有效指纹后仍可能报告 `End of file` 并以 `3` 退出。主程序同步、异步路径此前把所有非零退出码直接视为失败，导致可用指纹被丢弃。

本 PR 将 `0` 和 `3` 定义为可继续校验输出的退出码；两种情况下都必须通过现有 JSON、音频时长和指纹非空校验。其它退出码仍按失败处理，因此不会把空输出或真实解码失败当成有效结果。

依赖包事实与处理边界：

- Debian Bookworm 当前提供 [`1.5.1-2+b1`](https://packages.debian.org/bookworm/libchromaprint-tools)，Debian [#1062530](https://bugs.debian.org/1062530) 记录了有效指纹伴随 `rc=3` 的相同现象。
- Chromaprint upstream [#122](https://github.com/acoustid/chromaprint/issues/122) 确认 FFmpeg 5 读取结束时的控制流问题，修复已由 [#125](https://github.com/acoustid/chromaprint/pull/125) 合并。
- Debian Trixie 的 [`1.5.1-7`](https://packages.debian.org/trixie/libchromaprint-tools) 已带入对应修复。本 PR 不升级 Debian，也不把 Docker 替换为官方 [`fpcalc 1.6.1`](https://github.com/acoustid/chromaprint/releases/tag/v1.6.1)，仅在主程序层兼容依赖已定义的非致命退出语义。

验证：

- 同一批 WAV、FLAC、MP3、M4A、Vorbis、Opus、CAF、AMR 和可生成部分指纹的截断 MP3：Bookworm `1.5.1-2+b1` 均为有效 JSON + `rc=3`，Trixie `1.5.1-7` 均为相同指纹 + `rc=0`；无效文件和无法生成指纹的严重截断文件均保持 `rc=2`。
- 使用真实 Bookworm `fpcalc 1.5.1-2+b1` 验证同步、异步路径均可读取 `rc=3` 的有效指纹，`rc=2` 无效文件仍被拒绝。
- `python tests/run.py`：`5042 passed, 3 skipped`。
- 触及模块与测试的 Pylint：`10.00/10`，0 告警。
- 完整 `pylint app` 仍为上游现有 lazy export 基线的 46 个 `E0611`，评分 `9.98/10`，本 PR 未新增同类问题。
