### PR TITLE
fix(subscribe): 兼容 v2 下载记录中的 tmdbid 订阅来源

### DIFF
--- a/app/application/subscription/query.py
+++ b/app/application/subscription/query.py
@@ -7,7 +7,7 @@ from typing import Any, Optional, Protocol
 from app.domain.context import MediaInfo
 from app.domain.meta.metabase import MetaBase
 from app.schemas.media import resolve_media_identity
-from app.schemas.types import MediaType
+from app.schemas.types import MediaSource, MediaType
 from app.schemas.workflow import Subscribe as SubscribeView
 
 
@@ -85,6 +85,14 @@ class SubscriptionQueryService:
         "media_id",
         "music_type",
     }
+    _LEGACY_ID_FIELDS: tuple[tuple[str, MediaSource], ...] = (
+        ("tmdbid", MediaSource.TMDB),
+        ("doubanid", MediaSource.Douban),
+        ("bangumiid", MediaSource.Bangumi),
+        ("anilistid", MediaSource.AniList),
+        ("imdbid", MediaSource.IMDb),
+        ("tvdbid", MediaSource.TVDB),
+    )
 
     def __init__(
         self,
@@ -199,6 +207,30 @@ class SubscriptionQueryService:
             episode_group=mediainfo.episode_group,
         ))
 
+    @classmethod
+    def _has_media_identity(cls, identity: dict[str, Any]) -> bool:
+        """判断来源关键字是否已带成对的媒体身份。"""
+        media_id = identity.get("media_id")
+        return bool(identity.get("media_source")) and media_id not in (
+            None,
+            "",
+            0,
+            "0",
+        )
+
+    @classmethod
+    def _legacy_media_identity(cls, source_keyword: dict[str, Any]) -> dict[str, Any]:
+        """把 v2 订阅来源里的 tmdbid/doubanid 等补成 media_source + media_id。"""
+        for field, source in cls._LEGACY_ID_FIELDS:
+            raw = source_keyword.get(field)
+            if raw in (None, "", 0, "0"):
+                continue
+            return {
+                "media_source": source,
+                "media_id": str(raw),
+            }
+        return {}
+
     def get_by_source(self, source_keyword: Optional[dict]) -> Optional[Any]:
         """从已解析来源关键字筛出稳定身份字段并读取订阅。"""
         if not source_keyword:
@@ -208,6 +240,10 @@ class SubscriptionQueryService:
             for key, value in source_keyword.items()
             if key in self._SOURCE_FIELDS
         }
+        if not self._has_media_identity(identity):
+            identity.update(self._legacy_media_identity(source_keyword))
+        if not identity.get("type") or not self._has_media_identity(identity):
+            return None
         return self._repository.get_by(**identity)
 
     def has_music(self, searchable_states: str) -> bool:

--- a/tests/test_subscription_query_service.py
+++ b/tests/test_subscription_query_service.py
@@ -63,6 +63,45 @@ def test_subscription_query_service_filters_source_and_music_state() -> None:
     repository.list.assert_called_once_with("R,P")
 
 
+def test_get_by_source_upgrades_legacy_tmdbid_identity() -> None:
+    """v2 下载记录只有 tmdbid 时，应补成 themoviedb + media_id 再查订阅。"""
+    repository = Mock()
+    expected = SimpleNamespace(id=22)
+    repository.get_by.return_value = expected
+    service = SubscriptionQueryService(repository)
+
+    result = service.get_by_source({
+        "id": 22,
+        "name": "阿滋漫画大王",
+        "type": MediaType.TV.value,
+        "season": 1,
+        "tmdbid": 12143,
+        "imdbid": "tt0339955",
+        "tvdbid": 79077,
+    })
+
+    assert result is expected
+    repository.get_by.assert_called_once_with(
+        type=MediaType.TV.value,
+        season=1,
+        media_source=MediaSource.TMDB,
+        media_id="12143",
+    )
+
+
+def test_get_by_source_skips_incomplete_legacy_identity() -> None:
+    """来源既无 media_id 也无旧 tmdbid 时，不得把半对身份传给仓储。"""
+    repository = Mock()
+    service = SubscriptionQueryService(repository)
+
+    assert service.get_by_source({
+        "type": MediaType.TV.value,
+        "season": 1,
+        "name": "Demo",
+    }) is None
+    repository.get_by.assert_not_called()
+
+
 def test_subscribe_chain_facade_delegates_three_query_slices() -> None:
     """SubscribeChain 保持三个公开方法签名并仅负责来源解析和结果转发。"""
     service = Mock()


### PR DESCRIPTION
### 场景与痛点 (Problem)

v3 订阅身份是成对的 `media_source` + `media_id`。`SubscriptionQueryService.get_by_source` 只从解析后的来源字典里挑 `_SOURCE_FIELDS`，然后调用 `SubscribeOper.get_by(type, media_source, media_id, ...)`。

从 v2 升上来的 `downloadhistory.note` 里，`Subscribe|{...}` 仍然是 `tmdbid` / `doubanid` 等旧字段，没有 `media_source` / `media_id`。整理时 `_get_subscribe_custom_words` 会按这个来源反查订阅，结果 `get_by()` 缺必填参数直接 TypeError，整次手动整理失败。

### 解决方案 (Solution)

- 没有成对身份时，按 tmdbid → doubanid → bangumiid → anilistid → imdbid → tvdbid 补成 `media_source` + `media_id`
- 仍然没有 `type` 或成对身份时返回 `None`，不再把半对身份传给仓储
- 已有 v3 身份的记录不改查询结果

### 影响范围与测试 (Testing & Safety)

- 只改 `app/application/subscription/query.py` 和 `tests/test_subscription_query_service.py`
- 无配置或数据库迁移
- 风险：v2 note 同时带 tmdbid 和 imdbid 时优先 TMDB（与常见订阅主键一致）；查不到订阅时整理继续，只是拿不到订阅自定义识别词
- 已在从 v2 升级的 Windows 实例上验证：旧 tmdbid note 的整理记录可以重新入库

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 11c260d36f87b1065e81f04ca9b086d9566f9b75

- 兼容 v2 订阅来源旧媒体 ID
- 将旧 ID 映射为完整媒体身份
- 缺失身份时跳过仓储查询
- 新增旧记录与无效身份测试
<!-- pr-agent-summary:end -->
