### PR TITLE
fix: 避免任务完成后停机被误报未提交

### DIFF
--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -917,9 +917,9 @@ class Scheduler(ConfigReloadMixin, metaclass=SingletonClass):
         job_name = job.get("name") if job else job_id
         # 收尾可能发生在事件循环上（__run_coro_job），使用异步进度后端避免阻塞
         progress = AsyncProgressHelper(self._get_progress_key(job_id))
-        current_progress = await progress.get() or {}
-        progress_value = 100 if success else current_progress.get("value", 0)
         try:
+            current_progress = await progress.get() or {}
+            progress_value = 100 if success else current_progress.get("value", 0)
             await progress.end(
                 text=f"{job_name} {'执行完成' if success else '执行失败'}",
                 data={
@@ -1198,17 +1198,21 @@ class Scheduler(ConfigReloadMixin, metaclass=SingletonClass):
                 and not target_loop.is_closed()
             )
             if running_loop and (not target_loop_available or running_loop is target_loop):
+                started = threading.Event()
+
+                async def run_owned_job() -> None:
+                    started.set()
+                    await self.__run_coro_job(
+                        coro_factory=coro_factory,
+                        job_id=job_id,
+                        job=job,
+                        generation=generation,
+                    )
+
                 with self._lock:
                     if not self._accepts_handle(job_id, generation):
                         return False, False
-                    handle = running_loop.create_task(
-                        self.__run_coro_job(
-                            coro_factory=coro_factory,
-                            job_id=job_id,
-                            job=job,
-                            generation=generation,
-                        ),
-                    )
+                    handle = running_loop.create_task(run_owned_job())
                     registered = self._register_handle(
                         job_id=job_id,
                         generation=generation,
@@ -1219,7 +1223,7 @@ class Scheduler(ConfigReloadMixin, metaclass=SingletonClass):
                     def _finish_cancelled_before_start(
                             submitted: asyncio.Future[Any],
                     ) -> None:
-                        if submitted.cancelled():
+                        if submitted.cancelled() and not started.is_set():
                             self._finish_unsubmitted_job(
                                 job_id=job_id,
                                 job=job,

--- a/tests/test_scheduler_lifecycle.py
+++ b/tests/test_scheduler_lifecycle.py
@@ -100,6 +100,56 @@ async def test_stop_async_cancels_and_awaits_scheduler_owned_job(monkeypatch) ->
 
 
 @pytest.mark.anyio
+async def test_stop_during_final_progress_does_not_mark_completed_job_unsubmitted(
+        monkeypatch,
+) -> None:
+    """业务协程已完成后，取消最终进度写入不得改写任务执行结果。"""
+    finish_started = asyncio.Event()
+
+    class BlockingFinishProgress(_AsyncProgressStub):
+        """把任务停在最终进度读取阶段。"""
+
+        async def get(self):
+            finish_started.set()
+            await asyncio.Event().wait()
+
+    async def job() -> None:
+        return None
+
+    monkeypatch.setattr(scheduler_module, "ProgressHelper", _ProgressStub)
+    monkeypatch.setattr(
+        scheduler_module,
+        "AsyncProgressHelper",
+        BlockingFinishProgress,
+    )
+    scheduler = _scheduler("final-progress-stop", job)
+
+    assert scheduler.start("final-progress-stop") is True
+    await asyncio.wait_for(finish_started.wait(), timeout=1)
+
+    await scheduler.stop_async()
+
+    assert scheduler._jobs["final-progress-stop"]["running"] is False
+    assert scheduler._jobs["final-progress-stop"]["last_error"] is None
+    assert scheduler._handles == {}
+    assert scheduler._active_job_generations == {}
+
+    monkeypatch.setattr(
+        scheduler_module,
+        "AsyncProgressHelper",
+        _AsyncProgressStub,
+    )
+    scheduler._lifecycle_state = "running"
+    assert scheduler.start("final-progress-stop") is True
+
+    async def wait_until_finished() -> None:
+        while scheduler._handles or scheduler._active_job_generations:
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(wait_until_finished(), timeout=1)
+
+
+@pytest.mark.anyio
 async def test_foreign_loop_submission_runs_on_main_loop_and_finishes_before_stop(
         monkeypatch,
 ) -> None:


### PR DESCRIPTION
## 问题

同一事件循环中的 Scheduler 任务在业务协程已经完成、但最终进度仍在读取或写入时遇到停机取消，取消回调会把它误判为“任务从未提交”。这会覆盖真实执行结果，并可能留下未释放的 active generation，阻止同 ID 任务再次启动。

## 调整

- 显式记录 Scheduler 持有的协程任务是否已经开始执行，仅在任务确实未开始时写入“未提交”补偿状态。
- 将最终进度读取纳入 generation 释放的 `finally` 边界，确保收尾阶段取消后仍能释放运行权。
- 增加确定性生命周期回归，覆盖业务完成后停在最终进度读取阶段再执行停机，并验证同 ID 可重新启动。

## 验证

- Scheduler 生命周期测试：17 passed
- 受影响文件 Pylint：10.00/10
- `git diff --check`

该调整只修正停机收尾状态，不改变任务调度、重叠策略或业务执行顺序。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at bb93b8ce56be014f3764f92669fd326e4e5dca84

- 修正停机取消覆盖已完成任务结果
- 仅补偿实际未启动的协程任务
- 收尾进度取消仍释放任务 generation
- 新增最终进度阶段停机回归测试
<!-- pr-agent-summary:end -->
