### PR TITLE
ci: 为漏洞豁免设置复查期限

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -4,58 +4,68 @@ vulnerabilities:
       - Python
     purls:
       - pkg:pypi/msgpack@1.1.2
+    expired_at: 2026-11-20
     statement: The finding belongs to the base image's system pip and is not imported by MoviePilot.
   - id: CVE-2025-47273
     paths:
       - Python
     purls:
       - pkg:pypi/setuptools@70.3.0
+    expired_at: 2026-11-20
     statement: The finding belongs to the base image's system pip and is not used for dependency installation.
   - id: CVE-2026-33818
     paths:
       - usr/bin/rclone
     purls:
       - pkg:golang/stdlib@v1.26.5
+    expired_at: 2026-11-20
     statement: The official rclone binary has no patched release for this embedded Go runtime yet.
   - id: CVE-2026-39821
     paths:
       - usr/bin/rclone
     purls:
       - pkg:golang/stdlib@v1.26.5
+    expired_at: 2026-11-20
     statement: The official rclone binary has no patched release for this embedded Go runtime yet.
   - id: CVE-2026-46600
     paths:
       - usr/bin/rclone
     purls:
       - pkg:golang/stdlib@v1.26.5
+    expired_at: 2026-11-20
     statement: The official rclone binary has no patched release for this embedded Go runtime yet.
   - id: CVE-2026-56853
     paths:
       - usr/bin/rclone
     purls:
       - pkg:golang/stdlib@v1.26.5
+    expired_at: 2026-11-20
     statement: The official rclone binary has no patched release for this embedded Go runtime yet.
   - id: CVE-2026-56858
     paths:
       - usr/bin/rclone
     purls:
       - pkg:golang/stdlib@v1.26.5
+    expired_at: 2026-11-20
     statement: The official rclone binary has no patched release for this embedded Go runtime yet.
   - id: CVE-2026-56859
     paths:
       - usr/bin/rclone
     purls:
       - pkg:golang/stdlib@v1.26.5
+    expired_at: 2026-11-20
     statement: The official rclone binary has no patched release for this embedded Go runtime yet.
   - id: CVE-2026-56860
     paths:
       - usr/bin/rclone
     purls:
       - pkg:golang/stdlib@v1.26.5
+    expired_at: 2026-11-20
     statement: The official rclone binary has no patched release for this embedded Go runtime yet.
   - id: CVE-2026-56862
     paths:
       - usr/bin/rclone
     purls:
       - pkg:golang/stdlib@v1.26.5
+    expired_at: 2026-11-20
     statement: The official rclone binary has no patched release for this embedded Go runtime yet.

--- a/tests/test_release_supply_chain.py
+++ b/tests/test_release_supply_chain.py
@@ -1,5 +1,6 @@
 """正式镜像发布的供应链门禁合同。"""
 
+from datetime import date
 from pathlib import Path
 
 from ruamel.yaml import YAML
@@ -8,6 +9,7 @@ from ruamel.yaml import YAML
 ROOT = Path(__file__).resolve().parents[1]
 DOCKERFILE = ROOT / "docker" / "Dockerfile"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "build-v3.yml"
+TRIVY_IGNORE = ROOT / ".trivyignore.yaml"
 
 
 def _load_workflow() -> dict:
@@ -92,6 +94,18 @@ def test_release_scans_both_architectures_before_registry_login_and_publish() ->
     assert last_scan < names.index("Login DockerHub")
     assert last_scan < names.index("Login GitHub Container Registry")
     assert last_scan < names.index("Publish multi-architecture image")
+
+
+def test_vulnerability_ignores_are_scoped_justified_and_time_bounded() -> None:
+    """漏洞豁免必须限定制品范围，并保留复查期限和接受理由。"""
+    yaml = YAML(typ="safe")
+    vulnerabilities = yaml.load(TRIVY_IGNORE.read_text(encoding="utf-8"))["vulnerabilities"]
+
+    for vulnerability in vulnerabilities:
+        assert vulnerability["paths"]
+        assert vulnerability["purls"]
+        assert vulnerability["statement"]
+        assert isinstance(vulnerability["expired_at"], date)
 
 
 def test_publish_reuses_scanned_architecture_caches_without_refreshing_base() -> None:


### PR DESCRIPTION
现有 Trivy 漏洞豁免虽然限定了漏洞、制品路径和包，但没有复查期限，可能在上游依赖已经修复后继续长期隐藏扫描结果。

本 PR 为现有 10 条豁免统一设置 90 天复查期限（2026-11-20）。期限届满后，Trivy 会在下一次正式镜像构建中重新报告对应漏洞，并由既有发布门禁阻止未经复核的镜像发布。

同时补充供应链合同测试，要求漏洞豁免必须限定路径和包，并包含接受理由及合法的到期日期，避免后续新增无期限豁免。

验证：

- `python -m pytest tests/test_release_supply_chain.py -q`：5 passed
- `git diff --check`
