### PR TITLE
fix: 修复 Python 3.14t 合并后的 CI 基线

### DIFF
--- a/tests/fixtures/architecture/startup-performance-baseline.json
+++ b/tests/fixtures/architecture/startup-performance-baseline.json
@@ -6,7 +6,7 @@
   "repeat": 3,
   "targets": {
     "app.startup.lifecycle": {
-      "loaded_app_module_count": 357,
+      "loaded_app_module_count": 358,
       "max_ms": 968.725,
       "median_ms": 937.268,
       "min_ms": 933.205,
@@ -17,7 +17,7 @@
       ]
     },
     "app.factory": {
-      "loaded_app_module_count": 369,
+      "loaded_app_module_count": 370,
       "max_ms": 943.204,
       "median_ms": 941.996,
       "min_ms": 937.878,
@@ -28,7 +28,7 @@
       ]
     },
     "app.main": {
-      "loaded_app_module_count": 371,
+      "loaded_app_module_count": 372,
       "max_ms": 1068.791,
       "median_ms": 1064.912,
       "min_ms": 1053.947,

--- a/tests/test_plugin_sdk.py
+++ b/tests/test_plugin_sdk.py
@@ -35,7 +35,7 @@ def test_sdk_exports_canonical_plugin_interfaces():
     from app.runtime.extensions.plugin_manager import PluginManager as CanonicalPluginManager
     from app.adapters.network.http import RequestUtils as CanonicalRequestUtils
     from app.application.rss import RssHelper as CanonicalRssHelper
-    from app.application.site.sites import SitesHelper as CanonicalSitesHelper  # pylint: disable=no-name-in-module
+    from app.application.site.sites import SitesHelper as CanonicalSitesHelper  # pylint: disable=import-error,no-name-in-module
     from app.runtime.cache import Cache as CanonicalCache
     from app.runtime.cache import cached as canonical_cached
     from app.runtime.config import settings as canonical_settings


### PR DESCRIPTION
## 问题

#6434 合并时有两个 PR 门禁失败：

- Pylint 会检查本次触及的 `tests/test_plugin_sdk.py`，但 CI 不包含动态下发的站点资源模块，因此 `app.application.site.sites` 被判定为 `import-error`。pytest 会通过统一测试 bootstrap 安装该模块的最小垫片，所以测试本身不受影响。
- 启动生命周期新增 `app.foundation.environment` 后，三个冷导入入口的宿主模块数量各增加 1；实际冷导入耗时仍低于既有预算，但确定性的模块数量基线尚未同步。

## 调整

- 对动态站点资源导入补齐与仓内其他生产入口一致的 Pylint 例外，不改变 SDK canonical 身份测试。
- 将 `app.startup.lifecycle`、`app.factory`、`app.main` 的宿主模块计数分别更新为 358、370、372；保留原性能样本和预算，不重写平台相关耗时数据。

## 验证

- `pylint tests/test_plugin_sdk.py`：`10.00/10`
- 插件 SDK：`4 passed`
- 架构合同：`94 passed`
- `scripts/startup/performance.py --check --repeat 3`：通过，三个入口实测中位数均低于预算
- `git diff --check`

关联：#6434

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at c2af4c32133a300de5fee435f0531955b5b60725

- 修复动态站点模块的 Pylint 导入误报
- 同步启动冷导入模块数量基线
- 不改变运行时代码或性能预算
- 未新增自动化测试；更新既有测试门禁数据
<!-- pr-agent-summary:end -->
