### PR TITLE
fix(modules): 默认服务配置改为尊重显式标记，不再按读取顺序取第一个

### DIFF
--- a/app/modules/__init__.py
+++ b/app/modules/__init__.py
@@ -202,9 +202,18 @@ class ServiceBase(Generic[TService, TConf], metaclass=ABCMeta):
         """
         获取默认服务配置的名称
 
-        :return: 默认第一个配置的名称
+        优先返回被显式标记为默认的配置。只有在没有任何配置带标记时，才退回到第一个配置——
+        配置的先后来自读取顺序，用户既看不见也控制不了，删掉一个配置会让「默认」静默改指
+        另一个，因此它只能作为无标记时的兜底，不能盖过用户的显式选择。
+
+        :return: 默认配置的名称，无配置时为 None
         """
-        # 默认使用第一个配置的名称
+        marked = next(
+            (conf for conf in self._configs.values() if getattr(conf, "default", False)),
+            None,
+        )
+        if marked:
+            return marked.name
         first_conf = next(iter(self._configs.values()), None)
         return first_conf.name if first_conf else None
 

--- a/tests/test_service_default_config.py
+++ b/tests/test_service_default_config.py
@@ -1,0 +1,117 @@
+"""默认服务配置的选取必须尊重用户的显式标记。
+
+配置的先后来自读取顺序，用户既看不见也控制不了。按顺序取第一个意味着：删掉一个无关配置，
+「默认下载器」就会静默改指另一个，而下载任务的归属记录已经按旧的默认写进了历史。
+"""
+
+from typing import Dict, Optional
+
+import pytest
+
+from app.modules import ServiceBase
+from app.schemas.system import DownloaderConf
+
+
+class _StubService(ServiceBase[object, DownloaderConf]):
+    """只提供配置字典的服务基类桩，不连接任何真实后端。"""
+
+    def __init__(self, configs: Dict[str, DownloaderConf]) -> None:
+        """记录待测配置，跳过真实服务实例化。
+
+        :param configs: 名称到配置的映射，顺序即读取顺序
+        """
+        self._configs = configs
+        self._instances = {}
+        self._service_name = "qbittorrent"
+
+    def get_configs(self) -> Dict[str, DownloaderConf]:
+        """返回构造时传入的配置字典。
+
+        :return: 名称到配置的映射
+        """
+        return self._configs
+
+
+def _conf(name: str, *, default: bool = False) -> DownloaderConf:
+    """构造一份已启用的下载器配置。
+
+    :param name: 配置名称
+    :param default: 是否标记为默认
+    :return: 下载器配置
+    """
+    return DownloaderConf(
+        name=name,
+        type="qbittorrent",
+        enabled=True,
+        default=default,
+        config={},
+    )
+
+
+def test_no_config_has_no_default() -> None:
+    """没有任何配置时不应凭空给出默认名称。"""
+    service = _StubService({})
+
+    assert service.get_default_config_name() is None
+
+
+def test_single_config_is_the_default() -> None:
+    """只有一份配置时它就是默认，无需用户额外标记。"""
+    service = _StubService({"only": _conf("only")})
+
+    assert service.get_default_config_name() == "only"
+
+
+def test_marked_config_wins_over_order() -> None:
+    """标记为默认的配置优先，即使它不排在最前。"""
+    service = _StubService(
+        {
+            "first": _conf("first"),
+            "second": _conf("second", default=True),
+        }
+    )
+
+    assert service.get_default_config_name() == "second"
+
+
+def test_marked_config_survives_reordering() -> None:
+    """读取顺序变化不得改变已标记的默认配置。
+
+    这是本修复要守住的性质：顺序是实现细节，标记才是用户的意思。
+    """
+    marked = _conf("marked", default=True)
+    plain = _conf("plain")
+
+    forward = _StubService({"marked": marked, "plain": plain})
+    backward = _StubService({"plain": plain, "marked": marked})
+
+    assert forward.get_default_config_name() == "marked"
+    assert backward.get_default_config_name() == "marked"
+
+
+def test_unmarked_configs_fall_back_to_first() -> None:
+    """一个标记都没有时保持原有行为，不改变既有部署的默认目标。"""
+    service = _StubService(
+        {
+            "alpha": _conf("alpha"),
+            "beta": _conf("beta"),
+        }
+    )
+
+    assert service.get_default_config_name() == "alpha"
+
+
+@pytest.mark.parametrize("name", ["alpha", "beta"])
+def test_get_config_without_name_follows_the_default(name: str) -> None:
+    """不指定名称时取到的必须是默认配置本身。"""
+    service = _StubService(
+        {
+            "alpha": _conf("alpha", default=name == "alpha"),
+            "beta": _conf("beta", default=name == "beta"),
+        }
+    )
+
+    resolved: Optional[DownloaderConf] = service.get_config()
+
+    assert resolved is not None
+    assert resolved.name == name


### PR DESCRIPTION
## 问题

`DownloaderConf` 等配置模型上一直有 `default` 字段（`app/schemas/system.py:77`「是否默认」），但 `ServiceBase.get_default_config_name()` 从不读它：

```python
# app/modules/__init__.py:207
first_conf = next(iter(self._configs.values()), None)
return first_conf.name if first_conf else None
```

取的是配置字典里的第一个。**字典顺序来自配置读取顺序，用户在界面上既看不见也控制不了。**

## 影响

落在下载任务的归属记录上。`app/modules/qbittorrent/__init__.py`（4 处）与 `transmission/__init__.py`（2 处）都是这个形状：

```python
return downloader or self.get_default_config_name(), torrent_hash, ...
```

用户没指定下载器时，记录里写的是当时的「第一个」。**删掉一份无关配置、或配置读取顺序变化，默认目标就会静默改指另一个下载器**，而历史记录已经按旧的默认写了进去。两者对不上，也没有任何报错。

`default` 字段本身有完整的写入与解析路径——实测前端只要在配置载荷里带上它就会被存下并解析出来，缺的只是读取端。

## 改法

优先返回被标记为默认的那份；**一个标记都没有时仍退回第一个**。

因此这是一个向后兼容的改动：既有部署（没人标记过默认）行为完全不变，只有在用户确实做过选择时，那个选择才开始生效。

## 验证

新增 7 条测试。**在未打补丁的 `3904a8396` 上先跑过一遍**，确认其中 3 条会红：

```
未修复： 3 failed, 4 passed
修复后： 7 passed
```

其中 `test_marked_config_survives_reordering` 专门断言读取顺序颠倒后默认配置不变——顺序是实现细节，标记才是用户的意思，这是本次要守住的性质。

全量对拍（两边都排除 `tests/test_downloader_path_mapping.py`，它在未打补丁的 `3904a8396` 上就有 `ImportError: cannot import name 'DownloaderFile'`，与本 PR 无关）：

```
基线    75 failed, 5779 passed, 3 skipped
本 PR   75 failed, 5786 passed, 3 skipped
```

`+7 passed` 即新增的 7 条。失败集合逐条对拍：一进一出，进的那条 `test_scanner_invalidates_equal_size_source_with_preserved_mtime` **在纯 `3904a8396` 代码上单跑同样失败**，是既有的时序敏感用例，与本 PR 无关。

需要说明：跑全量要加 `--timeout-method=signal`，默认的 thread 方式下有挂起用例会让整轮无输出。

## 规模

2 个文件：`app/modules/__init__.py` 改 1 个方法，新增 1 个测试文件。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at a8e37cc4115a4eb2c74ab6b2653ddadf1b44be8e

- 默认服务配置优先遵从 `default` 标记
- 无显式标记时保留首项回退行为
- 覆盖空配置、重排及配置解析场景
- 兼容影响：已有未标记配置行为不变
- 风险：多个配置同时标记时仍按顺序选取
<!-- pr-agent-summary:end -->
