### PR TITLE
fix: 避免站点映射查询阻塞事件循环

### DIFF
--- a/app/api/endpoints/site.py
+++ b/app/api/endpoints/site.py
@@ -580,14 +580,14 @@ def auth_site(
     response_model=_SchemaResponse[_SchemaSiteMappingData],
 )
 async def site_mapping(
-    query: SiteQueryService = Depends(get_site_sync_query_service),
+    query: SiteQueryService = Depends(get_site_query_service),
     _: ApiPrincipal = Depends(get_current_active_superuser_async),
 ):
     """
     获取站点域名到名称的映射关系
     """
     try:
-        sites = query.list_sync()
+        sites = await query.list_ordered()
         mapping = {}
         for site in sites:
             mapping[site.domain] = site.name

--- a/tests/test_site_media_filter.py
+++ b/tests/test_site_media_filter.py
@@ -82,3 +82,24 @@ def test_read_sites_by_media_type_rejects_unknown_type():
 
     assert error.value.status_code == 400
     assert error.value.detail == "不支持的媒体类型"
+
+
+def test_site_mapping_uses_async_query_port():
+    """异步站点映射不得在事件循环内调用同步数据库查询。"""
+    sites = [
+        SimpleNamespace(domain="one.example", name="One"),
+        SimpleNamespace(domain="two.example", name="Two"),
+    ]
+    query = SimpleNamespace(
+        list_ordered=AsyncMock(return_value=sites),
+        list_sync=pytest.fail,
+    )
+
+    result = asyncio.run(site_endpoint.site_mapping(query=query))
+
+    assert result.success is True
+    assert result.data == {
+        "one.example": "One",
+        "two.example": "Two",
+    }
+    query.list_ordered.assert_awaited_once()


### PR DESCRIPTION
`/site/mapping` 是异步接口，但此前仍通过同步站点查询服务直接访问数据库；查询变慢时会占用事件循环，影响同进程其他请求的调度。

本 PR 将该接口切换到请求级异步 `SiteQueryService`，并等待既有的 `list_ordered()` canonical port。站点优先级顺序、超级用户认证及错误响应语义保持不变，同时补充回归测试，防止异步接口重新调用同步查询。

受控 A/B 中，阻塞查询期间的事件循环延迟由约 193 ms 降至约 0.18 ms；收益来自避免阻塞事件循环，不改变数据库查询本身。

验证：

- `29 passed`（站点接口与 async blocking focused tests）
- async blocking ratchet 通过
- 改动 Python 文件 Pylint `10.00/10`
- `git diff --check` 通过

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 499ff84a5bd0b164bb27ed8236e51443ebcb6c4e

- 映射接口改用异步站点查询
- 避免同步数据库查询阻塞事件循环
- 保持站点排序与响应语义
- 新增异步查询端口回归测试
<!-- pr-agent-summary:end -->
