### PR TITLE
fix: 修正精确搜索与模糊搜索的 response_model，避免返回空壳数据

### DIFF
--- a/app/api/endpoints/search.py
+++ b/app/api/endpoints/search.py
@@ -432,7 +432,7 @@ async def search_by_id_stream(
 @router.get(
     "/media/{media_id}",
     summary="精确搜索资源",
-    response_model=_SchemaResponse[list[_SchemaTorrentInfo]],
+    response_model=List[_SchemaContext],
 )
 async def search_by_id(
     media_id: str,
@@ -513,7 +513,7 @@ async def search_by_title_stream(
 @router.get(
     "/title",
     summary="模糊搜索资源",
-    response_model=_SchemaResponse[list[_SchemaTorrentInfo]],
+    response_model=List[_SchemaContext],
 )
 async def search_by_title(
     keyword: Optional[str] = None,


### PR DESCRIPTION
## 问题

`/api/v1/search/media/{media_id}` 与 `/api/v1/search/title` 返回的种子列表里，
**每一条的所有字段都是 null**。

对运行中的 v3 实例实测（单站点、关键词搜索）：

```
GET /api/v1/search/title?keyword=阿凡达&sites=4   → HTTP 200，13 条结果

元素顶层键: site, site_name, title, media_source, media_id, enclosure, size, seeders ...
title: null    site_name: null    size: 0    pubdate: null    seeders: 0
有 title 的条目：0 / 13
```

同一次搜索的结果通过 `/api/v1/search/last` 取回则是完整的：

```
torrent_info.title: Avatar Fire and Ash 2025 UHD BluRay 2160p x265 10bit DV HDR TrueHD7.1 Atmos ...
torrent_info.site_name: 朋友 | size: 41596758262 | pubdate: 2026-08-19 03:39:05
meta_info.name: Avatar Fire And Ash
```

数据本身没有问题，是在接口出口处被序列化掉了。

## 原因

`app/api/endpoints/search.py` 中两处 `response_model` 与链路实际返回的类型不一致：

```python
@router.get("/media/{media_id}", response_model=_SchemaResponse[list[_SchemaTorrentInfo]])
async def search_by_id(...):
    torrents = await SearchChain().async_search_by_id(...)
    return _SchemaResponse(success=True, data=[torrent.to_dict() for torrent in torrents])

@router.get("/title", response_model=_SchemaResponse[list[_SchemaTorrentInfo]])
async def search_by_title(...):
    torrents = await SearchChain().async_search_by_title(...)
    return _SchemaResponse(success=True, data=[torrent.to_dict() for torrent in torrents])
```

而 `app/chain/search/media.py` 与 `app/chain/search/title.py` 里：

```python
async def async_search_by_id(...) -> List[Context]:
async def async_search_by_title(...) -> List[Context]:
```

`Context.to_dict()` 产出的是 `{meta_info, media_info, torrent_info, ...}` 三层结构，
与 `TorrentInfo` 的字段集完全不相交。pydantic 按 `response_model` 序列化时，
在 Context 的 dict 里找不到任何一个 TorrentInfo 字段，于是全部填成默认值 null，
接口对外就返回了一批空壳。

SSE 流式端点（`/search/media/{media_id}/stream`、`/search/title/stream`）声明的是
`response_model=None` + `StreamingResponse`，不经过这层过滤，所以数据是完整的
—— 前端走流式接口因此没有受影响，只有直接调用非流式接口的客户端会踩到。

## 改动

两行，把 `response_model` 改成与同文件 `/search/last` 一致的写法：

```python
@router.get("/last", summary="查询搜索结果", response_model=List[_SchemaContext])   # 既有写法
```

由 `ResponseAPIRouter` 统一包装成 `Response[List[Context]]`，OpenAPI 里的响应类型
从 `Response_list_TorrentInfo__` 变为 `Response_List_Context__`，与实际返回值一致。

`_SchemaContext` 在该文件第 16 行已导入，无需新增 import。

## 影响

- 修正后这两个接口返回完整的 Context 列表，与 `/search/last`、与 SSE 流式接口保持一致
- OpenAPI 声明的响应类型发生变化，但**实际返回的报文结构没有变**（原本就是 Context，
  只是被错误的声明清空了字段），因此对已有客户端只会从「全空」变成「有数据」
