### PR TITLE
fix(search): honor site intervals in multi-name search

### DIFF
--- a/app/chain/search/provider.py
+++ b/app/chain/search/provider.py
@@ -1,5 +1,8 @@
 """站点与插件资源 provider fan-out owner。"""
 
+import asyncio
+import threading
+import time
 from concurrent.futures import FIRST_COMPLETED, Future, wait
 from contextlib import aclosing
 from dataclasses import dataclass
@@ -18,6 +21,51 @@ from app.schemas.types import MediaType, ProgressKey, SystemConfigKey
 
 SiteIndexer = Dict[str, Any]
 SyncPending = dict[Future[Any], tuple[SiteIndexer, int, int]]
+
+_site_request_schedule_lock = threading.Lock()
+_site_next_request_at: Dict[str, float] = {}
+
+
+def _site_request_interval(site: SiteIndexer) -> float:
+    """读取站点管理中已有的单次访问间隔配置。"""
+    try:
+        return max(0.0, float(site.get("limit_seconds") or 0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _reserve_site_request(site: SiteIndexer) -> float:
+    """按站点原子预约请求起始时间，避免并发搜索绕过同一流控窗口。"""
+    interval = _site_request_interval(site)
+    if interval <= 0:
+        return 0.0
+    site_key = str(
+        site.get("id")
+        or site.get("domain")
+        or site.get("url")
+        or site.get("name")
+    )
+    now = time.monotonic()
+    with _site_request_schedule_lock:
+        request_at = max(now, _site_next_request_at.get(site_key, now))
+        _site_next_request_at[site_key] = request_at + interval
+    return max(0.0, request_at - now)
+
+
+def _wait_for_site_request(site: SiteIndexer) -> None:
+    """同步等待当前站点预约时间，不阻塞其他站点的线程任务。"""
+    delay = _reserve_site_request(site)
+    if delay > 0:
+        logger.info(f"{site.get('name')} 站点流控等待 {delay:.1f} 秒 ...")
+        time.sleep(delay)
+
+
+async def _async_wait_for_site_request(site: SiteIndexer) -> None:
+    """异步等待当前站点预约时间，让其他站点继续并发搜索。"""
+    delay = _reserve_site_request(site)
+    if delay > 0:
+        logger.info(f"{site.get('name')} 站点流控等待 {delay:.1f} 秒 ...")
+        await asyncio.sleep(delay)
 
 
 @dataclass(frozen=True)
@@ -115,12 +163,18 @@ class SearchProviderOwner(_SearchOwnerBase):
     ) -> None:
         """向进程共享线程 owner 提交一页，并登记该站点的续页位置。"""
         page_number = search_pages[page_index]
+
+        def search_site_page() -> List[TorrentInfo]:
+            _wait_for_site_request(site)
+            return self.search_site_torrents(
+                site=site,
+                keyword=search_keyword,
+                mtype=media_type,
+                page=page_number,
+            )
+
         future = ThreadHelper().submit(
-            self.search_site_torrents,
-            site=site,
-            keyword=search_keyword,
-            mtype=media_type,
-            page=page_number,
+            search_site_page,
         )
         pending[future] = (site, page_index, page_number)
 
@@ -536,6 +590,7 @@ class SearchProviderOwner(_SearchOwnerBase):
             page_number: int,
         ) -> List[TorrentInfo]:
             """在统一分页器调度下请求一页站点资源。"""
+            await _async_wait_for_site_request(site)
             return await self.async_search_site_torrents(
                 site=site,
                 keyword=search_keyword,

--- a/tests/test_search_site_throttle.py
+++ b/tests/test_search_site_throttle.py
@@ -1,0 +1,51 @@
+"""站点搜索请求间隔调度测试。"""
+
+import pytest
+
+from app.chain.search import provider
+
+
+@pytest.fixture(autouse=True)
+def reset_site_request_schedule():
+    """隔离进程级站点预约状态。"""
+    provider._site_next_request_at.clear()  # pylint: disable=protected-access
+    yield
+    provider._site_next_request_at.clear()  # pylint: disable=protected-access
+
+
+def test_site_without_interval_does_not_wait():
+    assert provider._reserve_site_request({"id": 1, "name": "普通站点"}) == 0
+
+
+def test_configured_requests_are_reserved_twenty_seconds_apart(monkeypatch):
+    monkeypatch.setattr(provider.time, "monotonic", lambda: 100.0)
+    site = {"id": 6, "name": "观众", "limit_seconds": 20}
+
+    assert provider._reserve_site_request(site) == 0
+    assert provider._reserve_site_request(site) == 20
+    assert provider._reserve_site_request(site) == 40
+
+
+def test_invalid_interval_does_not_throttle(monkeypatch):
+    monkeypatch.setattr(provider.time, "monotonic", lambda: 100.0)
+    site = {"id": 6, "name": "观众", "limit_seconds": "invalid"}
+
+    assert provider._reserve_site_request(site) == 0
+
+
+@pytest.mark.asyncio
+async def test_async_wait_only_sleeps_for_throttled_site(monkeypatch):
+    delays = []
+
+    async def fake_sleep(delay):
+        delays.append(delay)
+
+    monkeypatch.setattr(provider.time, "monotonic", lambda: 100.0)
+    monkeypatch.setattr(provider.asyncio, "sleep", fake_sleep)
+    site = {"id": 6, "name": "观众", "limit_seconds": 20}
+
+    await provider._async_wait_for_site_request({"id": 1, "name": "普通站点"})
+    await provider._async_wait_for_site_request(site)
+    await provider._async_wait_for_site_request(site)
+
+    assert delays == [20]


### PR DESCRIPTION
## Summary

- preserve the existing random 1-10 second delay between alternate media names
- honor each site's configured `limit_seconds` before starting a search request
- reserve request start times atomically per site so concurrent searches cannot bypass the interval
- keep unthrottled sites running independently while a throttled site waits

## Problem solved

This fixes multi-name searches on Audiences (`audiences.me`) when the site is configured with a 20-second request interval.

MoviePilot previously started the next alternate-name search after only the global random 1-10 second delay. Audiences then rejected later requests through its configured rate limiter, and each rejected request was surfaced as an empty result. Useful aliases such as `相反的你和我` were therefore never actually searched, so episode resources such as E20/E21 could be missed.

With this change, the existing random delay is retained, while each configured site waits only for the remainder of its own `limit_seconds` interval. Later aliases are searched instead of silently skipped. The implementation uses the existing site setting and contains no Audiences-specific hardcoding, so other sites with configured request intervals benefit as well.

## Tests

- `tests/test_search_site_throttle.py`
- `tests/test_search_page_orchestration.py`
- `tests/test_search_sync_async_parity.py`

20 focused tests passed on Python 3.14t.

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at fc16196c6695e70abd0717c1a7af7129abb48dc2

- 按站点配置预约搜索请求时间
- 同步与异步搜索均遵守流控间隔
- 原子调度避免并发请求绕过限速
- 新增站点限速预约与等待测试
<!-- pr-agent-summary:end -->