### PR TITLE
fix: 隔离待恢复更新的控制脚本代际

### DIFF
--- a/docker/launcher.sh
+++ b/docker/launcher.sh
@@ -109,8 +109,13 @@ function pending_recovery_control_dir() {
     case "${state}" in
     prepared|dependencies)
         [ -e "${UPDATE_PREVIOUS_APP}" ] || return 1
-        source_bundle_is_trusted "${previous_control_dir}" || return 1
-        printf '%s\n' "${previous_control_dir}"
+        if source_bundle_is_trusted "${previous_control_dir}"; then
+            printf '%s\n' "${previous_control_dir}"
+        else
+            # pending 恢复只能使用旧代或镜像控制脚本，不能执行尚未提交的新源码控制脚本。
+            printf '%s\n' "MoviePilot 旧代控制脚本不完整或不可信，回退到镜像内置版本。" >&2
+            printf '%s\n' "${IMAGE_CONTROL_DIR}"
+        fi
         return 0
         ;;
     esac

--- a/tests/test_docker_bootstrap.py
+++ b/tests/test_docker_bootstrap.py
@@ -108,7 +108,13 @@ def test_launcher_prefers_complete_trusted_source_bundle(tmp_path: Path) -> None
     assert result.stdout == "source\n"
 
 
-def test_launcher_uses_previous_generation_during_pending_recovery(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("previous_bundle_state", "expected_output"),
+    [("trusted", "old\n"), ("incomplete", "image\n"), ("untrusted", "image\n")],
+)
+def test_launcher_isolates_control_generation_during_pending_recovery(
+    tmp_path: Path, previous_bundle_state: str, expected_output: str
+) -> None:
     source = tmp_path / "source"
     image = tmp_path / "image"
     previous = tmp_path / "previous-app"
@@ -116,6 +122,8 @@ def test_launcher_uses_previous_generation_during_pending_recovery(tmp_path: Pat
     _write_bundle(source, "new")
     _write_bundle(image, "image")
     _write_bundle(previous / "docker", "old")
+    if previous_bundle_state == "incomplete":
+        (previous / "docker" / "browser.sh").unlink()
     (config / "temp").mkdir(parents=True)
     (config / "temp" / "__update_pending__").write_text("prepared\n", encoding="utf-8")
     script = textwrap.dedent(
@@ -126,7 +134,14 @@ def test_launcher_uses_previous_generation_during_pending_recovery(tmp_path: Pat
         RUNTIME_ROOT="$3"
         UPDATE_PENDING_FILE="$4"
         UPDATE_PREVIOUS_APP="$5"
-        source_bundle_is_trusted() {{ control_bundle_generation "$1" >/dev/null; }}
+        PREVIOUS_BUNDLE_STATE="$6"
+        PREVIOUS_CONTROL_DIR="$5/docker"
+        source_bundle_is_trusted() {{
+            [ "${{PREVIOUS_BUNDLE_STATE}}" != "untrusted" ] \
+                || [ "$1" != "${{PREVIOUS_CONTROL_DIR}}" ] \
+                || return 1
+            control_bundle_generation "$1" >/dev/null
+        }}
         launcher_main
         """
     )
@@ -142,6 +157,7 @@ def test_launcher_uses_previous_generation_during_pending_recovery(tmp_path: Pat
             str(tmp_path / "run"),
             str(config / "temp" / "__update_pending__"),
             str(previous),
+            previous_bundle_state,
         ],
         text=True,
         capture_output=True,
@@ -149,7 +165,7 @@ def test_launcher_uses_previous_generation_during_pending_recovery(tmp_path: Pat
     )
 
     assert result.returncode == 0
-    assert result.stdout == "old\n"
+    assert result.stdout == expected_output
 
 
 @pytest.mark.parametrize("missing_file", BASE_CONTROL_FILES)


### PR DESCRIPTION
更新事务处于待恢复状态时，如果旧备份仍存在，但其中的控制脚本缺失、不完整或权限不可信，launcher 会继续选择当前源码中的新控制脚本。随后恢复旧源码后，容器仍由新一代控制脚本继续启动，形成控制面与应用源码的代际混用。

本 PR 收口 launcher 的选择规则：

- 待恢复且旧控制包可信时，继续使用旧代控制脚本完成恢复；
- 待恢复但旧控制包不可用或不可信时，使用镜像内置的稳定控制脚本；
- 已提交更新和普通启动路径保持原有选择逻辑。

实现只调整 pending 分支的控制目录选择，并补齐旧控制包不完整、权限不可信两类回归，不新增事务状态、锁或 generation 元数据。

验证：

- Docker bootstrap：54 passed
- Python 3.14 全量：5363 passed，3 skipped
- launcher、entrypoint、update、browser、cert Shell 语法检查通过
- Linux 容器验证覆盖可信旧控制包、不完整旧控制包、不可信旧控制包和已提交更新四种状态
