### PR TITLE
fix(vocechat): accept numeric user IDs

### DIFF
--- a/app/modules/vocechat/vocechat.py
+++ b/app/modules/vocechat/vocechat.py
@@ -236,15 +236,26 @@ class VoceChat:
     def __send_request(self, userid: str, caption: str) -> bool:
         """
         向VoceChat发送报文
-        userid格式：UID#xxx / GID#xxx
+        userid格式：数字用户ID / UID#xxx / GID#xxx
         """
         if not self._client:
             return False
         if userid.startswith("GID#"):
             action = "send_to_group"
-        else:
+            idstr = userid[4:]
+        elif userid.startswith("UID#"):
             action = "send_to_user"
-        idstr = userid[4:]
+            idstr = userid[4:]
+        elif "#" not in userid:
+            action = "send_to_user"
+            idstr = userid
+        else:
+            logger.error(f"VoceChat消息接收对象格式错误：{userid}")
+            return False
+
+        if not idstr.isdigit():
+            logger.error(f"VoceChat消息接收对象ID无效：{userid}")
+            return False
 
         with lock:
             result = self._client.post_res(f"{self._host}api/bot/{action}/{idstr}", data=caption.encode("utf-8"))

--- a/tests/test_vocechat.py
+++ b/tests/test_vocechat.py
@@ -1,0 +1,44 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from app.modules.vocechat.vocechat import VoceChat
+
+
+@pytest.mark.parametrize(
+    ("userid", "endpoint"),
+    [
+        ("123", "send_to_user/123"),
+        ("UID#123", "send_to_user/123"),
+        ("GID#456", "send_to_group/456"),
+    ],
+)
+def test_send_msg_normalizes_vocechat_target(userid: str, endpoint: str):
+    client = Mock()
+    client.post_res.return_value = SimpleNamespace(status_code=200)
+    vocechat = VoceChat(
+        VOCECHAT_HOST="https://voce.example.com",
+        VOCECHAT_API_KEY="test-key",
+        VOCECHAT_CHANNEL_ID="456",
+    )
+    vocechat._client = client
+
+    assert vocechat.send_msg(title="测试消息", userid=userid) is True
+    assert client.post_res.call_args.args[0] == (
+        f"https://voce.example.com/api/bot/{endpoint}"
+    )
+
+
+@pytest.mark.parametrize("userid", ["UID#", "GID#", "SID#123", "abc"])
+def test_send_msg_rejects_invalid_vocechat_target(userid: str):
+    client = Mock()
+    vocechat = VoceChat(
+        VOCECHAT_HOST="https://voce.example.com",
+        VOCECHAT_API_KEY="test-key",
+        VOCECHAT_CHANNEL_ID="456",
+    )
+    vocechat._client = client
+
+    assert vocechat.send_msg(title="测试消息", userid=userid) is False
+    client.post_res.assert_not_called()


### PR DESCRIPTION
## 问题

用户资料中的 VoceChat 用户 ID 输入框没有要求 `UID#` 前缀，而发送实现无条件截去目标值前四个字符。填写 VoceChat 官方文档所示的裸数字 UID（例如 `123`）时，请求最终会发送到空的用户路径。

## 修复

- 裸数字目标按 VoceChat 用户 UID 发送
- 保持兼容内部现有的 `UID#123` 与 `GID#456` 目标格式
- 在发起 HTTP 请求前拒绝空 ID、未知前缀和非数字 ID
- 增加用户、群组及非法格式的回归测试

参考：VoceChat Bot API 使用 `/api/bot/send_to_user/{uid}`，其中 `uid` 为数字用户 ID。

## 验证

- `pytest tests/test_vocechat.py -q`：7 passed（Python 3.14.7，v3t 临时测试容器）
- `pylint app/modules/vocechat/vocechat.py --errors-only`：通过
- 无依赖、数据库或配置格式变更

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 77d5d92c3bee6076360da471ef414c161aafbd96

- 支持裸数字 VoceChat 用户 ID
- 保留 `UID#`、`GID#` 目标格式兼容
- 拒绝空、未知及非数字目标
- 新增目标规范化与非法输入测试
<!-- pr-agent-summary:end -->
