### PR TITLE
docs: 明确 S4 Lite 增量治理与插件兼容边界

### DIFF
--- a/docs/architecture/optimization-checklist.md
+++ b/docs/architecture/optimization-checklist.md
@@ -160,6 +160,13 @@ ARCH-201 至 ARCH-204 均达到实现、验证、提交、推送和远端门禁�
 | ARCH-203 | P2 | 已交付 | 拆分 Domain 投影与 Startup 高扇出目录 | Domain 四来源投影与 Startup 单词型 composition owner 均已完成；最终精确 head CI 已闭环 |
 | ARCH-204 | P2 | 已交付 | 合并重复 sync/async 核心逻辑并转换存量测试风格 | 双 ABI 只保留 I/O 外壳，共享解析、校验、映射和状态决策；最终精确 head CI 已闭环 |
 
+S4/ARCH-110/111 的取消不撤销现有防回退门禁。后续按路线图的 **S4 Lite** 边界做增量治理：
+第三方插件 Module/Event 合同校验继续 diagnostic，宿主 strict contract enforcement 只覆盖
+独立评审的内置高风险能力和 durable internal event；这不改变现有 strict 异常传播接口仍可触达
+插件 provider 的事实。现有插件 ABI、SDK/Compat/Legacy 行为及原始返回形状不得因宿主升级改变。
+复杂度、并发、mypy、Ruff 和 coverage 继续使用当前 zero-growth/低水位 ratchet，但不再追求
+一次性清空全宿主历史债务。
+
 ## 5. P0：先恢复主线
 
 ### ARCH-001 恢复 mypy ratchet

--- a/docs/architecture/refactor-roadmap.md
+++ b/docs/architecture/refactor-roadmap.md
@@ -183,6 +183,25 @@ G-ARCH 只有在 S3、S5 及以下条件全部满足后才可完成；S4 不属�
 | S4-L5 Ruff 治理债务清零 | `CANCELLED` | — | 原计划取消 |
 | S4-L6 Coverage/并发/质量证据 | `CANCELLED` | — | 原计划取消 |
 
+#### S4 Lite：后续增量治理边界（非阶段）
+
+S4 Lite 不是新的 Stage、Leaf 或 Goal，不设置状态、进度或统一完成日期，也不改变 S4
+`CANCELLED` 的事实。它只约束后续实际触及相关 owner 时的增量治理，避免取消全量清零后失去
+防回退边界：
+
+- Module/Event 合同继续以插件兼容为硬边界。第三方插件的合同校验保持 diagnostic；只有宿主
+  内置的高风险能力或 durable internal event，才可在独立变更中引入 strict contract
+  enforcement，并补齐对应行为、生命周期和失败恢复证据。这里的 strict 仅指合同校验策略；
+  现有 `run_module_strict` / `send_event_strict` 是调用方选择的异常传播接口，仍可触达插件
+  provider，不属于本条收窄范围。
+- 宿主升级不得要求已可用插件先行适配。`run_module` / `async_run_module` 的字符串方法 ABI、
+  参数兼容、聚合与原始返回形状，以及现有 SDK/Compat/Legacy 行为保持稳定；若增量 strict
+  治理导致既有插件失效，首先按宿主兼容回归处理，而不是把迁移责任转给插件。
+- complexity v2、原生并发、mypy、Ruff 和 coverage 保留现有 zero-growth/低水位 ratchet；
+  新增或实质修改高风险 owner 时补对应专项证据，但不恢复全宿主历史债务清零目标。
+- 每项治理必须在独立变更中说明 owner、风险、兼容影响和退出条件，并通过受影响宿主路径与插件
+  兼容验证；不得以刷新 baseline、增加文档或只通过静态快照宣称语义完成。
+
 ### S5：Plugin、Agent、Domain、Startup 与最终收口
 
 退出条件：剩余 Facade/Manager/Domain/Startup 重复职责清零；官方插件兼容、全量测试和远端交付完成。


### PR DESCRIPTION
## 背景

S4 已按维护者决定取消，但现有文档只记录了“不再全量清零”，没有明确取消后如何继续做增量治理，也容易把合同校验 strict 与现有 `run_module_strict` / `send_event_strict` 的异常传播语义混为一谈。

## 调整

- 将 S4 Lite 定义为非 Stage、非 Leaf、非 Goal 的后续增量治理边界，不改变 S4 `CANCELLED` 状态。
- 第三方插件的 Module/Event 合同校验继续保持 diagnostic；宿主 strict contract enforcement 仅允许按内置高风险能力或 durable internal event 独立推进。
- 明确现有 strict 异常传播接口仍可触达插件 provider，不属于合同 enforcement 的收窄范围。
- 保持 `run_module` / `async_run_module` 字符串 ABI、参数兼容、聚合、原始返回形状及 SDK/Compat/Legacy 行为稳定。
- complexity、并发、mypy、Ruff、coverage 继续使用现有 zero-growth/低水位 ratchet，不恢复全宿主历史债务清零目标。

本 PR 仅校准治理文档，不修改运行时行为。

## 验证

- `python -m pytest -q tests/test_architecture_contract_baseline.py tests/test_architecture_documentation.py tests/test_module_invocation_dispatcher.py tests/test_event_contracts.py`：57 passed
- `git diff --check`
