### PR TITLE
test: 对齐 oss2 Python 3.14 告警过滤

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -11,7 +11,7 @@ asyncio_debug = true
 filterwarnings =
     error::pytest.PytestUnhandledThreadExceptionWarning
     ignore:'_UnionGenericAlias' is deprecated and slated for removal in Python 3\.17:DeprecationWarning:google\.genai\.types
-    ignore:invalid escape sequence '\\&':SyntaxWarning:oss2\.api
+    ignore:"\\&" is an invalid escape sequence\..*:SyntaxWarning
     ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning
     ignore:'crypt' is deprecated:DeprecationWarning
     ignore:'audioop' is deprecated:DeprecationWarning


### PR DESCRIPTION
## 问题与处理

Python 3.14 在冷缓存编译 `oss2/api.py` 时会报告已知的无效转义 `SyntaxWarning`。生产启动已按具体消息过滤该第三方告警，但 pytest 仍沿用旧消息格式并限定 `oss2.api` 模块；编译期告警不会以该模块名参与 pytest 的 module 过滤，因此全量测试仍会稳定留下 1 条 warning。

本 PR 将 pytest 规则与生产启动规则对齐，仅忽略 `"\\&" is an invalid escape sequence...` 这一具体消息和 `SyntaxWarning` 类别。其他无效转义消息继续暴露，不扩大为通用 warning 屏蔽，也不改变生产代码。

## 验证

- Python 3.14 冷缓存 A/B：修改前 `4 passed, 1 warning`，修改后 `4 passed` 且零 warning
- 相关启动过滤、真实 oss2 导入与运行依赖测试：`14 passed`
- `git diff --check`：通过

独立 Review 已确认 pytest 过滤语法、真实告警路径和匹配范围均符合预期。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at e78bc01b0f63d5f46863e50256a196cb17cffe6d

- 对齐 `oss2` 已知转义告警过滤
- 按消息精确匹配 Python 3.14 `SyntaxWarning`
- 移除失效的模块名限定
- 其他无效转义告警仍会暴露
<!-- pr-agent-summary:end -->
