### PR TITLE
feat: support independent plugin project URLs

### DIFF
--- a/app/api/endpoints/plugin.py
+++ b/app/api/endpoints/plugin.py
@@ -238,6 +238,7 @@ def _merge_plugin_market_metadata(
     """
     合并插件市场中的远端元数据，供已安装插件按需展示更新说明。
     """
+    plugin.project_url = market_plugin.project_url or plugin.project_url
     plugin.repo_url = market_plugin.repo_url or plugin.repo_url
     plugin.history = market_plugin.history or {}
     plugin.release = market_plugin.release

--- a/app/core/plugin.py
+++ b/app/core/plugin.py
@@ -1432,6 +1432,9 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
             # 作者链接
             if hasattr(plugin_class, "author_url"):
                 plugin.author_url = plugin_class.author_url
+            # 项目主页，兼容旧插件自定义的 plugin_repo 声明
+            plugin.project_url = getattr(plugin_class, "project_url", None) \
+                or getattr(plugin_class, "plugin_repo", None)
             # 加载顺序
             if hasattr(plugin_class, "plugin_order"):
                 plugin.plugin_order = plugin_class.plugin_order
@@ -1692,6 +1695,9 @@ class PluginManager(ConfigReloadMixin, metaclass=Singleton):
         # 作者
         if plugin_info.get("author"):
             plugin.plugin_author = plugin_info.get("author")
+        # 项目主页
+        if plugin_info.get("project_url"):
+            plugin.project_url = plugin_info.get("project_url")
         # 更新历史
         if plugin_info.get("history"):
             plugin.history = plugin_info.get("history")

--- a/app/schemas/plugin.py
+++ b/app/schemas/plugin.py
@@ -22,6 +22,8 @@ class Plugin(BaseModel):
     plugin_author: Optional[str] = None
     # 作者主页
     author_url: Optional[str] = None
+    # 项目主页
+    project_url: Optional[str] = None
     # 插件配置项ID前缀
     plugin_config_prefix: Optional[str] = None
     # 加载顺序

--- a/tests/test_plugin_endpoint.py
+++ b/tests/test_plugin_endpoint.py
@@ -27,6 +27,7 @@ def test_plugin_history_merges_remote_metadata():
     )
     market_plugin = schemas.Plugin(
         id="DemoPlugin",
+        project_url="https://github.com/demo/plugin",
         repo_url="https://github.com/demo/plugins",
         history={"v1.1.0": "- 新增更新说明"},
         system_version=">=2.0.0",
@@ -42,6 +43,7 @@ def test_plugin_history_merges_remote_metadata():
         result = asyncio.run(plugin_history("DemoPlugin", None, True))
 
     assert result.repo_url == "https://github.com/demo/plugins"
+    assert result.project_url == "https://github.com/demo/plugin"
     assert result.history == {"v1.1.0": "- 新增更新说明"}
     assert result.system_version == ">=2.0.0"
     assert result.has_update

--- a/tests/test_plugin_helper.py
+++ b/tests/test_plugin_helper.py
@@ -649,6 +649,7 @@ class TestPluginHelper:
                 "description": "Demo",
                 "version": "1.0.0",
                 "labels": ["站点", "通知", ""],
+                "project_url": "https://github.com/demo/plugin",
                 "v2": True,
             }
         }
@@ -664,7 +665,33 @@ class TestPluginHelper:
 
         assert len(plugins) == 1
         assert plugins[0].plugin_label == "站点 通知"
+        assert plugins[0].project_url == "https://github.com/demo/plugin"
         assert plugins[0].model_dump()["plugin_label"] == "站点 通知"
+
+    def test_get_local_plugins_maps_legacy_plugin_repo_to_project_url(self, monkeypatch) -> None:
+        """本地插件旧有的 plugin_repo 声明应作为独立项目主页返回。"""
+        try:
+            from app.core.plugin import PluginManager
+        except ModuleNotFoundError as exc:
+            pytest.skip(f"missing dependency: {exc}")
+
+        class DemoPlugin:
+            plugin_name = "Demo Plugin"
+            plugin_repo = "https://github.com/demo/plugin"
+
+        plugin_manager = PluginManager()
+        monkeypatch.setattr(plugin_manager, "_plugins", {"DemoPlugin": DemoPlugin})
+        monkeypatch.setattr(plugin_manager, "_running_plugins", {})
+        monkeypatch.setattr(
+            "app.core.plugin.SystemConfigOper",
+            lambda: SimpleNamespace(get=lambda _key: ["DemoPlugin"]),
+        )
+        monkeypatch.setattr("app.core.plugin.SitesHelper", lambda: SimpleNamespace(auth_level=1))
+
+        plugins = plugin_manager.get_local_plugins()
+
+        assert len(plugins) == 1
+        assert plugins[0].project_url == "https://github.com/demo/plugin"
 
     def test_get_online_plugins_force_keeps_release_cache_scoped(self, monkeypatch):
         """


### PR DESCRIPTION
## Summary
- expose optional project_url metadata for installed and marketplace plugins
- keep plugin_repo as a compatibility fallback for existing plugins
- preserve project_url when marketplace metadata is merged with installed plugin history

## Verification
- targeted plugin metadata tests passed
- full suite: 2462 passed, 1 skipped, 14 subtests passed
- one unrelated existing failure remains in tests/test_metainfo.py: moviepilot-rust 0.2.8 returns UHD BluRay while the test expects UHD

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 27b96f1b50abc16e948b1503abb4a4ab023a5926

- 新增插件独立项目主页字段
- 市场与本地元数据均支持 `project_url`
- 兼容旧插件的 `plugin_repo` 声明
- 合并远端信息时保留项目主页
- 补充市场、本地及接口合并测试
<!-- pr-agent-summary:end -->
