### PR TITLE
fix(ci): 修复 V3 双镜像标签发布

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -119,7 +119,7 @@ jobs:
             ${{ secrets.DOCKER_USERNAME }}/moviepilot-v3
             ghcr.io/${{ github.repository }}-v3
           tags: |
-            type=raw,value=beta-${{ github.run_id }}-${{ github.run_attempt }}
+            type=raw,value=beta
 
       - name: Docker Meta free-threaded
         id: meta_ft
@@ -129,7 +129,7 @@ jobs:
             ${{ secrets.DOCKER_USERNAME }}/moviepilot-v3t
             ghcr.io/${{ github.repository }}-v3t
           tags: |
-            type=raw,value=beta-${{ github.run_id }}-${{ github.run_attempt }}
+            type=raw,value=beta
 
       - name: Set Up QEMU
         uses: docker/setup-qemu-action@v3
@@ -338,18 +338,3 @@ jobs:
           cache-from: |
             type=gha,scope=moviepilot-v3t-docker-amd64,version=2
             type=gha,scope=moviepilot-v3t-docker-arm64,version=2
-
-      - name: Promote beta image pair
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        run: |
-          candidate="beta-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          for image in \
-            "${DOCKER_USERNAME}/moviepilot-v3" \
-            "ghcr.io/${GITHUB_REPOSITORY}-v3" \
-            "${DOCKER_USERNAME}/moviepilot-v3t" \
-            "ghcr.io/${GITHUB_REPOSITORY}-v3t"; do
-            docker buildx imagetools create \
-              --tag "${image}:beta" \
-              "${image}:${candidate}"
-          done

--- a/.github/workflows/build-v3.yml
+++ b/.github/workflows/build-v3.yml
@@ -367,16 +367,17 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         run: |
+          ghcr_repository="${GITHUB_REPOSITORY,,}"
           for image in \
             "${DOCKER_USERNAME}/moviepilot-v3" \
-            "ghcr.io/${GITHUB_REPOSITORY}-v3"; do
+            "ghcr.io/${ghcr_repository}-v3"; do
             docker buildx imagetools create \
               --tag "${image}:latest" \
               "${image}:${app_version}"
           done
           for image in \
             "${DOCKER_USERNAME}/moviepilot-v3t" \
-            "ghcr.io/${GITHUB_REPOSITORY}-v3t"; do
+            "ghcr.io/${ghcr_repository}-v3t"; do
             docker buildx imagetools create \
               --tag "${image}:latest" \
               "${image}:${app_version}"

--- a/tests/test_release_supply_chain.py
+++ b/tests/test_release_supply_chain.py
@@ -223,6 +223,10 @@ def test_release_promotes_latest_only_after_both_versioned_images() -> None:
     )
     promote = indexed["Promote latest image pair"]["run"]
     assert "moviepilot-v3:latest" not in promote
+    assert 'ghcr_repository="${GITHUB_REPOSITORY,,}"' in promote
+    assert "ghcr.io/${GITHUB_REPOSITORY}" not in promote
+    assert "ghcr.io/${ghcr_repository}-v3" in promote
+    assert "ghcr.io/${ghcr_repository}-v3t" in promote
     assert '"${image}:latest"' in promote
     assert '"${image}:${app_version}"' in promote
 
@@ -263,11 +267,8 @@ def test_beta_applies_the_same_variant_scan_and_publish_contract() -> None:
     assert "MOVIEPILOT_PYTHON_VARIANT=free-threaded" in indexed[publish_names[1]]["with"]["build-args"]
     assert "scope=moviepilot-v3-standard-docker-amd64" in indexed[publish_names[0]]["with"]["cache-from"]
     assert "scope=moviepilot-v3t-docker-amd64" in indexed[publish_names[1]]["with"]["cache-from"]
-    assert "value=beta-${{ github.run_id }}-${{ github.run_attempt }}" in indexed["Docker Meta"]["with"]["tags"]
-    assert "value=beta-${{ github.run_id }}-${{ github.run_attempt }}" in indexed[
-        "Docker Meta free-threaded"
-    ]["with"]["tags"]
-    assert all(names.index(name) < names.index("Promote beta image pair") for name in publish_names)
-    promote = indexed["Promote beta image pair"]["run"]
-    assert '"${image}:beta"' in promote
-    assert '"${image}:${candidate}"' in promote
+    assert "value=beta" in indexed["Docker Meta"]["with"]["tags"]
+    assert "value=beta" in indexed["Docker Meta free-threaded"]["with"]["tags"]
+    assert "github.run_id" not in indexed["Docker Meta"]["with"]["tags"]
+    assert "github.run_id" not in indexed["Docker Meta free-threaded"]["with"]["tags"]
+    assert "Promote beta image pair" not in names


### PR DESCRIPTION
## 问题

V3 Beta workflow 先发布 `beta-<run_id>-<attempt>` 候选标签，再提升为 `beta`，会持续留下无用的运行号标签。提升阶段还直接使用含大写仓库名的 GHCR 地址，导致 Docker 报 `repository name must be lowercase`。

正式发布使用同样的 GHCR 地址拼接方式，因此版本镜像发布后，`latest` 提升也会失败，可能造成 Docker Hub 与 GHCR、V3 与 V3t 的 `latest` 状态不一致。

## 调整

- Beta 恢复直接发布固定的 `moviepilot-v3:beta` 与 `moviepilot-v3t:beta`，删除运行号候选标签及二次提升步骤。
- 正式发布保留“先发布两个版本标签，再统一提升 `latest`”的现有流程，仅在提升前将 GHCR 仓库名转换为小写。
- 不拆分 workflow，不调整并行策略，不增加互斥或中间制品。

## 验证

- `python -m pytest tests/test_release_supply_chain.py -q`：10 passed
- 两份 workflow 均通过 YAML 解析
- `git diff --check`

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at f01ab17b81d57d298701dd51e972bd3e99ecaab7

- Beta 镜像直接发布固定 `beta` 标签
- 删除候选标签二次提升流程
- 正式版 GHCR 仓库名统一转小写
- 更新发布供应链契约测试
<!-- pr-agent-summary:end -->
