### PR TITLE
fix: 保持 Release 更新的代理与缓存配置

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -263,6 +263,25 @@ def _mark_prepared_update_failed(message: str) -> None:
     _clear_json_file(PREPARED_UPDATE_MANIFEST)
 
 
+def _local_update_env() -> dict[str, str]:
+    """构造本地更新子进程使用的包缓存、代理和认证环境。"""
+    update_env = os.environ.copy()
+    package_cache_root = Path(
+        update_env.get("PACKAGE_CACHE_ROOT", "").strip() or settings.PACKAGE_CACHE_PATH
+    )
+    update_env.setdefault("PACKAGE_CACHE_ROOT", str(package_cache_root))
+    update_env.setdefault("UV_CACHE_DIR", str(package_cache_root / "uv"))
+    if settings.PIP_PROXY:
+        update_env["PIP_PROXY"] = settings.PIP_PROXY
+    if settings.PROXY_HOST:
+        update_env["PROXY_HOST"] = settings.PROXY_HOST
+        for key in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+            update_env[key] = settings.PROXY_HOST
+    if settings.GITHUB_TOKEN:
+        update_env.setdefault("GITHUB_TOKEN", settings.GITHUB_TOKEN)
+    return update_env
+
+
 def _apply_prepared_release_update() -> bool:
     """本地 CLI 重启时离线安装已校验的 Release；返回是否发现安装意图。"""
     manifest = _read_json_file(PREPARED_UPDATE_MANIFEST)
@@ -309,7 +328,7 @@ def _apply_prepared_release_update() -> bool:
         result = subprocess.run(
             update_command,
             cwd=str(_repo_root()),
-            env=os.environ.copy(),
+            env=_local_update_env(),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
@@ -375,24 +394,11 @@ def _best_effort_auto_update() -> None:
         str(settings.CONFIG_PATH),
     ]
 
-    update_env = os.environ.copy()
-    package_cache_root = Path(update_env.get("PACKAGE_CACHE_ROOT", "").strip() or settings.PACKAGE_CACHE_PATH)
-    update_env.setdefault("PACKAGE_CACHE_ROOT", str(package_cache_root))
-    update_env.setdefault("UV_CACHE_DIR", str(package_cache_root / "uv"))
-    if settings.PIP_PROXY:
-        update_env["PIP_PROXY"] = settings.PIP_PROXY
-    if settings.PROXY_HOST:
-        update_env["PROXY_HOST"] = settings.PROXY_HOST
-        for key in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
-            update_env[key] = settings.PROXY_HOST
-    if settings.GITHUB_TOKEN:
-        update_env.setdefault("GITHUB_TOKEN", settings.GITHUB_TOKEN)
-
     click.echo(f"检测到 MOVIEPILOT_AUTO_UPDATE={mode}，启动前执行本地自动更新")
     result = subprocess.run(
         update_command,
         cwd=str(_repo_root()),
-        env=update_env,
+        env=_local_update_env(),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,

--- a/tests/test_cli_auto_update.py
+++ b/tests/test_cli_auto_update.py
@@ -142,6 +142,46 @@ def test_prepared_release_uses_downloaded_package_before_dev_mode():
     mode.assert_not_called()
 
 
+def test_prepared_release_passes_package_env_and_overrides_proxy():
+    module = load_cli_module()
+    module.settings.PROXY_HOST = "http://proxy.example:7890"
+    module.settings.PIP_PROXY = "https://mirror.example/simple"
+    module.PREPARED_UPDATE_ROOT.mkdir(parents=True, exist_ok=True)
+    backend = module.PREPARED_UPDATE_ROOT / "backend.zip"
+    frontend = module.PREPARED_UPDATE_ROOT / "frontend.zip"
+    backend.write_bytes(b"backend")
+    frontend.write_bytes(b"frontend")
+    module.PREPARED_UPDATE_MANIFEST.write_text(
+        json.dumps(
+            {
+                "version": "v3.1.0",
+                "frontend_version": "v3.1.0",
+                "backend_archive": str(backend),
+                "frontend_archive": str(frontend),
+                "backend_sha256": hashlib.sha256(backend.read_bytes()).hexdigest(),
+                "frontend_sha256": hashlib.sha256(frontend.read_bytes()).hexdigest(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    run_result = SimpleNamespace(returncode=0, stdout="ok")
+
+    with patch.dict(
+        module.os.environ,
+        {"HTTPS_PROXY": "http://old.example:8080"},
+        clear=True,
+    ), patch.object(
+        module.subprocess, "run", return_value=run_result
+    ) as run_mock, patch.object(module.click, "echo"):
+        assert module._apply_prepared_release_update() is True
+
+    env = run_mock.call_args.kwargs["env"]
+    assert env["HTTPS_PROXY"] == "http://proxy.example:7890"
+    assert env["PIP_PROXY"] == "https://mirror.example/simple"
+    assert env["PACKAGE_CACHE_ROOT"] == str(module.settings.PACKAGE_CACHE_PATH)
+    assert env["UV_CACHE_DIR"] == str(module.settings.PACKAGE_CACHE_PATH / "uv")
+
+
 def test_best_effort_auto_update_does_not_pass_frontend_version_override():
     module = load_cli_module()
     run_result = SimpleNamespace(returncode=0, stdout="ok")


### PR DESCRIPTION
## 问题与处理

已下载并校验的 Release 会在下次本地 CLI 启动时调用 `local_setup.py update` 完成安装。该路径此前只继承进程环境，没有应用 MoviePilot 的包缓存、代理与 GitHub 认证配置；在必须通过应用代理访问依赖源的环境中，后台准备成功的更新仍可能在最终安装阶段失败。

本 PR 抽取统一的本地更新子进程环境，并让 prepared Release 与开发版更新共同使用：

- 复用持久化的包缓存目录与 uv 缓存目录；
- 应用已配置的 PyPI 镜像与 HTTP/HTTPS 代理；
- 在父进程未显式提供时传递 GitHub 认证配置；
- 保持 Release 归档摘要校验、离线安装命令、更新选择顺序和失败恢复语义不变。

## 验证

- `pytest tests/test_cli_auto_update.py -q`：8 passed
- `pylint app/cli.py`：10.00/10
- Ruff ratchet：通过，未增加诊断
- mypy ratchet：通过，未增加类型错误
- `git diff --check`：通过

独立 Review 已确认没有遗漏其他本地更新子进程路径，认证信息仅进入子进程环境，不会写入命令或日志。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 01302adfeb3945b9ba6df90439d52774a6a70c67

- 统一本地更新子进程环境构造
- 已准备 Release 继承缓存与代理配置
- 保留 GitHub 令牌的父环境优先级
- 新增预下载更新代理覆盖测试
<!-- pr-agent-summary:end -->
