### PR TITLE
fix(search): honor site intervals in multi-name search

### DIFF
--- a/app/chain/search/provider.py
+++ b/app/chain/search/provider.py
@@ -68,6 +68,18 @@ async def _async_wait_for_site_request(site: SiteIndexer) -> None:
         await asyncio.sleep(delay)
 
 
+def _search_sync_site_page(
+    search: Callable[..., List[TorrentInfo]],
+    site: SiteIndexer,
+    keyword: str,
+    media_type: Optional[MediaType],
+    page: int,
+) -> List[TorrentInfo]:
+    """在模块级包装同步站点请求，避免扩大既有超限 Owner。"""
+    _wait_for_site_request(site)
+    return search(site=site, keyword=keyword, mtype=media_type, page=page)
+
+
 @dataclass(frozen=True)
 class ProviderBatch:
     """一次 provider 页完成后发布的统一事实。"""
@@ -163,18 +175,9 @@ class SearchProviderOwner(_SearchOwnerBase):
     ) -> None:
         """向进程共享线程 owner 提交一页，并登记该站点的续页位置。"""
         page_number = search_pages[page_index]
-
-        def search_site_page() -> List[TorrentInfo]:
-            _wait_for_site_request(site)
-            return self.search_site_torrents(
-                site=site,
-                keyword=search_keyword,
-                mtype=media_type,
-                page=page_number,
-            )
-
         future = ThreadHelper().submit(
-            search_site_page,
+            _search_sync_site_page, self.search_site_torrents,
+            site, search_keyword, media_type, page_number,
         )
         pending[future] = (site, page_index, page_number)
 


### PR DESCRIPTION
## Summary

- preserve the existing random 1-10 second delay between alternate media names
- honor each site's configured `limit_seconds` before starting a search request
- reserve request start times atomically per site so concurrent searches cannot bypass the interval
- keep unthrottled sites running independently while a throttled site waits

## Problem solved

This fixes multi-name searches on Audiences (`audiences.me`) when the site is configured with a 20-second request interval.

MoviePilot previously started the next alternate-name search after only the global random 1-10 second delay. Audiences then rejected later requests through its configured rate limiter, and each rejected request was surfaced as an empty result. Useful aliases such as `相反的你和我` were therefore never actually searched, so episode resources such as E20/E21 could be missed.

With this change, the existing random delay is retained, while each configured site waits only for the remainder of its own `limit_seconds` interval. Later aliases are searched instead of silently skipped. The implementation uses the existing site setting and contains no Audiences-specific hardcoding, so other sites with configured request intervals benefit as well.

## Tests

- `tests/test_search_site_throttle.py`
- `tests/test_search_page_orchestration.py`
- `tests/test_search_sync_async_parity.py`

20 focused tests passed on Python 3.14t.

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at e50526578c89308203fb1e7c6a14b1f1e072d955

- 线程池搜索改用模块级请求包装器
- 保留站点限流等待及搜索参数
- 避免闭包扩大线程任务所有权
- 未新增或更新测试
<!-- pr-agent-summary:end -->
