### PR TITLE
fix(tmdb): 修复剧集组查询参数名

### DIFF
--- a/app/modules/themoviedb/__init__.py
+++ b/app/modules/themoviedb/__init__.py
@@ -753,7 +753,7 @@ class TheMovieDbModule(MediaAuxiliaryProviderMixin, _ModuleBase):
         if plan.episode_group:
             group_seasons = yield _RecognizeStep(
                 action=_RecognizeAction.LOAD_GROUP,
-                kwargs={"episode_group": plan.episode_group},
+                kwargs={"group_id": plan.episode_group},
             )
 
         cache_hit = bool(cache_info and plan.use_cache)

--- a/tests/test_tmdb_sync_async_parity.py
+++ b/tests/test_tmdb_sync_async_parity.py
@@ -88,6 +88,40 @@ def test_recognize_sync_async_share_identity_cache_and_result_decisions() -> Non
     ]
 
 
+def test_recognize_sync_async_pass_episode_group_as_group_id() -> None:
+    """剧集组 ID 应按 TmdbApi 的 group_id 参数在双入口转发。"""
+    module = _module_with_clients()
+    info = _movie_info()
+    group_id = "5ad0ec240e0a26303f00d84d"
+    module.tmdb.get_info.return_value = info
+    module.tmdb.async_get_info = AsyncMock(return_value=info)
+    module.tmdb.get_tv_group_seasons.return_value = []
+    module.tmdb.async_get_tv_group_seasons = AsyncMock(return_value=[])
+    module.category.get_movie_category.return_value = "剧情片"
+
+    module.recognize_media(
+        mtype=MediaType.MOVIE,
+        media_source=MediaSource.TMDB,
+        media_id="10",
+        episode_group=group_id,
+        cache=False,
+    )
+    asyncio.run(
+        module.async_recognize_media(
+            mtype=MediaType.MOVIE,
+            media_source=MediaSource.TMDB,
+            media_id="10",
+            episode_group=group_id,
+            cache=False,
+        )
+    )
+
+    module.tmdb.get_tv_group_seasons.assert_called_once_with(group_id=group_id)
+    module.tmdb.async_get_tv_group_seasons.assert_awaited_once_with(
+        group_id=group_id
+    )
+
+
 def test_recognize_sync_async_share_negative_cache_short_circuit() -> None:
     """负缓存命中时双入口都不得继续访问 TMDB 客户端。"""
     module = _module_with_clients()


### PR DESCRIPTION
## 问题

状态机将业务字段 `episode_group` 作为关键字参数转发给 `TmdbApi.get_tv_group_seasons` 及其异步版本；两个接口的实际形参均为 `group_id`，导致携带剧集组的识别请求在调用前抛出 `TypeError`。

## 修复

仅调整 `LOAD_GROUP` 步骤的转发参数名为 `group_id`，保持外部识别接口、`_RecognizePlan.episode_group` 和剧集详情查询逻辑不变。

## 验证

- 新增同步/异步识别路径的回归测试，断言剧集组 ID 按 `group_id` 转发。
- 已执行 `git diff --check` 和 Python AST 语法解析。
- 未能执行 pytest：本机 `uv 0.11.15`，仓库要求 `uv >=0.12.5`。