### PR TITLE
fix: 固定源码更新载荷身份并拒绝旧发布覆盖

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -50,10 +50,27 @@ jobs:
           esac
           [[ "$frontend_sha256" =~ ^[0-9a-f]{64}$ ]]
 
+          resource_dir=$(mktemp -d)
+          trap 'rm -rf "$resource_dir"' EXIT
+          resource_base="https://raw.githubusercontent.com/jxxghp/MoviePilot-Resources/${resources_revision}/resources.v3"
+          for resource_file in \
+            user.sites.v3.bin \
+            sites.cpython-314-x86_64-linux-gnu.so \
+            sites.cpython-314-aarch64-linux-gnu.so; do
+            curl --fail --show-error --silent --location \
+              "${resource_base}/${resource_file}" -o "${resource_dir}/${resource_file}"
+          done
+          resource_index_sha256=$(sha256sum "${resource_dir}/user.sites.v3.bin" | awk '{print $1}')
+          resource_amd64_sha256=$(sha256sum "${resource_dir}/sites.cpython-314-x86_64-linux-gnu.so" | awk '{print $1}')
+          resource_arm64_sha256=$(sha256sum "${resource_dir}/sites.cpython-314-aarch64-linux-gnu.so" | awk '{print $1}')
+
           echo "plugins_revision=$plugins_revision" >> "$GITHUB_OUTPUT"
           echo "resources_revision=$resources_revision" >> "$GITHUB_OUTPUT"
           echo "frontend_digest=$frontend_digest" >> "$GITHUB_OUTPUT"
           echo "frontend_sha256=$frontend_sha256" >> "$GITHUB_OUTPUT"
+          echo "resource_index_sha256=$resource_index_sha256" >> "$GITHUB_OUTPUT"
+          echo "resource_amd64_sha256=$resource_amd64_sha256" >> "$GITHUB_OUTPUT"
+          echo "resource_arm64_sha256=$resource_arm64_sha256" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Wiki Plugin Market
         uses: actions/checkout@v4
@@ -129,10 +146,15 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
+            MOVIEPILOT_BUILD_CHANNEL=beta
+            MOVIEPILOT_BACKEND_REVISION=${{ env.SOURCE_COMMIT }}
             MOVIEPILOT_FRONTEND_VERSION=${{ steps.release_version.outputs.frontend_version }}
             MOVIEPILOT_FRONTEND_SHA256=${{ steps.payloads.outputs.frontend_sha256 }}
             MOVIEPILOT_PLUGINS_REF=${{ steps.payloads.outputs.plugins_revision }}
             MOVIEPILOT_RESOURCES_REF=${{ steps.payloads.outputs.resources_revision }}
+            MOVIEPILOT_RESOURCE_INDEX_SHA256=${{ steps.payloads.outputs.resource_index_sha256 }}
+            MOVIEPILOT_RESOURCE_AMD64_SHA256=${{ steps.payloads.outputs.resource_amd64_sha256 }}
+            MOVIEPILOT_RESOURCE_ARM64_SHA256=${{ steps.payloads.outputs.resource_arm64_sha256 }}
           labels: |
             ${{ steps.meta.outputs.labels }}
             org.opencontainers.image.revision=${{ env.SOURCE_COMMIT }}

--- a/.github/workflows/build-v3.yml
+++ b/.github/workflows/build-v3.yml
@@ -11,6 +11,10 @@ permissions:
   contents: write
   packages: write
 
+concurrency:
+  group: moviepilot-v3-release
+  cancel-in-progress: false
+
 jobs:
   Docker-build:
     runs-on: ubuntu-latest
@@ -269,6 +273,35 @@ jobs:
           ignore-unfixed: true
           trivyignores: .trivyignore.yaml
           exit-code: 1
+
+      - name: Verify release generation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_GENERATION: ${{ github.run_id }}.${{ github.run_attempt }}
+        run: |
+          latest_release=$(gh api "repos/${{ github.repository }}/releases/latest")
+          asset_count=$(jq '[.assets[]? | select(.name == "source-update-payload.json")] | length' <<< "$latest_release")
+          if [ "$asset_count" -eq 0 ]; then
+            echo "当前正式 Release 尚未提供源码更新身份，允许首次迁移发布"
+            exit 0
+          fi
+          if [ "$asset_count" -ne 1 ]; then
+            echo "当前正式 Release 的源码更新身份资产不唯一" >&2
+            exit 1
+          fi
+
+          latest_tag=$(jq -er '.tag_name' <<< "$latest_release")
+          published_payload=$(mktemp)
+          trap 'rm -f "$published_payload"' EXIT
+          gh release download "$latest_tag" \
+            --repo "${{ github.repository }}" \
+            --pattern source-update-payload.json \
+            --output "$published_payload"
+          published_generation=$(jq -er \
+            'select(.schema_version == 2 and .channel == "release") | .release_generation' \
+            "$published_payload")
+          python3 scripts/check_release_generation.py \
+            "$RELEASE_GENERATION" "$published_generation"
 
       - name: Login DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/build-v3.yml
+++ b/.github/workflows/build-v3.yml
@@ -69,10 +69,27 @@ jobs:
           esac
           [[ "$frontend_sha256" =~ ^[0-9a-f]{64}$ ]]
 
+          resource_dir=$(mktemp -d)
+          trap 'rm -rf "$resource_dir"' EXIT
+          resource_base="https://raw.githubusercontent.com/jxxghp/MoviePilot-Resources/${resources_revision}/resources.v3"
+          for resource_file in \
+            user.sites.v3.bin \
+            sites.cpython-314-x86_64-linux-gnu.so \
+            sites.cpython-314-aarch64-linux-gnu.so; do
+            curl --fail --show-error --silent --location \
+              "${resource_base}/${resource_file}" -o "${resource_dir}/${resource_file}"
+          done
+          resource_index_sha256=$(sha256sum "${resource_dir}/user.sites.v3.bin" | awk '{print $1}')
+          resource_amd64_sha256=$(sha256sum "${resource_dir}/sites.cpython-314-x86_64-linux-gnu.so" | awk '{print $1}')
+          resource_arm64_sha256=$(sha256sum "${resource_dir}/sites.cpython-314-aarch64-linux-gnu.so" | awk '{print $1}')
+
           echo "plugins_revision=$plugins_revision" >> "$GITHUB_OUTPUT"
           echo "resources_revision=$resources_revision" >> "$GITHUB_OUTPUT"
           echo "frontend_digest=$frontend_digest" >> "$GITHUB_OUTPUT"
           echo "frontend_sha256=$frontend_sha256" >> "$GITHUB_OUTPUT"
+          echo "resource_index_sha256=$resource_index_sha256" >> "$GITHUB_OUTPUT"
+          echo "resource_amd64_sha256=$resource_amd64_sha256" >> "$GITHUB_OUTPUT"
+          echo "resource_arm64_sha256=$resource_arm64_sha256" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Wiki Plugin Market
         uses: actions/checkout@v4
@@ -121,6 +138,45 @@ jobs:
           fi
           echo "release_commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Generate Source Update Payload
+        id: source_update_payload
+        env:
+          RELEASE_GENERATION: ${{ github.run_id }}.${{ github.run_attempt }}
+          BACKEND_REVISION: ${{ steps.release_snapshot.outputs.release_commit }}
+          FRONTEND_VERSION: ${{ steps.release_version.outputs.frontend_version }}
+          FRONTEND_SHA256: ${{ steps.payloads.outputs.frontend_sha256 }}
+          RESOURCES_REVISION: ${{ steps.payloads.outputs.resources_revision }}
+          RESOURCE_INDEX_SHA256: ${{ steps.payloads.outputs.resource_index_sha256 }}
+          RESOURCE_AMD64_SHA256: ${{ steps.payloads.outputs.resource_amd64_sha256 }}
+          RESOURCE_ARM64_SHA256: ${{ steps.payloads.outputs.resource_arm64_sha256 }}
+        run: |
+          mkdir -p .build
+          jq -n \
+            --arg release_generation "$RELEASE_GENERATION" \
+            --arg backend_revision "$BACKEND_REVISION" \
+            --arg frontend_version "$FRONTEND_VERSION" \
+            --arg frontend_sha256 "$FRONTEND_SHA256" \
+            --arg resources_revision "$RESOURCES_REVISION" \
+            --arg resource_index_sha256 "$RESOURCE_INDEX_SHA256" \
+            --arg resource_amd64_sha256 "$RESOURCE_AMD64_SHA256" \
+            --arg resource_arm64_sha256 "$RESOURCE_ARM64_SHA256" \
+            '{
+              schema_version: 2,
+              channel: "release",
+              release_generation: $release_generation,
+              backend_revision: $backend_revision,
+              frontend_version: $frontend_version,
+              frontend_sha256: $frontend_sha256,
+              resources_revision: $resources_revision,
+              resource_sha256: {
+                "user.sites.v3.bin": $resource_index_sha256,
+                "sites.cpython-314-x86_64-linux-gnu.so": $resource_amd64_sha256,
+                "sites.cpython-314-aarch64-linux-gnu.so": $resource_arm64_sha256
+              }
+            }' > .build/source-update-payload.json
+          jq -e . .build/source-update-payload.json >/dev/null
+          echo "sha256=$(sha256sum .build/source-update-payload.json | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
       - name: Docker Meta
         id: meta
         uses: docker/metadata-action@v5
@@ -149,10 +205,17 @@ jobs:
           pull: true
           tags: moviepilot-v3-candidate:linux-amd64
           build-args: |
+            MOVIEPILOT_BUILD_CHANNEL=release
+            MOVIEPILOT_RELEASE_GENERATION=${{ github.run_id }}.${{ github.run_attempt }}
+            MOVIEPILOT_SOURCE_UPDATE_PAYLOAD_SHA256=${{ steps.source_update_payload.outputs.sha256 }}
+            MOVIEPILOT_BACKEND_REVISION=${{ steps.release_snapshot.outputs.release_commit }}
             MOVIEPILOT_FRONTEND_VERSION=${{ steps.release_version.outputs.frontend_version }}
             MOVIEPILOT_FRONTEND_SHA256=${{ steps.payloads.outputs.frontend_sha256 }}
             MOVIEPILOT_PLUGINS_REF=${{ steps.payloads.outputs.plugins_revision }}
             MOVIEPILOT_RESOURCES_REF=${{ steps.payloads.outputs.resources_revision }}
+            MOVIEPILOT_RESOURCE_INDEX_SHA256=${{ steps.payloads.outputs.resource_index_sha256 }}
+            MOVIEPILOT_RESOURCE_AMD64_SHA256=${{ steps.payloads.outputs.resource_amd64_sha256 }}
+            MOVIEPILOT_RESOURCE_ARM64_SHA256=${{ steps.payloads.outputs.resource_arm64_sha256 }}
           cache-from: type=gha,scope=moviepilot-v3-docker-amd64,version=2
           cache-to: type=gha,scope=moviepilot-v3-docker-amd64,mode=max,version=2
 
@@ -180,10 +243,17 @@ jobs:
           pull: true
           tags: moviepilot-v3-candidate:linux-arm64
           build-args: |
+            MOVIEPILOT_BUILD_CHANNEL=release
+            MOVIEPILOT_RELEASE_GENERATION=${{ github.run_id }}.${{ github.run_attempt }}
+            MOVIEPILOT_SOURCE_UPDATE_PAYLOAD_SHA256=${{ steps.source_update_payload.outputs.sha256 }}
+            MOVIEPILOT_BACKEND_REVISION=${{ steps.release_snapshot.outputs.release_commit }}
             MOVIEPILOT_FRONTEND_VERSION=${{ steps.release_version.outputs.frontend_version }}
             MOVIEPILOT_FRONTEND_SHA256=${{ steps.payloads.outputs.frontend_sha256 }}
             MOVIEPILOT_PLUGINS_REF=${{ steps.payloads.outputs.plugins_revision }}
             MOVIEPILOT_RESOURCES_REF=${{ steps.payloads.outputs.resources_revision }}
+            MOVIEPILOT_RESOURCE_INDEX_SHA256=${{ steps.payloads.outputs.resource_index_sha256 }}
+            MOVIEPILOT_RESOURCE_AMD64_SHA256=${{ steps.payloads.outputs.resource_amd64_sha256 }}
+            MOVIEPILOT_RESOURCE_ARM64_SHA256=${{ steps.payloads.outputs.resource_arm64_sha256 }}
           cache-from: type=gha,scope=moviepilot-v3-docker-arm64,version=2
           cache-to: type=gha,scope=moviepilot-v3-docker-arm64,mode=max,version=2
 
@@ -225,10 +295,17 @@ jobs:
           pull: false
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
+            MOVIEPILOT_BUILD_CHANNEL=release
+            MOVIEPILOT_RELEASE_GENERATION=${{ github.run_id }}.${{ github.run_attempt }}
+            MOVIEPILOT_SOURCE_UPDATE_PAYLOAD_SHA256=${{ steps.source_update_payload.outputs.sha256 }}
+            MOVIEPILOT_BACKEND_REVISION=${{ steps.release_snapshot.outputs.release_commit }}
             MOVIEPILOT_FRONTEND_VERSION=${{ steps.release_version.outputs.frontend_version }}
             MOVIEPILOT_FRONTEND_SHA256=${{ steps.payloads.outputs.frontend_sha256 }}
             MOVIEPILOT_PLUGINS_REF=${{ steps.payloads.outputs.plugins_revision }}
             MOVIEPILOT_RESOURCES_REF=${{ steps.payloads.outputs.resources_revision }}
+            MOVIEPILOT_RESOURCE_INDEX_SHA256=${{ steps.payloads.outputs.resource_index_sha256 }}
+            MOVIEPILOT_RESOURCE_AMD64_SHA256=${{ steps.payloads.outputs.resource_amd64_sha256 }}
+            MOVIEPILOT_RESOURCE_ARM64_SHA256=${{ steps.payloads.outputs.resource_arm64_sha256 }}
           labels: |
             ${{ steps.meta.outputs.labels }}
             org.opencontainers.image.revision=${{ steps.release_snapshot.outputs.release_commit }}
@@ -386,6 +463,7 @@ jobs:
           tag_name: v${{ env.app_version }}
           name: v${{ env.app_version }}
           body: ${{ env.RELEASE_BODY }}
+          files: .build/source-update-payload.json
           draft: false
           prerelease: false
           make_latest: true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -184,19 +184,28 @@ FROM prepare_payload AS prepare_resources
 
 ARG TARGETARCH
 ARG MOVIEPILOT_RESOURCES_REF="main"
+ARG MOVIEPILOT_RESOURCE_INDEX_SHA256=""
+ARG MOVIEPILOT_RESOURCE_AMD64_SHA256=""
+ARG MOVIEPILOT_RESOURCE_ARM64_SHA256=""
 
 RUN set -eu; \
     test -n "${MOVIEPILOT_RESOURCES_REF}"; \
     python_ver="$(python3 -c 'import sys; print(f"cpython-{sys.version_info.major}{sys.version_info.minor}")')"; \
     target_arch="${TARGETARCH:-$(uname -m)}"; \
     case "${target_arch}" in \
-        arm64|aarch64) suffix="aarch64-linux-gnu" ;; \
-        amd64|x86_64) suffix="x86_64-linux-gnu" ;; \
+        arm64|aarch64) suffix="aarch64-linux-gnu"; sites_sha256="${MOVIEPILOT_RESOURCE_ARM64_SHA256}" ;; \
+        amd64|x86_64) suffix="x86_64-linux-gnu"; sites_sha256="${MOVIEPILOT_RESOURCE_AMD64_SHA256}" ;; \
         *) printf 'Unsupported architecture: %s\n' "${target_arch}" >&2; exit 1 ;; \
     esac; \
     mkdir -p /resources; \
     curl -fsSL "https://raw.githubusercontent.com/jxxghp/MoviePilot-Resources/${MOVIEPILOT_RESOURCES_REF}/resources.v3/user.sites.v3.bin" -o /resources/user.sites.v3.bin; \
-    curl -fsSL "https://raw.githubusercontent.com/jxxghp/MoviePilot-Resources/${MOVIEPILOT_RESOURCES_REF}/resources.v3/sites.${python_ver}-${suffix}.so" -o "/resources/sites.${python_ver}-${suffix}.so"
+    curl -fsSL "https://raw.githubusercontent.com/jxxghp/MoviePilot-Resources/${MOVIEPILOT_RESOURCES_REF}/resources.v3/sites.${python_ver}-${suffix}.so" -o "/resources/sites.${python_ver}-${suffix}.so"; \
+    if [ -n "${MOVIEPILOT_RESOURCE_INDEX_SHA256}" ]; then \
+        printf '%s  %s\n' "${MOVIEPILOT_RESOURCE_INDEX_SHA256}" /resources/user.sites.v3.bin | sha256sum -c -; \
+    fi; \
+    if [ -n "${sites_sha256}" ]; then \
+        printf '%s  %s\n' "${sites_sha256}" "/resources/sites.${python_ver}-${suffix}.so" | sha256sum -c -; \
+    fi
 
 
 # 准备容器控制面
@@ -220,8 +229,23 @@ RUN mkdir -p /bundle/control /bundle/nginx /bundle/bin \
 # final 阶段: 安装运行时依赖和配置最终镜像
 FROM prepare_package AS final
 
+ARG MOVIEPILOT_BUILD_CHANNEL=""
+ARG MOVIEPILOT_RELEASE_GENERATION=""
+ARG MOVIEPILOT_SOURCE_UPDATE_PAYLOAD_SHA256=""
+ARG MOVIEPILOT_BACKEND_REVISION=""
+ARG MOVIEPILOT_FRONTEND_VERSION=""
+ARG MOVIEPILOT_FRONTEND_SHA256=""
+ARG MOVIEPILOT_RESOURCES_REF=""
+
 ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so" \
-    MOVIEPILOT_DOCKER_KEEPALIVE_ON_FAILURE="true"
+    MOVIEPILOT_DOCKER_KEEPALIVE_ON_FAILURE="true" \
+    MOVIEPILOT_IMAGE_UPDATE_CHANNEL="${MOVIEPILOT_BUILD_CHANNEL}" \
+    MOVIEPILOT_IMAGE_RELEASE_GENERATION="${MOVIEPILOT_RELEASE_GENERATION}" \
+    MOVIEPILOT_IMAGE_SOURCE_UPDATE_PAYLOAD_SHA256="${MOVIEPILOT_SOURCE_UPDATE_PAYLOAD_SHA256}" \
+    MOVIEPILOT_IMAGE_BACKEND_REVISION="${MOVIEPILOT_BACKEND_REVISION}" \
+    MOVIEPILOT_IMAGE_FRONTEND_VERSION="${MOVIEPILOT_FRONTEND_VERSION}" \
+    MOVIEPILOT_IMAGE_FRONTEND_SHA256="${MOVIEPILOT_FRONTEND_SHA256}" \
+    MOVIEPILOT_IMAGE_RESOURCES_REVISION="${MOVIEPILOT_RESOURCES_REF}"
 
 # 引入支持 amr 编码的静态 ffmpeg
 COPY --from=ffmpeg /ffmpeg /usr/local/bin/

--- a/docker/update.sh
+++ b/docker/update.sh
@@ -31,6 +31,7 @@ PUBLIC_DIR=/public
 UPDATE_PENDING_FILE="${CONFIG_DIR}/temp/__update_pending__"
 UPDATE_PREVIOUS_APP="${APP_DIR}.__update_previous__"
 UPDATE_PREVIOUS_PUBLIC="${PUBLIC_DIR}.__update_previous__"
+UPDATE_PAYLOAD_ASSET="source-update-payload.json"
 
 function apply_package_cache_env() {
     PACKAGE_CACHE_ROOT="${PACKAGE_CACHE_ROOT:-${CONFIG_DIR}/.cache}"
@@ -48,6 +49,17 @@ UPDATE_RECOVERY_REQUIRED="false"
 UPDATE_RECOVERY_COMPLETED="false"
 DEPENDENCY_SYNC_ATTEMPTED="false"
 PACKAGE_ROUTE_READY="false"
+TARGET_UPDATE_CHANNEL=""
+TARGET_RELEASE_GENERATION=""
+TARGET_PAYLOAD_SHA256=""
+TARGET_PAYLOAD_UNCHANGED="false"
+TARGET_BACKEND_REVISION=""
+TARGET_FRONTEND_VERSION=""
+TARGET_FRONTEND_SHA256=""
+TARGET_RESOURCES_REVISION=""
+TARGET_RESOURCE_INDEX_SHA256=""
+TARGET_RESOURCE_SITES_SHA256=""
+TARGET_PAYLOAD_FILE=""
 
 function set_package_proxy_env() {
     PACKAGE_ENV=()
@@ -61,30 +73,59 @@ function set_package_proxy_env() {
     fi
 }
 
-# 下载及解压
-function download_and_unzip() {
+function download_file() {
     local retries=0
     local max_retries=3
     local url="$1"
-    local target_dir="$2"
+    local destination="$2"
+    local expected_sha256="${3:-}"
+    local temporary="${destination}.part.$$"
+
     INFO "→ 正在下载 ${url}..."
     while [ $retries -lt $max_retries ]; do
-        if curl ${CURL_OPTIONS} "${url}" ${CURL_HEADERS} | busybox unzip -d ${TMP_PATH} - > /dev/null; then
-            if [ -e ${TMP_PATH}/MoviePilot-* ]; then
-                mv ${TMP_PATH}/MoviePilot-* ${TMP_PATH}/"${target_dir}"
+        rm -f "${temporary}"
+        if curl ${CURL_OPTIONS} --fail "${url}" ${CURL_HEADERS} -o "${temporary}" \
+            && [ -s "${temporary}" ]; then
+            if [ -n "${expected_sha256}" ] \
+                && ! printf '%s  %s\n' "${expected_sha256}" "${temporary}" | sha256sum -c - > /dev/null; then
+                ERROR "${url} 完整性校验失败"
+                rm -f "${temporary}"
+                return 1
             fi
-            break
-        else
-            WARN "下载 ${url} 失败，正在进行第 $((retries + 1)) 次重试..."
-            retries=$((retries + 1))
+            mv -f "${temporary}" "${destination}"
+            return 0
         fi
+        WARN "下载 ${url} 失败，正在进行第 $((retries + 1)) 次重试..."
+        retries=$((retries + 1))
     done
-    if [ $retries -eq $max_retries ]; then
-        ERROR "下载 ${url} 失败，已达到最大重试次数！"
+
+    rm -f "${temporary}"
+    ERROR "下载 ${url} 失败，已达到最大重试次数！"
+    return 1
+}
+
+# 下载及解压
+function download_and_unzip() {
+    local url="$1"
+    local target_dir="$2"
+    local expected_sha256="${3:-}"
+    local archive="${TMP_PATH}/.${target_dir}.zip"
+    local extracted_dir
+
+    download_file "${url}" "${archive}" "${expected_sha256}" || return 1
+    if ! busybox unzip -t "${archive}" > /dev/null \
+        || ! busybox unzip -q "${archive}" -d "${TMP_PATH}"; then
+        ERROR "${url} 不是完整的 ZIP 制品"
         return 1
-    else
-        return 0
     fi
+    if [ ! -d "${TMP_PATH}/${target_dir}" ]; then
+        extracted_dir=$(find "${TMP_PATH}" -mindepth 1 -maxdepth 1 -type d \
+            -name 'MoviePilot-*' -print -quit)
+        if [ -n "${extracted_dir}" ]; then
+            mv "${extracted_dir}" "${TMP_PATH}/${target_dir}" || return 1
+        fi
+    fi
+    [ -d "${TMP_PATH}/${target_dir}" ]
 }
 
 function sync_project_dependencies() {
@@ -232,44 +273,252 @@ function recover_pending_update() {
     INFO "→ 未完成的容器更新事务已恢复"
 }
 
-function existing_resource_dir() {
-    local resource_source_dir="${APP_DIR}/app/application/site"
-    for legacy_resource_dir in "${APP_DIR}/app/infrastructure" "${APP_DIR}/app/adapters/network" "${APP_DIR}/app/helper"; do
-        if [ ! -d "${resource_source_dir}" ] && [ -d "${legacy_resource_dir}" ]; then
-            resource_source_dir="${legacy_resource_dir}"
-        fi
-    done
-    printf '%s\n' "${resource_source_dir}"
+function resource_sites_file() {
+    local python_version
+    local arch
+    local arch_suffix
+
+    python_version="$(python3 -c 'import sys; print(f"cpython-{sys.version_info.major}{sys.version_info.minor}")')" \
+        || return 1
+    arch="$(uname -m)"
+    case "${arch}" in
+        aarch64|arm64) arch_suffix="aarch64-linux-gnu" ;;
+        x86_64|amd64) arch_suffix="x86_64-linux-gnu" ;;
+        *)
+            ERROR "不支持的更新资源架构：${arch}"
+            return 1
+            ;;
+    esac
+    printf 'sites.%s-%s.so\n' "${python_version}" "${arch_suffix}"
 }
 
-function download_staged_resource() {
-    local url="$1"
-    local destination="$2"
-    local fallback="$3"
-    local label="$4"
+function payload_identity_file() {
+    printf '%s/.moviepilot-payload.json\n' "${APP_DIR}"
+}
 
-    if curl ${CURL_OPTIONS} --fail "${url}" -o "${destination}" \
-        && [ -s "${destination}" ]; then
-        return 0
-    fi
-    rm -f "${destination}"
-    if [ -f "${fallback}" ]; then
-        cp -a "${fallback}" "${destination}"
+function installed_payload_value() {
+    local field="$1"
+    local identity_file
+    identity_file="$(payload_identity_file)"
+
+    if [ -f "${identity_file}" ] \
+        && jq -e '.schema_version == 2' "${identity_file}" > /dev/null 2>&1; then
+        jq -er --arg field "${field}" '.[$field] | strings | select(length > 0)' \
+            "${identity_file}" 2>/dev/null
         return $?
     fi
-    ERROR "${label} 下载失败且没有可用旧资源"
-    return 1
+
+    case "${field}" in
+        channel) printf '%s\n' "${MOVIEPILOT_IMAGE_UPDATE_CHANNEL:-}" ;;
+        release_generation) printf '%s\n' "${MOVIEPILOT_IMAGE_RELEASE_GENERATION:-}" ;;
+        payload_sha256) printf '%s\n' "${MOVIEPILOT_IMAGE_SOURCE_UPDATE_PAYLOAD_SHA256:-}" ;;
+        backend_revision) printf '%s\n' "${MOVIEPILOT_IMAGE_BACKEND_REVISION:-}" ;;
+        frontend_version) printf '%s\n' "${MOVIEPILOT_IMAGE_FRONTEND_VERSION:-}" ;;
+        frontend_sha256) printf '%s\n' "${MOVIEPILOT_IMAGE_FRONTEND_SHA256:-}" ;;
+        resources_revision) printf '%s\n' "${MOVIEPILOT_IMAGE_RESOURCES_REVISION:-}" ;;
+        *) return 1 ;;
+    esac
+}
+
+function validate_target_payload() {
+    local sites_file="$1"
+
+    [[ "${TARGET_UPDATE_CHANNEL}" =~ ^(release|dev)$ ]] \
+        && { [ "${TARGET_UPDATE_CHANNEL}" = "dev" ] \
+            || [[ "${TARGET_RELEASE_GENERATION}" =~ ^[1-9][0-9]*\.[1-9][0-9]*$ ]]; } \
+        && { [ "${TARGET_UPDATE_CHANNEL}" = "dev" ] \
+            || [[ "${TARGET_PAYLOAD_SHA256}" =~ ^[0-9a-f]{64}$ ]]; } \
+        && [[ "${TARGET_BACKEND_REVISION}" =~ ^[0-9a-f]{40}$ ]] \
+        && [[ "${TARGET_FRONTEND_VERSION}" =~ ^v3\.[0-9A-Za-z._-]+$ ]] \
+        && [[ "${TARGET_FRONTEND_SHA256}" =~ ^[0-9a-f]{64}$ ]] \
+        && [[ "${TARGET_RESOURCES_REVISION}" =~ ^[0-9a-f]{40}$ ]] \
+        && { [ -z "${TARGET_RESOURCE_INDEX_SHA256}" ] \
+            || [[ "${TARGET_RESOURCE_INDEX_SHA256}" =~ ^[0-9a-f]{64}$ ]]; } \
+        && { [ -z "${TARGET_RESOURCE_SITES_SHA256}" ] \
+            || [[ "${TARGET_RESOURCE_SITES_SHA256}" =~ ^[0-9a-f]{64}$ ]]; } \
+        && [[ "${sites_file}" =~ ^sites\.cpython-[0-9]+-(x86_64|aarch64)-linux-gnu\.so$ ]]
+}
+
+function load_release_payload() {
+    local release_tag="$1"
+    local sites_file
+    local payload_url
+    local release_metadata="${TMP_PATH}/latest-v3-release.json"
+    local payload_digest
+
+    TARGET_PAYLOAD_SHA256=""
+    TARGET_PAYLOAD_UNCHANGED="false"
+    if [ ! -s "${release_metadata}" ]; then
+        curl ${CURL_OPTIONS} --compressed --fail --connect-timeout 5 --max-time 15 \
+            "https://api.github.com/repos/jxxghp/MoviePilot/releases/tags/${release_tag}" \
+            ${CURL_HEADERS} > "${release_metadata}" || return 1
+    fi
+    payload_digest=$(jq -er --arg asset "${UPDATE_PAYLOAD_ASSET}" \
+        '.assets[] | select(.name == $asset) | .digest' "${release_metadata}") || return 1
+    TARGET_PAYLOAD_SHA256="${payload_digest#sha256:}"
+    [[ "${TARGET_PAYLOAD_SHA256}" =~ ^[0-9a-f]{64}$ ]] || return 1
+    if [ "$(installed_payload_value payload_sha256 2>/dev/null)" = "${TARGET_PAYLOAD_SHA256}" ]; then
+        TARGET_PAYLOAD_UNCHANGED="true"
+        return 0
+    fi
+
+    sites_file="$(resource_sites_file)" || return 1
+    TARGET_PAYLOAD_FILE="${TMP_PATH}/${UPDATE_PAYLOAD_ASSET}"
+    payload_url="${GITHUB_PROXY}https://github.com/jxxghp/MoviePilot/releases/download/${release_tag}/${UPDATE_PAYLOAD_ASSET}"
+    download_file "${payload_url}" "${TARGET_PAYLOAD_FILE}" "${TARGET_PAYLOAD_SHA256}" || return 1
+    if ! jq -e '.schema_version == 2 and .channel == "release"' \
+        "${TARGET_PAYLOAD_FILE}" > /dev/null; then
+        ERROR "发布载荷清单格式无效"
+        return 1
+    fi
+    TARGET_UPDATE_CHANNEL="$(jq -r '.channel' "${TARGET_PAYLOAD_FILE}")"
+    TARGET_RELEASE_GENERATION="$(jq -r '.release_generation' "${TARGET_PAYLOAD_FILE}")"
+    TARGET_BACKEND_REVISION="$(jq -r '.backend_revision' "${TARGET_PAYLOAD_FILE}")"
+    TARGET_FRONTEND_VERSION="$(jq -r '.frontend_version' "${TARGET_PAYLOAD_FILE}")"
+    TARGET_FRONTEND_SHA256="$(jq -r '.frontend_sha256' "${TARGET_PAYLOAD_FILE}")"
+    TARGET_RESOURCES_REVISION="$(jq -r '.resources_revision' "${TARGET_PAYLOAD_FILE}")"
+    TARGET_RESOURCE_INDEX_SHA256="$(jq -r '.resource_sha256["user.sites.v3.bin"] // ""' \
+        "${TARGET_PAYLOAD_FILE}")"
+    TARGET_RESOURCE_SITES_SHA256="$(jq -r --arg sites_file "${sites_file}" \
+        '.resource_sha256[$sites_file] // ""' "${TARGET_PAYLOAD_FILE}")"
+    if ! validate_target_payload "${sites_file}" \
+        || [ -z "${TARGET_RESOURCE_INDEX_SHA256}" ] \
+        || [ -z "${TARGET_RESOURCE_SITES_SHA256}" ]; then
+        ERROR "发布载荷清单缺少当前平台的完整身份"
+        return 1
+    fi
+}
+
+function github_commit_revision() {
+    local repository="$1"
+    local ref="$2"
+    local revision
+
+    revision=$(curl ${CURL_OPTIONS} --compressed --fail --connect-timeout 5 --max-time 15 \
+        "https://api.github.com/repos/${repository}/commits/${ref}" ${CURL_HEADERS} \
+        | jq -er '.sha') || return 1
+    [[ "${revision}" =~ ^[0-9a-f]{40}$ ]] || return 1
+    printf '%s\n' "${revision}"
+}
+
+function fetch_latest_frontend_v3_release() {
+    local response
+    local release_tag
+
+    response=$(curl ${CURL_OPTIONS} --compressed --fail --connect-timeout 5 --max-time 15 \
+        "https://api.github.com/repos/jxxghp/MoviePilot-Frontend/releases" \
+        ${CURL_HEADERS}) || return 1
+    release_tag=$(printf '%s\n' "${response}" | jq -r '.[].tag_name' \
+        | grep '^v3\.' | sort -V | tail -n 1)
+    [[ -n "${release_tag}" ]] || return 1
+    printf '%s\n' "${release_tag}"
+}
+
+function frontend_release_sha256() {
+    local release_tag="$1"
+    local digest
+
+    digest=$(curl ${CURL_OPTIONS} --compressed --fail --connect-timeout 5 --max-time 15 \
+        "https://api.github.com/repos/jxxghp/MoviePilot-Frontend/releases/tags/${release_tag}" \
+        ${CURL_HEADERS} \
+        | jq -er '.assets[] | select(.name == "dist.zip") | .digest') || return 1
+    digest="${digest#sha256:}"
+    [[ "${digest}" =~ ^[0-9a-f]{64}$ ]] || return 1
+    printf '%s\n' "${digest}"
+}
+
+function load_dev_payload() {
+    local sites_file
+
+    sites_file="$(resource_sites_file)" || return 1
+    TARGET_UPDATE_CHANNEL="dev"
+    TARGET_RELEASE_GENERATION=""
+    TARGET_PAYLOAD_SHA256=""
+    TARGET_PAYLOAD_UNCHANGED="false"
+    TARGET_BACKEND_REVISION="$(github_commit_revision jxxghp/MoviePilot v3)" || return 1
+    TARGET_FRONTEND_VERSION="$(fetch_latest_frontend_v3_release)" || return 1
+    TARGET_FRONTEND_SHA256="$(frontend_release_sha256 "${TARGET_FRONTEND_VERSION}")" || return 1
+    TARGET_RESOURCES_REVISION="$(github_commit_revision jxxghp/MoviePilot-Resources main)" || return 1
+    TARGET_RESOURCE_INDEX_SHA256=""
+    TARGET_RESOURCE_SITES_SHA256=""
+    validate_target_payload "${sites_file}"
+}
+
+function installed_payload_matches_target() {
+    [ "$(installed_payload_value channel 2>/dev/null)" = "${TARGET_UPDATE_CHANNEL}" ] \
+        && [ "$(installed_payload_value release_generation 2>/dev/null)" = "${TARGET_RELEASE_GENERATION}" ] \
+        && [ "$(installed_payload_value payload_sha256 2>/dev/null)" = "${TARGET_PAYLOAD_SHA256}" ] \
+        && [ "$(installed_payload_value backend_revision 2>/dev/null)" = "${TARGET_BACKEND_REVISION}" ] \
+        && [ "$(installed_payload_value frontend_version 2>/dev/null)" = "${TARGET_FRONTEND_VERSION}" ] \
+        && [ "$(installed_payload_value frontend_sha256 2>/dev/null)" = "${TARGET_FRONTEND_SHA256}" ] \
+        && [ "$(installed_payload_value resources_revision 2>/dev/null)" = "${TARGET_RESOURCES_REVISION}" ]
+}
+
+function target_release_is_older_than_installed() {
+    local installed_generation
+    local installed_run
+    local installed_attempt
+    local target_run
+    local target_attempt
+
+    [ "${TARGET_UPDATE_CHANNEL}" = "release" ] \
+        && [ "$(installed_payload_value channel 2>/dev/null)" = "release" ] || return 1
+    installed_generation="$(installed_payload_value release_generation 2>/dev/null)"
+    [[ "${installed_generation}" =~ ^[1-9][0-9]*\.[1-9][0-9]*$ ]] \
+        && [[ "${TARGET_RELEASE_GENERATION}" =~ ^[1-9][0-9]*\.[1-9][0-9]*$ ]] || return 1
+
+    installed_run="${installed_generation%.*}"
+    installed_attempt="${installed_generation##*.}"
+    target_run="${TARGET_RELEASE_GENERATION%.*}"
+    target_attempt="${TARGET_RELEASE_GENERATION##*.}"
+    (( 10#${target_run} < 10#${installed_run} \
+        || (10#${target_run} == 10#${installed_run} \
+            && 10#${target_attempt} < 10#${installed_attempt}) ))
+}
+
+function write_staged_payload_identity() {
+    local stage_app="${TMP_PATH}/App"
+    local stage_resource_dir="${stage_app}/app/application/site"
+    local sites_file
+    local resource_index_sha256
+    local resource_sites_sha256
+
+    sites_file="$(resource_sites_file)" || return 1
+    resource_index_sha256=$(sha256sum "${stage_resource_dir}/user.sites.v3.bin" | awk '{print $1}') \
+        || return 1
+    resource_sites_sha256=$(sha256sum "${stage_resource_dir}/${sites_file}" | awk '{print $1}') \
+        || return 1
+    jq -n \
+        --arg channel "${TARGET_UPDATE_CHANNEL}" \
+        --arg release_generation "${TARGET_RELEASE_GENERATION}" \
+        --arg payload_sha256 "${TARGET_PAYLOAD_SHA256}" \
+        --arg backend_revision "${TARGET_BACKEND_REVISION}" \
+        --arg frontend_version "${TARGET_FRONTEND_VERSION}" \
+        --arg frontend_sha256 "${TARGET_FRONTEND_SHA256}" \
+        --arg resources_revision "${TARGET_RESOURCES_REVISION}" \
+        --arg resource_index_sha256 "${resource_index_sha256}" \
+        --arg sites_file "${sites_file}" \
+        --arg resource_sites_sha256 "${resource_sites_sha256}" \
+        '{
+            schema_version: 2,
+            channel: $channel,
+            release_generation: $release_generation,
+            payload_sha256: $payload_sha256,
+            backend_revision: $backend_revision,
+            frontend_version: $frontend_version,
+            frontend_sha256: $frontend_sha256,
+            resources_revision: $resources_revision,
+            resource_sha256: {
+                "user.sites.v3.bin": $resource_index_sha256,
+                ($sites_file): $resource_sites_sha256
+            }
+        }' > "${stage_app}/.moviepilot-payload.json"
 }
 
 function stage_runtime_payload() {
     local stage_app="${TMP_PATH}/App"
     local stage_plugin_dir="${stage_app}/app/plugins"
     local stage_resource_dir="${stage_app}/app/application/site"
-    local resource_source_dir
-    local resource_file
-    local python_version
-    local arch
-    local arch_suffix
     local sites_file
 
     [ -f "${stage_app}/version.py" ] || return 1
@@ -293,35 +542,17 @@ function stage_runtime_payload() {
         return 1
     fi
 
-    resource_source_dir="$(existing_resource_dir)"
     mkdir -p "${stage_resource_dir}" || return 1
-    if [ -f "${resource_source_dir}/user.sites.v3.bin" ] \
-        && ! cp -a "${resource_source_dir}/user.sites.v3.bin" "${stage_resource_dir}/"; then
-        return 1
-    fi
-    for resource_file in "${resource_source_dir}"/sites.cp*; do
-        [ -f "${resource_file}" ] || continue
-        cp -a "${resource_file}" "${stage_resource_dir}/" || return 1
-    done
-
-    python_version="$(python3 -c 'import sys; print(f"cpython-{sys.version_info.major}{sys.version_info.minor}")')" || return 1
-    arch="$(uname -m)"
-    if [ "${arch}" = "aarch64" ]; then
-        arch_suffix="aarch64-linux-gnu"
-    else
-        arch_suffix="x86_64-linux-gnu"
-    fi
-    sites_file="sites.${python_version}-${arch_suffix}.so"
-    download_staged_resource \
-        "${GITHUB_PROXY}https://raw.githubusercontent.com/jxxghp/MoviePilot-Resources/main/resources.v3/user.sites.v3.bin" \
+    sites_file="$(resource_sites_file)" || return 1
+    download_file \
+        "${GITHUB_PROXY}https://raw.githubusercontent.com/jxxghp/MoviePilot-Resources/${TARGET_RESOURCES_REVISION}/resources.v3/user.sites.v3.bin" \
         "${stage_resource_dir}/user.sites.v3.bin" \
-        "${resource_source_dir}/user.sites.v3.bin" \
-        "user.sites.v3.bin" || return 1
-    download_staged_resource \
-        "${GITHUB_PROXY}https://raw.githubusercontent.com/jxxghp/MoviePilot-Resources/main/resources.v3/${sites_file}" \
+        "${TARGET_RESOURCE_INDEX_SHA256}" || return 1
+    download_file \
+        "${GITHUB_PROXY}https://raw.githubusercontent.com/jxxghp/MoviePilot-Resources/${TARGET_RESOURCES_REVISION}/resources.v3/${sites_file}" \
         "${stage_resource_dir}/${sites_file}" \
-        "${resource_source_dir}/${sites_file}" \
-        "${sites_file}" || return 1
+        "${TARGET_RESOURCE_SITES_SHA256}" || return 1
+    write_staged_payload_identity || return 1
 }
 
 function swap_staged_payload() {
@@ -339,8 +570,39 @@ function swap_staged_payload() {
 
 # 下载程序资源，$1: 后端版本路径
 function install_backend_and_download_resources() {
+    local backend_url
+    local frontend_version
+    local release_tag
+
+    if [[ "${1}" == "heads/v3.zip" ]]; then
+        if ! load_dev_payload; then
+            ERROR "Dev 更新载荷身份解析失败"
+            return 1
+        fi
+    else
+        release_tag="${1#tags/}"
+        release_tag="${release_tag%.zip}"
+        if ! load_release_payload "${release_tag}"; then
+            ERROR "Release 更新载荷身份解析失败"
+            return 1
+        fi
+        if [ "${TARGET_PAYLOAD_UNCHANGED}" = "true" ]; then
+            INFO "发布载荷身份未变化，跳过载荷下载"
+            return 0
+        fi
+    fi
+    if target_release_is_older_than_installed; then
+        INFO "远程发布清单早于当前镜像，跳过旧代际载荷"
+        return 0
+    fi
+    if installed_payload_matches_target; then
+        INFO "后端、前端和站点资源身份均未变化，跳过载荷下载"
+        return 0
+    fi
+
     # 更新后端程序
-    if ! download_and_unzip "${GITHUB_PROXY}https://github.com/jxxghp/MoviePilot/archive/refs/${1}" "App"; then
+    backend_url="${GITHUB_PROXY}https://github.com/jxxghp/MoviePilot/archive/${TARGET_BACKEND_REVISION}.zip"
+    if ! download_and_unzip "${backend_url}" "App"; then
         WARN "后端程序下载失败，继续使用旧的程序来启动..."
         return 1
     fi
@@ -360,31 +622,18 @@ function install_backend_and_download_resources() {
         return 1
     fi
     
-    # 如果是"heads/v3.zip"，则查找v3开头的最新版本号
-    if [[ "${1}" == "heads/v3.zip" ]]; then
-        INFO "→ 正在获取前端最新版本号..."
-        # 获取所有发布的版本列表，并筛选出以v3开头的版本号
-        releases=$(curl ${CURL_OPTIONS} "https://api.github.com/repos/jxxghp/MoviePilot-Frontend/releases" ${CURL_HEADERS} | jq -r '.[].tag_name' | grep "^v3\.")
-        if [ -z "$releases" ]; then
-            WARN "未找到任何v3前端版本，继续启动..."
-            return 1
-        else
-            # 找到最新的v3版本
-            frontend_version=$(echo "$releases" | sort -V | tail -n 1)
-        fi
-        INFO "前端最新版本号：${frontend_version}"
-    else
-        INFO "→ 正在获取前端版本号..."
-        # 从后端文件中读取前端版本号
-        frontend_version=$(sed -n "s/^FRONTEND_VERSION\s*=\s*'\([^']*\)'/\1/p" ${TMP_PATH}/App/version.py)
-        if [[ "${frontend_version}" != *v* ]]; then
-            WARN "前端版本号获取失败，继续启动..."
-            return 1
-        fi
-        INFO "前端版本号：${frontend_version}"
+    frontend_version=$(sed -n "s/^FRONTEND_VERSION\s*=\s*'\([^']*\)'/\1/p" "${TMP_PATH}/App/version.py")
+    if [ "${TARGET_UPDATE_CHANNEL}" = "release" ] \
+        && [ "${frontend_version}" != "${TARGET_FRONTEND_VERSION}" ]; then
+        ERROR "后端源码声明的前端版本与发布载荷清单不一致"
+        return 1
     fi
+    INFO "前端版本号：${TARGET_FRONTEND_VERSION}"
     # 更新前端程序
-    if ! download_and_unzip "${GITHUB_PROXY}https://github.com/jxxghp/MoviePilot-Frontend/releases/download/${frontend_version}/dist.zip" "dist"; then
+    if ! download_and_unzip \
+        "${GITHUB_PROXY}https://github.com/jxxghp/MoviePilot-Frontend/releases/download/${TARGET_FRONTEND_VERSION}/dist.zip" \
+        "dist" \
+        "${TARGET_FRONTEND_SHA256}"; then
         WARN "前端程序下载失败，继续使用旧的程序来启动..."
         return 1
     fi
@@ -429,7 +678,7 @@ function install_backend_and_download_resources() {
     fi
     rm -rf "${TMP_PATH}"
     MOVIEPILOT_UPDATE_RESULT="updated"
-    INFO "程序更新成功，前端版本：${frontend_version}，后端版本：${1}"
+    INFO "程序更新成功，前端版本：${TARGET_FRONTEND_VERSION}，后端 revision：${TARGET_BACKEND_REVISION}"
     return 0
 }
 
@@ -552,6 +801,7 @@ function fetch_latest_v3_release() {
     local response
     local releases
     local latest_release
+    local release_metadata="${TMP_PATH}/latest-v3-release.json"
 
     response=$(curl ${CURL_OPTIONS} --compressed --fail --connect-timeout 5 --max-time 15 \
         "https://api.github.com/repos/jxxghp/MoviePilot/releases" \
@@ -559,6 +809,9 @@ function fetch_latest_v3_release() {
     releases=$(printf '%s\n' "${response}" | jq -r '.[].tag_name') || return 1
     latest_release=$(printf '%s\n' "${releases}" | grep "^v3\." | sort -V | tail -n 1)
     [[ -n "${latest_release}" ]] || return 1
+    printf '%s\n' "${response}" \
+        | jq -e --arg tag "${latest_release}" '.[] | select(.tag_name == $tag)' \
+            > "${release_metadata}" || return 1
     printf '%s\n' "${latest_release}"
 }
 
@@ -604,6 +857,14 @@ function compare_versions() {
             fi
         fi
     done
+    if [ "$(installed_payload_value channel 2>/dev/null)" = "release" ]; then
+        INFO "当前版本号未变化，继续核对发布载荷身份..."
+        if install_backend_and_download_resources "tags/$2.zip"; then
+            return 0
+        fi
+        MOVIEPILOT_UPDATE_RESULT="failed"
+        return 1
+    fi
     WARN "当前版本已是最新版本，跳过更新步骤..."
 }
 

--- a/scripts/check_release_generation.py
+++ b/scripts/check_release_generation.py
@@ -1,0 +1,44 @@
+"""阻止旧的正式发布任务覆盖较新的已发布载荷。"""
+
+import re
+import sys
+
+
+_GENERATION_PATTERN = re.compile(r"([1-9][0-9]*)\.([1-9][0-9]*)")
+
+
+def parse_generation(value: str) -> tuple[int, int]:
+    """解析 GitHub Actions run id 与 attempt 组成的发布代际。"""
+    match = _GENERATION_PATTERN.fullmatch(value)
+    if not match:
+        raise ValueError(f"无效的发布代际: {value}")
+    return int(match.group(1)), int(match.group(2))
+
+
+def main() -> int:
+    """仅允许当前代际不早于已经公开的正式发布代际。"""
+    if len(sys.argv) != 3:
+        print(
+            "用法: check_release_generation.py <candidate> <published>",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        candidate = parse_generation(sys.argv[1])
+        published = parse_generation(sys.argv[2])
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 2
+
+    if candidate < published:
+        print(
+            f"拒绝旧发布代际 {sys.argv[1]} 覆盖已发布代际 {sys.argv[2]}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_docker_bootstrap.py
+++ b/tests/test_docker_bootstrap.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 import os
 import shlex
 import subprocess
@@ -11,6 +13,38 @@ ROOT = Path(__file__).resolve().parents[1]
 LAUNCHER = ROOT / "docker" / "launcher.sh"
 UPDATER = ROOT / "docker" / "update.sh"
 BASE_CONTROL_FILES = ("entrypoint.sh", "update.sh", "browser.sh", "cert.sh")
+
+
+def _write_update_payload(
+    path: Path,
+    *,
+    backend_revision: str = "a" * 40,
+    frontend_sha256: str = "b" * 64,
+    resources_revision: str = "c" * 40,
+    release_generation: str = "100.1",
+    payload_sha256: str | None = "9" * 64,
+) -> None:
+    """写入覆盖两种 Linux 架构的正式源码更新载荷身份。"""
+    payload = {
+        "schema_version": 2,
+        "channel": "release",
+        "release_generation": release_generation,
+        "backend_revision": backend_revision,
+        "frontend_version": "v3.0.0",
+        "frontend_sha256": frontend_sha256,
+        "resources_revision": resources_revision,
+        "resource_sha256": {
+            "user.sites.v3.bin": "d" * 64,
+            "sites.cpython-314-x86_64-linux-gnu.so": "e" * 64,
+            "sites.cpython-314-aarch64-linux-gnu.so": "f" * 64,
+        },
+    }
+    if payload_sha256 is not None:
+        payload["payload_sha256"] = payload_sha256
+    path.write_text(
+        json.dumps(payload),
+        encoding="utf-8",
+    )
 
 
 def _write_bundle(path: Path, label: str, *, extra_files: tuple[str, ...] = ()) -> None:
@@ -874,6 +908,15 @@ def test_dependency_update_requires_complete_uv_manifests(
         INFO() {{ :; }}
         WARN() {{ :; }}
         ERROR() {{ :; }}
+        load_release_payload() {{
+            TARGET_UPDATE_CHANNEL=release
+            TARGET_BACKEND_REVISION=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            TARGET_FRONTEND_VERSION=v3.0.1
+            TARGET_FRONTEND_SHA256=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            TARGET_RESOURCES_REVISION=cccccccccccccccccccccccccccccccccccccccc
+            TARGET_RESOURCE_INDEX_SHA256=
+            TARGET_RESOURCE_SITES_SHA256=
+        }}
         download_and_unzip() {{ return 0; }}
         configure_package_route() {{ touch "${{ROUTE_MARKER}}"; }}
         cp() {{ touch "${{COPY_MARKER}}"; }}
@@ -959,6 +1002,15 @@ def test_failed_dependency_sync_does_not_replace_program_files(tmp_path: Path) -
         INFO() {{ :; }}
         WARN() {{ :; }}
         ERROR() {{ :; }}
+        load_release_payload() {{
+            TARGET_UPDATE_CHANNEL=release
+            TARGET_BACKEND_REVISION=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            TARGET_FRONTEND_VERSION=v3.0.1
+            TARGET_FRONTEND_SHA256=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            TARGET_RESOURCES_REVISION=cccccccccccccccccccccccccccccccccccccccc
+            TARGET_RESOURCE_INDEX_SHA256=
+            TARGET_RESOURCE_SITES_SHA256=
+        }}
         download_and_unzip() {{ return 0; }}
         curl() {{
             local output=""
@@ -1027,8 +1079,13 @@ def test_pending_update_recovers_previous_payload_on_next_start(tmp_path: Path) 
     (previous_app / "app").mkdir(parents=True)
     previous_public.mkdir()
     (live_app / "app" / "new.py").write_text("new", encoding="utf-8")
+    _write_update_payload(live_app / ".moviepilot-payload.json", backend_revision="1" * 40)
     (live_public / "index.html").write_text("new-front", encoding="utf-8")
     (previous_app / "app" / "old.py").write_text("old", encoding="utf-8")
+    _write_update_payload(
+        previous_app / ".moviepilot-payload.json",
+        backend_revision="2" * 40,
+    )
     (previous_app / "pyproject.toml").write_text("old-project", encoding="utf-8")
     (previous_app / "uv.lock").write_text("old-lock", encoding="utf-8")
     (previous_public / "index.html").write_text("old-front", encoding="utf-8")
@@ -1058,11 +1115,12 @@ def test_pending_update_recovers_previous_payload_on_next_start(tmp_path: Path) 
         ERROR() {{ :; }}
         configure_package_route() {{ PACKAGE_ENV=(); UV_OPTIONS=(); }}
         recover_pending_update
-        printf '%s|%s|%s|%s\\n' \\
+        printf '%s|%s|%s|%s|%s\\n' \\
             "$([[ -f "${{APP_DIR}}/app/old.py" ]] && printf old || printf missing)" \\
             "$([[ -f "${{PUBLIC_DIR}}/index.html" ]] && head -n1 "${{PUBLIC_DIR}}/index.html" || printf missing)" \\
             "$([[ -f "${{CONFIG_DIR}}/temp/__update_pending__" ]] && printf present || printf cleared)" \\
-            "${{UPDATE_RECOVERY_COMPLETED}}"
+            "${{UPDATE_RECOVERY_COMPLETED}}" \\
+            "$(jq -r .backend_revision "${{APP_DIR}}/.moviepilot-payload.json")"
         """
     )
     result = subprocess.run(
@@ -1084,7 +1142,7 @@ def test_pending_update_recovers_previous_payload_on_next_start(tmp_path: Path) 
         check=True,
     )
 
-    assert result.stdout == "old|old-front|cleared|true\n"
+    assert result.stdout == f"old|old-front|cleared|true|{'2' * 40}\n"
     assert uv_log.read_text(encoding="utf-8").startswith(
         f"sync --project {live_app} --locked --inexact --no-dev"
     )
@@ -1187,7 +1245,7 @@ def test_restore_does_not_nest_previous_app_when_current_removal_fails(tmp_path:
     assert result.stdout == "current|absent|retained|clean\n"
 
 
-def test_staged_resource_download_rejects_empty_response_and_keeps_fallback(
+def test_staged_resource_download_rejects_empty_response_without_using_fallback(
     tmp_path: Path,
 ) -> None:
     destination = tmp_path / "stage" / "sites.bin"
@@ -1202,9 +1260,7 @@ def test_staged_resource_download_rejects_empty_response_and_keeps_fallback(
         WARN() {{ :; }}
         ERROR() {{ :; }}
         curl() {{ return 0; }}
-        download_staged_resource https://resources.example/sites.bin \\
-            "$1" "$2" sites.bin
-        cat "$1"
+        download_file https://resources.example/sites.bin "$1"
         """
     )
     result = subprocess.run(
@@ -1214,14 +1270,344 @@ def test_staged_resource_download_rejects_empty_response_and_keeps_fallback(
             script,
             "resource-download-test",
             str(destination),
-            str(fallback),
         ],
         text=True,
         capture_output=True,
-        check=True,
+        check=False,
     )
 
-    assert result.stdout == "old-resource\n"
+    assert result.returncode != 0
+    assert not destination.exists()
+    assert fallback.read_text(encoding="utf-8") == "old-resource\n"
+
+
+def test_resource_generation_is_not_mixed_when_one_download_fails(tmp_path: Path) -> None:
+    """同一资源 revision 的任一文件失败时，整组准备失败且旧代际保持不变。"""
+    live_app = tmp_path / "app"
+    stage_root = tmp_path / "stage"
+    stage_app = stage_root / "App"
+    (live_app / "app" / "plugins").mkdir(parents=True)
+    (live_app / "app" / "application" / "site").mkdir(parents=True)
+    (live_app / "app" / "plugins" / "__init__.py").write_text("# compat\n", encoding="utf-8")
+    (live_app / "app" / "application" / "site" / "user.sites.v3.bin").write_text(
+        "old-resource\n", encoding="utf-8"
+    )
+    (stage_app / "app" / "plugins").mkdir(parents=True)
+    (stage_app / "app" / "plugins" / "__init__.py").write_text("# compat\n", encoding="utf-8")
+    (stage_app / "app" / "application" / "site").mkdir(parents=True)
+    (stage_app / "app" / "application" / "site" / "query.py").write_text(
+        "# application source\n", encoding="utf-8"
+    )
+    (stage_app / "version.py").write_text("FRONTEND_VERSION = 'v3.0.0'\n", encoding="utf-8")
+    (stage_app / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+    (stage_app / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+    (stage_root / "dist").mkdir()
+    (stage_root / "dist" / "index.html").write_text("front\n", encoding="utf-8")
+    script = textwrap.dedent(
+        f"""\
+        CONFIG_DIR="$1/config"
+        TMP_PATH="$2"
+        source {UPDATER!s}
+        APP_DIR="$3"
+        TARGET_UPDATE_CHANNEL=release
+        TARGET_BACKEND_REVISION=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        TARGET_FRONTEND_VERSION=v3.0.0
+        TARGET_FRONTEND_SHA256=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+        TARGET_RESOURCES_REVISION=cccccccccccccccccccccccccccccccccccccccc
+        TARGET_RESOURCE_INDEX_SHA256=
+        TARGET_RESOURCE_SITES_SHA256=
+        GITHUB_PROXY= CURL_OPTIONS= CURL_HEADERS=
+        INFO() {{ :; }}
+        WARN() {{ :; }}
+        ERROR() {{ :; }}
+        curl() {{
+            local url=""
+            local output=""
+            while [ "$#" -gt 0 ]; do
+                case "$1" in
+                    http*) url="$1"; shift ;;
+                    -o) output="$2"; shift 2 ;;
+                    *) shift ;;
+                esac
+            done
+            if [[ "${{url}}" == *sites.cpython-* ]]; then return 1; fi
+            printf 'new-resource\n' > "${{output}}"
+        }}
+        stage_runtime_payload
+        """
+    )
+
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            script,
+            "resource-generation-test",
+            str(tmp_path),
+            str(stage_root),
+            str(live_app),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert not (stage_app / ".moviepilot-payload.json").exists()
+    assert (
+        stage_app / "app" / "application" / "site" / "query.py"
+    ).read_text(encoding="utf-8") == "# application source\n"
+    assert (
+        live_app / "app" / "application" / "site" / "user.sites.v3.bin"
+    ).read_text(encoding="utf-8") == "old-resource\n"
+
+
+def test_matching_release_payload_skips_large_downloads(tmp_path: Path) -> None:
+    """正式镜像与发布清单身份一致时不重复下载运行载荷。"""
+    app_dir = tmp_path / "app"
+    app_dir.mkdir()
+    installed_payload = app_dir / ".moviepilot-payload.json"
+    release_payload = tmp_path / "release-payload.json"
+    _write_update_payload(release_payload, payload_sha256=None)
+    release_payload_sha256 = hashlib.sha256(release_payload.read_bytes()).hexdigest()
+    _write_update_payload(installed_payload, payload_sha256=release_payload_sha256)
+    large_download_log = tmp_path / "large-download.log"
+    script = textwrap.dedent(
+        f"""\
+        CONFIG_DIR="$1/config"
+        TMP_PATH="$1/stage"
+        mkdir -p "${{TMP_PATH}}"
+        GITHUB_PROXY= CURL_OPTIONS= CURL_HEADERS=
+        source {UPDATER!s}
+        APP_DIR="$2"
+        RELEASE_PAYLOAD="$3"
+        LARGE_DOWNLOAD_LOG="$4"
+        INFO() {{ :; }}
+        WARN() {{ :; }}
+        ERROR() {{ :; }}
+        release_payload_sha256=$(sha256sum "${{RELEASE_PAYLOAD}}" | awk '{{print $1}}')
+        printf '{{"assets":[{{"name":"source-update-payload.json","digest":"sha256:%s"}}]}}\n' \
+            "${{release_payload_sha256}}" > "${{TMP_PATH}}/latest-v3-release.json"
+        download_file() {{ printf 'unexpected\n' > "${{LARGE_DOWNLOAD_LOG}}"; return 1; }}
+        download_and_unzip() {{ printf '%s\n' "$1" >> "${{LARGE_DOWNLOAD_LOG}}"; return 1; }}
+        install_backend_and_download_resources tags/v3.0.0.zip
+        """
+    )
+
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            script,
+            "matching-release-payload-test",
+            str(tmp_path),
+            str(app_dir),
+            str(release_payload),
+            str(large_download_log),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not large_download_log.exists()
+
+
+def test_changed_release_revision_uses_immutable_backend_archive(tmp_path: Path) -> None:
+    """同版本发布 revision 变化时按目标 commit 下载，不再被版本号短路。"""
+    app_dir = tmp_path / "app"
+    app_dir.mkdir()
+    installed_payload = app_dir / ".moviepilot-payload.json"
+    release_payload = tmp_path / "release-payload.json"
+    _write_update_payload(installed_payload, backend_revision="a" * 40)
+    _write_update_payload(
+        release_payload,
+        backend_revision="1" * 40,
+        payload_sha256=None,
+    )
+    download_log = tmp_path / "download.log"
+    script = textwrap.dedent(
+        f"""\
+        CONFIG_DIR="$1/config"
+        TMP_PATH="$1/stage"
+        mkdir -p "${{TMP_PATH}}"
+        GITHUB_PROXY= CURL_OPTIONS= CURL_HEADERS=
+        source {UPDATER!s}
+        APP_DIR="$2"
+        RELEASE_PAYLOAD="$3"
+        DOWNLOAD_LOG="$4"
+        INFO() {{ :; }}
+        WARN() {{ :; }}
+        ERROR() {{ :; }}
+        release_payload_sha256=$(sha256sum "${{RELEASE_PAYLOAD}}" | awk '{{print $1}}')
+        printf '{{"assets":[{{"name":"source-update-payload.json","digest":"sha256:%s"}}]}}\n' \
+            "${{release_payload_sha256}}" > "${{TMP_PATH}}/latest-v3-release.json"
+        download_file() {{ cp "${{RELEASE_PAYLOAD}}" "$2"; }}
+        download_and_unzip() {{ printf '%s\n' "$1" > "${{DOWNLOAD_LOG}}"; return 1; }}
+        install_backend_and_download_resources tags/v3.0.0.zip
+        """
+    )
+
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            script,
+            "changed-release-payload-test",
+            str(tmp_path),
+            str(app_dir),
+            str(release_payload),
+            str(download_log),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert download_log.read_text(encoding="utf-8").strip().endswith(
+        f"/MoviePilot/archive/{'1' * 40}.zip"
+    )
+
+
+def test_newer_image_generation_rejects_stale_release_payload(tmp_path: Path) -> None:
+    """发布资产替换窗口内，旧清单不得把同版本新镜像降回旧代际。"""
+    app_dir = tmp_path / "app"
+    app_dir.mkdir()
+    installed_payload = app_dir / ".moviepilot-payload.json"
+    release_payload = tmp_path / "release-payload.json"
+    _write_update_payload(
+        installed_payload,
+        backend_revision="2" * 40,
+        release_generation="200.1",
+    )
+    _write_update_payload(
+        release_payload,
+        backend_revision="1" * 40,
+        release_generation="100.1",
+        payload_sha256=None,
+    )
+    large_download_log = tmp_path / "large-download.log"
+    script = textwrap.dedent(
+        f"""\
+        CONFIG_DIR="$1/config"
+        TMP_PATH="$1/stage"
+        mkdir -p "${{TMP_PATH}}"
+        GITHUB_PROXY= CURL_OPTIONS= CURL_HEADERS=
+        source {UPDATER!s}
+        APP_DIR="$2"
+        RELEASE_PAYLOAD="$3"
+        LARGE_DOWNLOAD_LOG="$4"
+        INFO() {{ :; }}
+        WARN() {{ :; }}
+        ERROR() {{ :; }}
+        release_payload_sha256=$(sha256sum "${{RELEASE_PAYLOAD}}" | awk '{{print $1}}')
+        printf '{{"assets":[{{"name":"source-update-payload.json","digest":"sha256:%s"}}]}}\n' \
+            "${{release_payload_sha256}}" > "${{TMP_PATH}}/latest-v3-release.json"
+        download_file() {{ cp "${{RELEASE_PAYLOAD}}" "$2"; }}
+        download_and_unzip() {{ printf '%s\n' "$1" >> "${{LARGE_DOWNLOAD_LOG}}"; return 1; }}
+        install_backend_and_download_resources tags/v3.0.0.zip
+        """
+    )
+
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            script,
+            "stale-release-payload-test",
+            str(tmp_path),
+            str(app_dir),
+            str(release_payload),
+            str(large_download_log),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not large_download_log.exists()
+
+
+def test_same_version_only_rechecks_identity_for_release_channel(tmp_path: Path) -> None:
+    """Beta 或本地镜像不会被同版本正式发布清单覆盖。"""
+    script = textwrap.dedent(
+        f"""\
+        CONFIG_DIR="$1/config"
+        source {UPDATER!s}
+        CHANNEL="$2"
+        CALL_LOG="$3"
+        INFO() {{ :; }}
+        WARN() {{ :; }}
+        ERROR() {{ :; }}
+        installed_payload_value() {{ [ "$1" = channel ] && printf '%s\n' "${{CHANNEL}}"; }}
+        install_backend_and_download_resources() {{ printf '%s\n' "$1" > "${{CALL_LOG}}"; }}
+        compare_versions v3.0.0 v3.0.0
+        """
+    )
+
+    for channel, should_call in (("release", True), ("beta", False), ("", False)):
+        call_log = tmp_path / f"{channel or 'legacy'}.log"
+        result = subprocess.run(
+            [
+                "/bin/bash",
+                "-c",
+                script,
+                "same-version-channel-test",
+                str(tmp_path),
+                channel,
+                str(call_log),
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        assert call_log.exists() is should_call
+        if should_call:
+            assert call_log.read_text(encoding="utf-8") == "tags/v3.0.0.zip\n"
+
+
+def test_download_file_rejects_digest_mismatch(tmp_path: Path) -> None:
+    """摘要不匹配的制品不得进入正式目标路径。"""
+    destination = tmp_path / "dist.zip"
+    script = textwrap.dedent(
+        f"""\
+        CONFIG_DIR="$1/config"
+        source {UPDATER!s}
+        INFO() {{ :; }}
+        WARN() {{ :; }}
+        ERROR() {{ :; }}
+        curl() {{
+            while [ "$#" -gt 0 ]; do
+                if [ "$1" = -o ]; then printf 'corrupt' > "$2"; return 0; fi
+                shift
+            done
+            return 1
+        }}
+        download_file https://example.invalid/dist.zip "$2" \
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        """
+    )
+
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            script,
+            "digest-mismatch-test",
+            str(tmp_path),
+            str(destination),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert not destination.exists()
 
 
 def test_staged_payload_swap_failure_restores_previous_generation(tmp_path: Path) -> None:

--- a/tests/test_docker_payload_contract.py
+++ b/tests/test_docker_payload_contract.py
@@ -93,10 +93,15 @@ def test_release_workflows_pin_and_record_external_payload_identities() -> None:
         workflow = _read(workflow_path)
 
         for build_arg in (
+            "MOVIEPILOT_BUILD_CHANNEL=",
+            "MOVIEPILOT_BACKEND_REVISION=",
             "MOVIEPILOT_FRONTEND_VERSION=",
             "MOVIEPILOT_FRONTEND_SHA256=",
             "MOVIEPILOT_PLUGINS_REF=",
             "MOVIEPILOT_RESOURCES_REF=",
+            "MOVIEPILOT_RESOURCE_INDEX_SHA256=",
+            "MOVIEPILOT_RESOURCE_AMD64_SHA256=",
+            "MOVIEPILOT_RESOURCE_ARM64_SHA256=",
         ):
             assert build_arg in workflow
 
@@ -117,6 +122,24 @@ def test_release_workflows_pin_and_record_external_payload_identities() -> None:
         assert "^[0-9a-f]{40}$" in workflow
         assert "^[0-9a-f]{64}$" in workflow
 
+    release_workflow = _read(RELEASE_WORKFLOW)
+    assert "MOVIEPILOT_RELEASE_GENERATION=" in release_workflow
+    assert "MOVIEPILOT_SOURCE_UPDATE_PAYLOAD_SHA256=" in release_workflow
+
+    dockerfile = _read(DOCKERFILE)
+    for variable in (
+        "MOVIEPILOT_IMAGE_UPDATE_CHANNEL",
+        "MOVIEPILOT_IMAGE_RELEASE_GENERATION",
+        "MOVIEPILOT_IMAGE_SOURCE_UPDATE_PAYLOAD_SHA256",
+        "MOVIEPILOT_IMAGE_BACKEND_REVISION",
+        "MOVIEPILOT_IMAGE_FRONTEND_VERSION",
+        "MOVIEPILOT_IMAGE_FRONTEND_SHA256",
+        "MOVIEPILOT_IMAGE_RESOURCES_REVISION",
+    ):
+        assert variable in dockerfile
+    assert 'printf \'%s  %s\\n\' "${MOVIEPILOT_RESOURCE_INDEX_SHA256}"' in dockerfile
+    assert 'printf \'%s  %s\\n\' "${sites_sha256}"' in dockerfile
+
 
 def test_same_version_rebuild_identity_is_not_derived_from_image_tag() -> None:
     """重复发布同一版本时，缓存身份必须来自源码和制品而不是镜像 Tag。"""
@@ -131,6 +154,11 @@ def test_same_version_rebuild_identity_is_not_derived_from_image_tag() -> None:
     assert "type=raw,value=${{ env.app_version }}" in release_workflow
     assert "MOVIEPILOT_PLUGINS_REF=${{ steps.payloads.outputs.plugins_revision }}" in release_workflow
     assert "MOVIEPILOT_RESOURCES_REF=${{ steps.payloads.outputs.resources_revision }}" in release_workflow
+    assert "Generate Source Update Payload" in release_workflow
+    assert "backend_revision: $backend_revision" in release_workflow
+    assert "frontend_sha256: $frontend_sha256" in release_workflow
+    assert "resources_revision: $resources_revision" in release_workflow
+    assert "files: .build/source-update-payload.json" in release_workflow
 
 
 def test_custom_frontend_directory_is_stable_but_artifacts_remain_untracked() -> None:

--- a/tests/test_release_supply_chain.py
+++ b/tests/test_release_supply_chain.py
@@ -1,5 +1,7 @@
 """正式镜像发布的供应链门禁合同。"""
 
+import subprocess
+import sys
 from datetime import date
 from pathlib import Path
 
@@ -9,6 +11,7 @@ from ruamel.yaml import YAML
 ROOT = Path(__file__).resolve().parents[1]
 DOCKERFILE = ROOT / "docker" / "Dockerfile"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "build-v3.yml"
+RELEASE_GENERATION_CHECK = ROOT / "scripts" / "check_release_generation.py"
 TRIVY_IGNORE = ROOT / ".trivyignore.yaml"
 
 
@@ -147,3 +150,48 @@ def test_release_binds_source_update_identity_to_image_payload() -> None:
     )
     assert "sha256=" in generate["run"]
     assert release["with"]["files"] == ".build/source-update-payload.json"
+
+
+def test_release_serializes_writers_and_checks_generation_before_mutation() -> None:
+    """正式发布必须串行，并在写入镜像、Tag 或 Release 前拒绝旧代际。"""
+    workflow = _load_workflow()
+    steps = workflow["jobs"]["Docker-build"]["steps"]
+    names = [step.get("name") for step in steps]
+    verify = _steps_by_name(workflow)["Verify release generation"]["run"]
+
+    assert workflow["concurrency"] == {
+        "group": "moviepilot-v3-release",
+        "cancel-in-progress": False,
+    }
+    verify_index = names.index("Verify release generation")
+    for mutation in (
+        "Publish multi-architecture image",
+        "Delete Release",
+        "Publish Release Tag",
+        "Generate Release",
+    ):
+        assert verify_index < names.index(mutation)
+    assert "releases/latest" in verify
+    assert "source-update-payload.json" in verify
+    assert "scripts/check_release_generation.py" in verify
+
+
+def test_release_generation_gate_rejects_late_old_run() -> None:
+    """A/B 发布乱序时仅允许不早于已发布代际的任务继续。"""
+    cases = (
+        ("200.1", "100.1", 0),
+        ("200.2", "200.1", 0),
+        ("200.2", "200.2", 0),
+        ("100.1", "200.1", 1),
+        ("200.1", "200.2", 1),
+        ("invalid", "200.1", 2),
+    )
+
+    for candidate, published, expected_code in cases:
+        result = subprocess.run(
+            [sys.executable, str(RELEASE_GENERATION_CHECK), candidate, published],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == expected_code

--- a/tests/test_release_supply_chain.py
+++ b/tests/test_release_supply_chain.py
@@ -120,3 +120,30 @@ def test_publish_reuses_scanned_architecture_caches_without_refreshing_base() ->
     assert publish["pull"] is False
     assert "scope=moviepilot-v3-docker-amd64" in publish["cache-from"]
     assert "scope=moviepilot-v3-docker-arm64" in publish["cache-from"]
+
+
+def test_release_binds_source_update_identity_to_image_payload() -> None:
+    """源码更新清单与镜像必须使用同一发布快照和外部载荷身份。"""
+    workflow = _load_workflow()
+    steps = workflow["jobs"]["Docker-build"]["steps"]
+    names = [step.get("name") for step in steps]
+    indexed = _steps_by_name(workflow)
+    generate = indexed["Generate Source Update Payload"]
+    release = indexed["Generate Release"]
+
+    assert names.index("Create Release Snapshot") < names.index("Generate Source Update Payload")
+    assert names.index("Generate Source Update Payload") < names.index("Build amd64 candidate")
+    assert generate["env"]["BACKEND_REVISION"] == (
+        "${{ steps.release_snapshot.outputs.release_commit }}"
+    )
+    assert generate["env"]["RELEASE_GENERATION"] == (
+        "${{ github.run_id }}.${{ github.run_attempt }}"
+    )
+    assert generate["env"]["FRONTEND_SHA256"] == (
+        "${{ steps.payloads.outputs.frontend_sha256 }}"
+    )
+    assert generate["env"]["RESOURCES_REVISION"] == (
+        "${{ steps.payloads.outputs.resources_revision }}"
+    )
+    assert "sha256=" in generate["run"]
+    assert release["with"]["files"] == ".build/source-update-payload.json"


### PR DESCRIPTION
同一版本标签可能被重新发布，并发发布 workflow 也可能乱序完成。源码更新此前主要依赖版本号判断目标，无法确认后端、前端和资源是否确实属于同一发布载荷，旧 workflow 也可能覆盖较新的发布结果。

本 PR 为源码更新建立可持久化、可校验的载荷身份：

- 发布工作流生成 schema 2 载荷清单，固定后端 revision、前端版本及摘要、资源 revision 及双架构资源摘要；
- 更新器校验清单和下载制品摘要，并将已安装载荷身份纳入更新事务；
- 相同载荷可直接跳过，版本相同但载荷变化时仍会正确更新；
- 发布 generation 使用固定并发组，并在发布前拒绝早于现有正式载荷的 workflow，避免乱序覆盖；
- 下载失败、摘要不一致或事务中断继续沿用既有回滚边界。

无更新检查的受控 A/B 约由 4.73 ms 增至 12.10 ms，增加约 7.37 ms；这里优先保证同版本重发、乱序发布和回滚身份的正确性。

验证：

- 相关更新、Docker 载荷合同及发布供应链测试：74 passed
- `bash -n docker/update.sh`
- `git diff --check`

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 11fbba817ecbeccb93f30e9f32845b0ca5b9b2bb

- 为源码更新绑定可验证发布载荷身份
- 校验后端、前端及双架构资源摘要
- 同版本重发按载荷身份更新或跳过
- 串行发布并阻止旧任务覆盖新发布
- 保留事务回滚，拒绝不完整制品
- 扩展 Docker、发布供应链更新测试
<!-- pr-agent-summary:end -->
