### PR TITLE
fix: 修复插件身份代码质量门禁

### DIFF
--- a/app/application/plugin/identity.py
+++ b/app/application/plugin/identity.py
@@ -8,7 +8,6 @@ from datetime import datetime
 from enum import StrEnum
 from typing import Protocol
 
-
 _PLUGIN_ID_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9]{0,127}$")
 _ONLINE_SOURCE_KEY_PATTERN = re.compile(
     r"^github:[a-z0-9](?:[a-z0-9-]{0,38})/"

--- a/app/db/adapters/pluginidentity.py
+++ b/app/db/adapters/pluginidentity.py
@@ -3,14 +3,14 @@
 from collections.abc import Callable
 from datetime import datetime
 
-from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
 
 from app.application.plugin.identity import (
     PluginBindingBasis,
-    PluginPayloadSourceType,
     PluginIdentity,
     PluginIdentityConflictError,
+    PluginPayloadSourceType,
     TrustedPluginSourceType,
     WritePluginIdentityCommand,
     normalize_physical_plugin_id,

--- a/app/db/oper/pluginidentity.py
+++ b/app/db/oper/pluginidentity.py
@@ -1,5 +1,7 @@
 """插件来源身份的数据访问原语。"""
 
+from typing import cast
+
 from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 
@@ -13,11 +15,14 @@ class PluginIdentityOper(DbOper):
     def get_by_plugin_id(self, plugin_id: str) -> PluginIdentity | None:
         """按规范化物理插件 ID 查询唯一身份。"""
         return self._execute_sync_query(
-            lambda session: session.execute(
-                select(PluginIdentity).where(
-                    PluginIdentity.normalized_plugin_id == plugin_id
-                )
-            ).scalar_one_or_none()
+            lambda session: cast(
+                PluginIdentity | None,
+                session.execute(
+                    select(PluginIdentity).where(
+                        PluginIdentity.normalized_plugin_id == plugin_id
+                    )
+                ).scalar_one_or_none(),
+            )
         )
 
     def stage_create(self, identity: PluginIdentity) -> None:

--- a/tests/test_plugin_identity.py
+++ b/tests/test_plugin_identity.py
@@ -1,9 +1,9 @@
 """插件身份事实、条件写和存量迁移决策测试。"""
 
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
-import threading
 
 import pytest
 import sqlalchemy as sa
@@ -22,7 +22,6 @@ from app.application.plugin.identity import (
 from app.db.adapters.pluginidentity import TransactionalPluginIdentityStore
 from app.db.models import load_all_models
 from app.db.models.pluginidentity import PluginIdentity as PluginIdentityModel
-
 
 NOW = datetime(2026, 8, 25, 12, 0, tzinfo=timezone.utc)
 OFFICIAL_SOURCE = "github:jxxghp/moviepilot-plugins"

--- a/tests/test_plugin_identity_migration.py
+++ b/tests/test_plugin_identity_migration.py
@@ -22,7 +22,6 @@ except ModuleNotFoundError:
 
 from app.db.models.pluginidentity import PluginIdentity
 
-
 MIGRATION = "database.versions.d2e4f6a8b0c1_3_0_9"
 
 


### PR DESCRIPTION
`#6454` 合并后的 Architecture Contract Gate 检测到插件来源身份代码新增 4 个 Ruff `I001` 诊断，以及 ORM 查询结果的 mypy `no-any-return` 诊断。

本 PR 使用项目锁定的 Ruff 0.16.4 规范化导入块，并在 SQLAlchemy 查询结果边界补充准确的 `PluginIdentity | None` 类型收窄。不修改 Ruff/mypy baseline、CI 配置或运行时行为。

验证：

- `python scripts/architecture/ruff_ratchet.py`：通过
- `python scripts/architecture/mypy_ratchet.py`：通过
- `ruff check`（4 个改动文件）：通过
- `pylint app/db/oper/pluginidentity.py`：10.00/10
- 插件身份与迁移测试：32 passed，1 skipped
- `git diff --check`：通过

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 98d7e1b1751e719c5177a749c048bb866acc7fd4

- 修复插件身份代码质量门禁
- 规范化导入顺序，满足 Ruff 检查
- 收窄 ORM 查询结果类型
- 不改变运行时或数据库行为
<!-- pr-agent-summary:end -->
