### PR TITLE
fix: 修复 Discord 启动窗口停止竞态

### DIFF
--- a/app/modules/discord/discord.py
+++ b/app/modules/discord/discord.py
@@ -264,11 +264,6 @@ class Discord:
                 ).result(timeout=10)
             except Exception as err:
                 logger.error(f"关闭 Discord Bot 失败：{err}")
-        elif not loop.is_closed():
-            try:
-                loop.call_soon_threadsafe(loop.stop)
-            except RuntimeError:
-                pass
         self._ready_event.clear()
         thread.join(timeout=5)
         if thread.is_alive():

--- a/tests/test_discord_lifecycle.py
+++ b/tests/test_discord_lifecycle.py
@@ -27,6 +27,19 @@ class _DiscordClientStub:
             self._release.set()
 
 
+class _YieldingCloseDiscordClientStub(_DiscordClientStub):
+    """关闭协程至少让出一次执行权，用于覆盖启动窗口内的停止竞态。"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.closed = threading.Event()
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        await asyncio.sleep(0)
+        self.closed.set()
+
+
 def _discord(client: _DiscordClientStub) -> Discord:
     """构造只包含线程与事件循环生命周期状态的 Discord 实例。"""
     instance = Discord.__new__(Discord)
@@ -80,4 +93,39 @@ def test_start_failure_closes_discord_thread_loop() -> None:
         assert not instance._thread.is_alive()
         assert instance._loop.is_closed()
     finally:
+        _cleanup(instance)
+
+
+def test_stop_during_thread_bootstrap_preserves_runner_cleanup(monkeypatch) -> None:
+    """线程已登记但循环尚未运行时，停止请求不得打断 runner 的关闭流程。"""
+    client = _YieldingCloseDiscordClientStub()
+    instance = _discord(client)
+    runner_entered = threading.Event()
+    release_runner = threading.Event()
+    original_set_event_loop = asyncio.set_event_loop
+
+    def block_runner(loop: asyncio.AbstractEventLoop | None) -> None:
+        if loop is instance._loop:
+            runner_entered.set()
+            assert release_runner.wait(timeout=1)
+        original_set_event_loop(loop)
+
+    monkeypatch.setattr(
+        "app.modules.discord.discord.asyncio.set_event_loop",
+        block_runner,
+    )
+    instance._start()
+    assert runner_entered.wait(timeout=1)
+    stop_thread = threading.Thread(target=instance.stop)
+    stop_thread.start()
+    assert instance._stop_requested.wait(timeout=1)
+    release_runner.set()
+
+    try:
+        stop_thread.join(timeout=2)
+        assert not stop_thread.is_alive()
+        assert client.closed.is_set()
+        assert instance._loop.is_closed()
+    finally:
+        release_runner.set()
         _cleanup(instance)


### PR DESCRIPTION
Discord Bot 在线程刚启动、事件循环尚未进入运行态时收到停止请求，旧逻辑会提前向该循环排入 `loop.stop`。runner 随后执行关闭协程时，循环可能先停止，导致 `client.close()` 未完成便关闭事件循环。

本 PR 调整停止边界：

- 循环已运行时，仍在线程安全路径中停止 typing 任务并关闭 Discord client；
- 循环尚未运行时，只登记停止请求，由 runner 统一跳过启动并完成 client 与事件循环清理；
- 增加确定性竞态测试，覆盖“线程已登记、loop 尚未运行”的窗口。

这是对 #6421 的生命周期收尾跟进，不改变 Discord 配置、消息或命令行为。

验证：

- Discord 与模块生命周期测试：19 passed
- 后端四分片全量测试：5620 passed, 3 skipped
- 目标 Pylint：10.00/10
- `git diff --check`

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at dae8f95ea5bc6793a96315f12c2c63d742fe51ed

- 修复 Discord 启动阶段的停止竞态
- 避免提前停止事件循环中断清理
- 新增线程启动窗口停止回归测试
- 不改变 Discord 配置与消息行为
<!-- pr-agent-summary:end -->
