### PR TITLE
refactor: 移除无消费者的同步 Service 方法

### DIFF
--- a/app/application/messaging/chat.py
+++ b/app/application/messaging/chat.py
@@ -77,20 +77,6 @@ class AsyncAgentChatRepository(Protocol):
         """同步读取服务端会话。"""
         ...
 
-    def save_display_messages(
-        self,
-        session_id: str,
-        user_id: Optional[str] = None,
-        messages: Optional[list[dict]] = None,
-        username: Optional[str] = None,
-        channel: Optional[Any] = None,
-        source: Optional[str] = None,
-        original_chat_id: Optional[str] = None,
-        client_session_id: Optional[str] = None,
-    ) -> Optional[Any]:
-        """同步保存用户可见会话消息。"""
-        ...
-
 
 class SyncAgentChatRepository(Protocol):
     """仅包含 Agent 编排所需同步持久化方法的适配器端口。"""
@@ -265,31 +251,6 @@ class AgentChatService:
     def get_sync(self, session_id: str) -> Optional[AgentChatRecord]:
         """同步读取会话投影，供同步 Agent 编排路径使用。"""
         record = self._repository.get(session_id=session_id)
-        return self._project(record) if record is not None else None
-
-    def save_display_sync(
-        self,
-        *,
-        session_id: str,
-        user_id: Optional[str] = None,
-        messages: Optional[list[dict]] = None,
-        username: Optional[str] = None,
-        channel: Optional[Any] = None,
-        source: Optional[str] = None,
-        original_chat_id: Optional[str] = None,
-        client_session_id: Optional[str] = None,
-    ) -> Optional[AgentChatRecord]:
-        """同步保存用户可见消息并返回最新投影。"""
-        record = self._repository.save_display_messages(
-            session_id=session_id,
-            user_id=user_id,
-            messages=messages,
-            username=username,
-            channel=channel,
-            source=source,
-            original_chat_id=original_chat_id,
-            client_session_id=client_session_id,
-        )
         return self._project(record) if record is not None else None
 
     @staticmethod

--- a/app/application/site/query.py
+++ b/app/application/site/query.py
@@ -59,10 +59,6 @@ class SiteQueryRepository(Protocol):
         """同步读取全部站点。"""
         ...
 
-    def list_order_by_pri(self) -> list[Any]:
-        """同步按优先级读取站点。"""
-        ...
-
     def get_userdata_latest(self) -> list[Any]:
         """同步读取各站点最新用户数据。"""
         ...
@@ -92,13 +88,6 @@ class SiteQueryService:
         """同步按 ID 返回站点配置 DTO。"""
         item = self._repository.get(site_id)
         return Site.model_validate(item) if item else None
-
-    def list_sync(self) -> list[Site]:
-        """同步返回全部站点配置 DTO。"""
-        return [
-            Site.model_validate(item)
-            for item in self._repository.list_order_by_pri()
-        ]
 
     async def get_by_domain(self, domain: str) -> Optional[Site]:
         """按域名返回站点配置 DTO。"""


### PR DESCRIPTION
主程序的站点查询与 AgentChat 数据链已经具备异步 canonical 入口，但 Application Service 中仍保留两组没有消费者的同步方法及其 Protocol 声明，继续形成重复业务入口，也会让后续同步 API 盘点产生误判。

本 PR 删除 `SiteQueryService.list_sync()`、`AgentChatService.save_display_sync()` 及仅为它们存在的同步仓储声明。主程序、SDK、CLI 和已审计插件仓均未发现调用方；底层 Repository/Oper 与仍有真实消费者的同步 compat 接口保持不变。

验证：

- 站点查询与 AgentChat focused 回归：28 passed
- async blocking、complexity 与架构依赖门禁：47 passed
- mypy 严格范围检查通过
- 目标文件 Pylint：10.00/10
- `git diff --check` 通过

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 631f44ca12c1eed1f90d198f65ebcbfe1da4fdc6

- 移除无消费者的同步服务入口
- 精简站点查询与 AgentChat 协议
- 保留现有异步及兼容同步路径
- 风险：外部未审计调用将失去接口
<!-- pr-agent-summary:end -->
