### PR TITLE
test: 消除生命周期关闭测试的调度竞态

### DIFF
--- a/tests/test_lifecycle_shutdown.py
+++ b/tests/test_lifecycle_shutdown.py
@@ -1137,8 +1137,10 @@ def test_stop_modules_drains_web_agent_tasks_before_persistence(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_shutdown_timeout_does_not_skip_database_worker_cleanup(monkeypatch):
-    """模块关闭超时取消当前步骤后仍应继续收口数据库 worker。"""
+async def test_stop_modules_cancellation_does_not_skip_database_worker_cleanup(
+    monkeypatch,
+):
+    """模块关闭收到取消请求后仍应继续收口数据库 worker。"""
     started = asyncio.Event()
 
     async def blocked_web_agent_shutdown():
@@ -1169,18 +1171,13 @@ async def test_shutdown_timeout_does_not_skip_database_worker_cleanup(monkeypatc
     monkeypatch.setattr(modules_initializer, "stop_database_worker", stop_database_worker)
     monkeypatch.setattr(modules_initializer, "_database_worker", object())
 
-    shutdown = asyncio.create_task(
-        lifecycle.run_shutdown_step(
-            "模块服务",
-            modules_initializer.stop_modules,
-            timeout_seconds=0.01,
-        )
-    )
+    shutdown = asyncio.create_task(modules_initializer.stop_modules())
     await started.wait()
+    shutdown.cancel()
     completed = await shutdown
 
     assert completed is False
-    await asyncio.wait_for(database_worker_stopped.wait(), timeout=1.0)
+    assert database_worker_stopped.is_set()
     stop_database_worker.assert_awaited_once_with()
 
 


### PR DESCRIPTION
## 问题

PR #6462 的 `Unit Tests (2/4)` 连续两次在同一生命周期测试中失败。该测试用 10ms 总超时触发关闭取消，并假设超时一定发生在 Web Agent 关闭阶段；CI 调度较慢时，超时可能先落在前面的 Redis 关闭步骤，随后流程进入 Web Agent 永久等待，形成测试竞态。

## 调整

- 直接启动 `stop_modules()`，等待测试替身确认流程已经进入 Web Agent 关闭阶段后再取消任务。
- 保留真实合同断言：取消请求被消费后继续收口，数据库 worker 必须完成关闭。
- 不修改生产生命周期、超时策略或资源所有权语义。

## 验证

- 目标用例连续运行 30 次通过。
- `tests/test_lifecycle_shutdown.py`：62 passed。
- Pylint：10.00/10。
- Ruff ratchet：通过，存量诊断未增长。
- `git diff --check`：通过。

Refs #6462

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 30a0f0e4dbf2a36fe8b2dea5f580d7ed7ad1e6e8

- 消除生命周期关闭测试的调度竞态
- 直接测试 `stop_modules()` 的取消行为
- 等待 Web Agent 启动后再发起取消
- 验证数据库 worker 仍完成清理
<!-- pr-agent-summary:end -->
