### PR TITLE
test: 隔离本地站点原生资源

### DIFF
--- a/app/testing/bootstrap.py
+++ b/app/testing/bootstrap.py
@@ -122,28 +122,11 @@ def _expose_plugin_source(path: Path) -> None:
         plugins_package.__path__.insert(0, value)
 
 
-def ensure_sites_stub() -> None:
-    """为 ``app.application.site.sites`` 补最小垫片（仅在缺失时）。
-
-    ``app.application.site.sites`` 由独立仓库动态拉取，CI / 全新环境无该模块，而众多 ``app.chain.*`` /
-    ``app.modules.*`` 在 import 期依赖它。统一补一个最小垫片，省去各测试文件各自打桩；若真实模块
-    已存在（本地已拉取）则用真实模块、不覆盖，不影响真实行为。须在隔离 CONFIG_DIR 之后调用，
-    以免试探性 ``import app.application.site.sites`` 牵入 ``app.runtime.config``、
-    把配置路径定型到真实目录。
-    """
-    if "app.application.site.sites" in sys.modules:
-        return
-    try:
-        import app.application.site.sites  # noqa: F401  本地已拉取时用真实模块
-    except (ModuleNotFoundError, ImportError):
-        install_sites_stub()
-
-
 def install_sites_stub() -> None:
-    """强制安装确定性的站点资源垫片，供隔离探针排除本机动态资源差异。
+    """安装确定性的站点资源垫片，隔离本机动态资源及其平台 ABI 差异。
 
-    与 :func:`ensure_sites_stub` 的“真实资源优先”语义不同，性能与架构探针需要在开发机和
-    source-only CI 中使用完全相同的 import 前提，因此必须在导入被测宿主模块前覆盖资源模块。
+    站点扩展由独立资源仓按平台下发，不属于普通单测的输入。主程序与各代插件测试必须在导入
+    业务模块前覆盖该模块；真实扩展的加载、ABI 与能力由资源专项验收负责。
     """
     from importlib.util import spec_from_loader
     from types import ModuleType
@@ -189,7 +172,7 @@ def prepare_backend() -> None:
     ``init_db`` 仅 import models + create_all，无 alembic/网络、幂等、毫秒级。
     """
     isolate_config_dir()
-    ensure_sites_stub()
+    install_sites_stub()
     from app.startup.initializers.database import init_db
     init_db()
     from app.db.adapters.transaction import TransactionalWriteRunner

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -29,7 +29,7 @@ uv run --locked --no-sync python tests/run.py --shard 1/4           # 只跑指�
 收集任何测试模块、`import app.*` **之前**，conftest 完成两件事：
 
 1. **临时库**：把 `CONFIG_DIR` 指向临时目录并 `init_db()` 建表。引擎本身已惰性创建（`import app.db` 不再连库），但 `settings` 在 `import app.runtime.config` 那一刻就把 `CONFIG_DIR` 读进字段并建好配置子目录，之后再改环境变量对 `settings.CONFIG_PATH` 毫无影响——引擎晚点才建，连的仍是真实 `user.db`。所以隔离必须早于首个牵入 `app.runtime.config` 的 import（`app.db` / `app.chain.*` 都会牵入）；空库会让运行期查表报 `no such table`，故必须建表。
-2. **`app.application.site.sites` 垫片**：该模块由独立仓库动态拉取、CI 无此文件，conftest 统一补最小垫片（本地存在真实模块时优先用真实模块）。兼容层会把旧插件的 `app.helper.sites` 导入路由到同一模块。
+2. **`app.application.site.sites` 垫片**：该模块由独立资源仓按平台下发，conftest 统一安装最小垫片，普通单测不会加载源码目录中的 `.so` / `.pyd`。兼容层会把旧插件的 `app.helper.sites` 导入路由到同一模块；真实制品由资源与 ABI 专项验收覆盖。
 
 由此推出两条**硬规范**：
 

--- a/tests/fixtures/architecture/dependency-baseline.json
+++ b/tests/fixtures/architecture/dependency-baseline.json
@@ -13,8 +13,8 @@
     "runtime_to_db": [],
     "workflow_to_db": []
   },
-  "edge_count": 6599,
-  "edge_sha256": "33b44ea7d1f05a4c76fd22c4c1b798689ac8e580099c50141fbd91345a625714",
+  "edge_count": 6598,
+  "edge_sha256": "0e3b249728099e7d0a634a965c54f33d1293d9c0a91331b8bc440de31eb668a1",
   "edges": [
     "app -> app.runtime",
     "app -> app.runtime.compat",
@@ -6426,7 +6426,6 @@
     "app.testing -> app.testing.stub",
     "app.testing.bootstrap -> app.application",
     "app.testing.bootstrap -> app.application.service",
-    "app.testing.bootstrap -> app.application.site",
     "app.testing.bootstrap -> app.db",
     "app.testing.bootstrap -> app.db.adapters",
     "app.testing.bootstrap -> app.db.adapters.transaction",

--- a/tests/test_agent_lazy_runtime_boundary.py
+++ b/tests/test_agent_lazy_runtime_boundary.py
@@ -142,9 +142,9 @@ import json
 import sys
 from typing import get_args, get_type_hints
 
-from app.testing.bootstrap import ensure_sites_stub
+from app.testing.bootstrap import install_sites_stub
 
-ensure_sites_stub()
+install_sites_stub()
 from app.agent.runtime_loader import get_tool_factory
 
 factory = get_tool_factory()

--- a/tests/test_architecture_contract_baseline.py
+++ b/tests/test_architecture_contract_baseline.py
@@ -302,10 +302,9 @@ import app.monitor
 assert not any(name.startswith('app.doctor.') for name in sys.modules)
 assert not any(name.startswith('app.monitor.') for name in sys.modules)
 
-# CI 无 app.application.site.sites 资源模块，触发实现加载前先补 conftest 同源垫片；
-# 独立子进程不经过 pytest 引导，必须在此显式安装，否则链式 import 会因缺模块失败。
-from app.testing.bootstrap import ensure_sites_stub
-ensure_sites_stub()
+# 独立子进程不经过 pytest 引导，触发实现加载前必须隔离站点原生制品。
+from app.testing.bootstrap import install_sites_stub
+install_sites_stub()
 
 from app.doctor import DoctorRunner, run_doctor
 from app.doctor.runner import DoctorRunner as DirectDoctorRunner

--- a/tests/test_database_index_migration.py
+++ b/tests/test_database_index_migration.py
@@ -69,10 +69,10 @@ IDENTITY_INDEX_SIGNATURES = {
 
 
 CURRENT_SCHEMA_CHAIN_SCRIPT = """
-from app.testing.bootstrap import ensure_sites_stub
+from app.testing.bootstrap import install_sites_stub
 
-# Alembic 会导入引用业务链的旧 revision；全新 CI 环境没有动态下发的 sites 模块。
-ensure_sites_stub()
+# Alembic 会导入引用业务链的旧 revision，迁移验证不应加载本机站点原生制品。
+install_sites_stub()
 
 from alembic.config import Config
 from alembic.script import ScriptDirectory

--- a/tests/test_legacy_import_compat.py
+++ b/tests/test_legacy_import_compat.py
@@ -167,9 +167,9 @@ def test_manifest_aliases_reuse_real_canonical_modules():
     code = """
 import importlib
 from app.runtime.compat.manifest import MODULE_ALIASES
-# CI 无 app.application.site.sites 二进制模块，先补垫片再校验全部映射（与 conftest 同源）。
-from app.testing.bootstrap import ensure_sites_stub
-ensure_sites_stub()
+# 独立探针不经过 pytest 引导，先隔离站点原生制品再校验兼容映射。
+from app.testing.bootstrap import install_sites_stub
+install_sites_stub()
 
 for legacy_name, alias in MODULE_ALIASES.items():
     try:

--- a/tests/test_main_direct_execution.py
+++ b/tests/test_main_direct_execution.py
@@ -14,10 +14,9 @@ def test_main_script_does_not_shadow_stdlib_platform(tmp_path):
         (
             "import runpy",
             "import sys",
-            # CI 无 app.application.site.sites 二进制模块，先补垫片再执行 main.py（与 conftest 同源）；
-            # 必须在篡改 sys.path / 摘除 platform 之前调用，避免真实依赖链受探针环境影响。
-            "from app.testing.bootstrap import ensure_sites_stub",
-            "ensure_sites_stub()",
+            # 独立探针不经过 pytest 引导，先隔离站点原生制品，再改变模块搜索路径。
+            "from app.testing.bootstrap import install_sites_stub",
+            "install_sites_stub()",
             f"sys.path.insert(0, {str(MAIN_PATH.parent)!r})",
             "sys.modules.pop('platform', None)",
             f"runpy.run_path({str(MAIN_PATH)!r}, run_name='pycharm_main_probe')",

--- a/tests/test_testing_bootstrap.py
+++ b/tests/test_testing_bootstrap.py
@@ -22,15 +22,17 @@ def test_install_sites_stub_replaces_loaded_dynamic_resource(monkeypatch):
     assert installed.SitesHelper is bootstrap._SitesHelperStub
 
 
-def test_ensure_sites_stub_preserves_loaded_dynamic_resource(monkeypatch):
-    """常规测试引导仍应优先复用已经加载的真实站点资源。"""
+def test_prepare_backend_replaces_loaded_dynamic_resource(monkeypatch):
+    """普通测试引导必须隔离源码目录中已存在的站点原生制品。"""
     real_module = types.ModuleType("app.application.site.sites")
     real_module.SitesHelper = object
     monkeypatch.setitem(sys.modules, "app.application.site.sites", real_module)
 
-    bootstrap.ensure_sites_stub()
+    bootstrap.prepare_backend()
 
-    assert sys.modules["app.application.site.sites"] is real_module
+    installed = sys.modules["app.application.site.sites"]
+    assert installed is not real_module
+    assert installed.SitesHelper is bootstrap._SitesHelperStub
 
 
 def test_isolate_config_cleanup_uses_loaded_db_module_without_late_import(monkeypatch):


### PR DESCRIPTION
普通主程序和插件测试此前会优先导入源码目录中的真实站点原生扩展。本地一旦残留某个平台或 ABI 的 `.so/.pyd`，测试结果便可能与全新 CI 环境不同；失配或异常制品还会在 pytest 引导阶段直接终止进程。

本 PR 让共享测试 bootstrap 默认强制安装确定性的站点资源 stub：

- 主程序与 V1/V2/V3 插件普通测试不再加载本地原生资源；
- 已加载的动态模块也会被测试 stub 覆盖，确保同一测试会话行为稳定；
- 真实资源仍保留给资源、ABI 和镜像专项验证，不改变生产启动合同；
- 测试文档与架构 baseline 同步更新。

该改动与 #6441 没有运行时语义依赖；两者都更新生成型架构 baseline，若其中一个先合并，后合并分支只需在 rebase 后重新生成 baseline。

### 验证

- 重放后受影响回归：51 passed, 1 skipped
- 同实现完整后端回归：6029 passed, 3 skipped
- 主程序及个人/官方插件仓 V2/V3 focused：26 passed
- `app/testing/bootstrap.py` Pylint：10.00/10
- 架构 baseline、旧入口清理与 `git diff --check`：通过

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 8b83edd55072b02a0bf3c32ca32c3a1f8fdeccbe

- 强制普通测试使用站点资源垫片
- 覆盖已加载的本地原生模块
- 更新独立进程测试的安装入口
- 明确真实制品由专项验收覆盖
<!-- pr-agent-summary:end -->
