### PR TITLE
fix(tmdb): 修复异步剧集组查询参数名

### DIFF
--- a/app/modules/themoviedb/__init__.py
+++ b/app/modules/themoviedb/__init__.py
@@ -1736,7 +1736,7 @@ class TheMovieDbModule(MediaAuxiliaryProviderMixin, _ModuleBase):
         :param episode_group:  剧集组
         """
         if episode_group:
-            season_info = await self.tmdb.async_get_tv_group_detail(episode_group, season=season)
+            season_info = await self.tmdb.async_get_tv_group_detail(group_id=episode_group, season=season)
         else:
             season_info = await self.tmdb.async_get_tv_season_detail(tmdbid=tmdbid, season=season)
         if not season_info or not season_info.get("episodes"):


### PR DESCRIPTION
## 问题

异步媒体识别在存在 `episode_group` 时，将本地参数名 `episode_group` 通过关键字参数传入 TMDB 剧集组查询方法。

下游接口实际使用 `group_id` 作为形参，导致请求发起前抛出 `TypeError`，媒体识别流程中断。

## 修复

使用 `group_id` 传递剧集组 ID，保持本地 `episode_group` 的业务语义不变。

## 验证

- 异步剧集组查询不再因未知关键字参数失败
- 携带剧集组的 TMDB 异步媒体识别可继续执行后续识别流程