### PR TITLE
fix: 同步插件恢复架构依赖基线

### DIFF
--- a/tests/fixtures/architecture/dependency-baseline.json
+++ b/tests/fixtures/architecture/dependency-baseline.json
@@ -13,8 +13,8 @@
     "runtime_to_db": [],
     "workflow_to_db": []
   },
-  "edge_count": 6075,
-  "edge_sha256": "3cea396b7570abbb70a8a30a9cd18006b52e21aa9d8d8106d2596baa52573d83",
+  "edge_count": 6076,
+  "edge_sha256": "98150e02051b59ca341c62a71ec050aaa3807b6f20eba40a3d1cda76682503d1",
   "edges": [
     "app -> app.runtime",
     "app -> app.runtime.compat",
@@ -5903,6 +5903,7 @@
     "app.startup.plugins_initializer -> app.runtime.log",
     "app.startup.plugins_initializer -> app.runtime.managed_resources",
     "app.startup.plugins_initializer -> app.schemas",
+    "app.startup.plugins_initializer -> app.schemas.plugin",
     "app.startup.plugins_initializer -> app.schemas.types",
     "app.startup.routers_initializer -> app.api",
     "app.startup.routers_initializer -> app.api.router_specs",


### PR DESCRIPTION
## 变更

补齐插件恢复生命周期改动对应的架构依赖基线。合并后的主程序代码新增了一条 `app.startup.plugins_initializer -> app.schemas.plugin` 依赖，但基线文件仍停留在合并前版本，导致架构基线测试在上游 CI 中失败。

本 PR 只更新 `tests/fixtures/architecture/dependency-baseline.json`，不重复提交已合并的插件恢复实现。

## 验证

- 后端全量测试：5151 passed，4 skipped
- 架构基线测试：11 passed
- `pylint app`：仍有仓库既有的 `no-name-in-module` 基线错误，本 PR 未新增生产代码

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 991be528fdb46f6180faa1e7f081175f0cf7691d

- 更新架构依赖基线
- 纳入插件恢复新增依赖
- 同步边数与校验摘要
- 未改变运行时代码
<!-- pr-agent-summary:end -->
