### PR TITLE
fix: 保留插件备份恢复中的顶层隐藏项

### DIFF
--- a/app/chain/system.py
+++ b/app/chain/system.py
@@ -165,7 +165,7 @@ class SystemChain(ChainBase):
         for item in backup_dir.iterdir():
             if (
                 item.name == SystemChain._plugin_restore_pending_file
-                or item.name.startswith(".")
+                or SystemChain.__is_snapshot_artifact(item.name)
             ):
                 continue
             target_path = plugins_dir / item.name
@@ -204,6 +204,11 @@ class SystemChain(ChainBase):
             logger.warning(f"删除备份目录失败: {str(e)}")
             if backup_dir.exists():
                 SystemChain.__write_plugin_restore_pending(pending_file, {})
+
+    @staticmethod
+    def __is_snapshot_artifact(name: str) -> bool:
+        """识别快照替换过程中生成的临时或旧快照条目。"""
+        return bool(re.fullmatch(r"\..+\.(?:tmp|old)-[0-9a-f]{32}", name))
 
     @staticmethod
     def __read_plugin_restore_pending(pending_file: Path) -> Optional[dict[str, bool]]:


### PR DESCRIPTION
插件 Docker 备份恢复会保存插件根目录下的所有非排除项，但恢复阶段此前用“所有点号开头”作为过滤条件，导致顶层隐藏文件或目录被跳过；随后备份目录整体删除，隐藏项的唯一副本会丢失。

本 PR 将过滤范围收窄为恢复流程实际生成的 `.tmp-<uuid>` 和 `.old-<uuid>` 快照临时项，同时继续显式跳过恢复重试标记。插件目录内部的隐藏文件仍随插件目录整体恢复，普通顶层隐藏项也会正常恢复。

验证：
- `tests/run.py`：4 个分片全部通过，合计 `5151 passed, 3 skipped`
- `git diff --check`：通过
- `pylint app`：当前 `upstream/v3` 基线仍有 60 条既有导入错误，本次未新增

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 51698a4667a23bd1fdf1c2a17dd31b7a8f64a13b

- 保留插件恢复时的顶层隐藏项
- 仅跳过 `.tmp`、`.old` 快照产物
- 继续忽略恢复重试标记文件
- 未新增自动化测试；正则匹配需覆盖命名边界
<!-- pr-agent-summary:end -->
