### PR TITLE
fix: 修复 CloakBrowser 在 CF 质询页获取网页源码超时

### DIFF
--- a/app/adapters/network/browser.py
+++ b/app/adapters/network/browser.py
@@ -1118,6 +1118,7 @@ class PlaywrightHelper:
         :param headless: 是否无头模式
         :param timeout: 超时时间
         """
+        timeout = timeout or 60
         source = None
         # 如果配置为 FlareSolverr，则直接调用获取页面源码
         if self.__browser_emulation() == "flaresolverr":
@@ -1140,10 +1141,33 @@ class PlaywrightHelper:
                 if cookies:
                     page.set_extra_http_headers({"cookie": cookies})
 
-                page.goto(url)
-                page.wait_for_load_state("networkidle", timeout=timeout * 1000)
+                page.goto(url, wait_until="load", timeout=timeout * 1000)
 
-                source = page.content()
+                # 修复: 部分站点(如 Cloudflare 质询页)会持续轮询请求,
+                # 导致 networkidle 永不触发而超时。改为等待页面加载完成后
+                # 轮询检查标题, 直到不再停留在质询/加载页。
+                challenge_titles = ("just a moment", "请稍候", "loading")
+                deadline = time.time() + timeout
+                while time.time() < deadline:
+                    try:
+                        current_title = (page.title() or "").strip().lower()
+                    except Exception:
+                        current_title = ""
+                    if current_title and not any(
+                            t in current_title for t in challenge_titles):
+                        break
+                    time.sleep(2)
+
+                # 页面跳转中 content() 可能失败, 重试几次
+                source = None
+                for _attempt in range(5):
+                    try:
+                        source = page.content()
+                        if source:
+                            break
+                    except Exception:
+                        source = None
+                        time.sleep(2)
 
             except Exception as e:
                 logger.error(f"获取网页源码失败: {str(e)}")


### PR DESCRIPTION
## Summary

修复 CloakBrowser 在 Cloudflare 质询页(或任何长轮询页面)上获取网页源码超时的问题。

## Problem

`get_page_source` 使用 `page.goto(url)` + `page.wait_for_load_state("networkidle")`
等待网络完全空闲。但 Cloudflare 的 "Just a moment..." 质询页会持续发起
轮询请求, 导致 networkidle 永不触发, 最终超时(默认 60s)返回 None。

受影响的场景:
- 配置了 CloakBrowser 作为浏览器仿真(BROWSER_EMULATION=cloakbrowser)
  且访问带 CF 盾的站点
- 任何页面有长轮询/心跳请求的站点(聊天室、自动刷新面板等)

实际表现: 站点连通性测试报"无法通过Cloudflare"或获取源码失败,
尽管浏览器实际已经能过质询(独立进程测试通过)。

## Changes

`app/adapters/network/browser.py`:

1. `get_page_source` 中:
   - `page.goto(url)` 改为 `page.goto(url, wait_until="load", ...)`(等 DOM 加载完成)
   - 移除 `wait_for_load_state("networkidle")`, 改为轮询检查页面标题,
     直到不再停留在质询/加载页("just a moment"/"请稍候"/"loading")
   - 页面跳转中 `page.content()` 可能失败, 增加最多 5 次重试
2. 函数开头增加 `timeout = timeout or 60` 防御(参数可空)

## Test Plan

- [x] 手动验证: CloakBrowser 访问带 CF 盾站点,
      修复前 60s 超时, 修复后 15s 内拿到页面源码
- [ ] 上游 CI 通过
- [ ] 现有 FlareSolverr 路径(BROWSER_EMULATION=flaresolverr)不受影响
      (该路径在修改点之前 return, 不经过 CloakBrowser 逻辑)

## Notes

- 轮询间隔 2s, 总超时 = 传入的 timeout(默认 60s), 与原行为一致
- 标题检测基于质询页的典型标题, 对其他正常页面无影响
  (正常页面标题不含这些关键字, 首轮即退出循环)
