### PR TITLE
优化 Docker 镜像复制层

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -268,17 +268,21 @@ FROM prepare_payload AS prepare_control
 WORKDIR /control
 
 COPY docker/ ./
-RUN mkdir -p /bundle/control /bundle/nginx /bundle/bin \
-    && find . -maxdepth 1 -type f -name '*.sh' ! -name 'launcher.sh' -exec cp -f -t /bundle/control {} + \
-    && cp -f launcher.sh /bundle/entrypoint.sh \
-    && cp -f nginx.common.conf /bundle/nginx/common.conf \
-    && cp -f nginx.template.conf /bundle/nginx/nginx.template.conf \
-    && cp -f docker_http_proxy.conf /bundle/nginx/docker_http_proxy.conf \
-    && printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail' 'cd /app' 'exec "${VENV_PATH:-/opt/venv}/bin/python3" -m app.cli "$@"' > /bundle/bin/moviepilot \
-    && bash -n /bundle/entrypoint.sh \
-    && for control_script in /bundle/control/*.sh; do bash -n "${control_script}" || exit 1; done \
-    && chmod 755 /bundle/entrypoint.sh /bundle/bin/moviepilot \
-    && chmod 500 /bundle/control/*.sh
+RUN mkdir -p \
+    /bundle/rootfs/etc/nginx \
+    /bundle/rootfs/usr/local/bin \
+    /bundle/rootfs/usr/local/lib/moviepilot/control \
+    && find . -maxdepth 1 -type f -name '*.sh' ! -name 'launcher.sh' \
+    -exec cp -f -t /bundle/rootfs/usr/local/lib/moviepilot/control {} + \
+    && cp -f launcher.sh /bundle/rootfs/entrypoint.sh \
+    && cp -f nginx.common.conf /bundle/rootfs/etc/nginx/common.conf \
+    && cp -f nginx.template.conf /bundle/rootfs/etc/nginx/nginx.template.conf \
+    && cp -f docker_http_proxy.conf /bundle/rootfs/etc/nginx/docker_http_proxy.conf \
+    && printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail' 'cd /app' 'exec "${VENV_PATH:-/opt/venv}/bin/python3" -m app.cli "$@"' > /bundle/rootfs/usr/local/bin/moviepilot \
+    && bash -n /bundle/rootfs/entrypoint.sh \
+    && for control_script in /bundle/rootfs/usr/local/lib/moviepilot/control/*.sh; do bash -n "${control_script}" || exit 1; done \
+    && chmod 755 /bundle/rootfs/entrypoint.sh /bundle/rootfs/usr/local/bin/moviepilot \
+    && chmod 500 /bundle/rootfs/usr/local/lib/moviepilot/control/*.sh
 
 # final 阶段: 安装运行时依赖和配置最终镜像
 FROM prepare_package AS final
@@ -287,8 +291,7 @@ ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so" \
     MOVIEPILOT_DOCKER_KEEPALIVE_ON_FAILURE="true"
 
 # 引入支持 amr 编码的静态 ffmpeg
-COPY --from=ffmpeg /ffmpeg /usr/local/bin/
-COPY --from=ffmpeg /ffprobe /usr/local/bin/
+COPY --from=ffmpeg /ffmpeg /ffprobe /usr/local/bin/
 COPY --from=rclone /usr/local/bin/rclone /usr/bin/rclone
 
 # python 环境
@@ -306,12 +309,7 @@ RUN playwright install-deps chromium \
     /var/tmp/*
 
 # 准备容器控制面和运行目录
-COPY --from=prepare_control /bundle/entrypoint.sh /entrypoint.sh
-COPY --from=prepare_control /bundle/control /usr/local/lib/moviepilot/control
-COPY --from=prepare_control /bundle/nginx/common.conf /etc/nginx/common.conf
-COPY --from=prepare_control /bundle/nginx/nginx.template.conf /etc/nginx/nginx.template.conf
-COPY --from=prepare_control /bundle/nginx/docker_http_proxy.conf /etc/nginx/docker_http_proxy.conf
-COPY --from=prepare_control /bundle/bin/moviepilot /usr/local/bin/moviepilot
+COPY --link --from=prepare_control /bundle/rootfs/ /
 
 RUN mkdir -p ${HOME} \
     && groupadd -r moviepilot -g 918 \

--- a/tests/test_docker_bootstrap.py
+++ b/tests/test_docker_bootstrap.py
@@ -42,18 +42,22 @@ def test_dockerfile_control_bundle_build_checks_fail_closed() -> None:
     assert "requirements.in" not in dockerfile
     assert "${VENV_PATH}/bin/pip" not in dockerfile
     assert "FROM prepare_payload AS prepare_control" in dockerfile
-    assert "-exec cp -f -t /bundle/control {} +" in dockerfile
-    assert "bash -n /bundle/entrypoint.sh" in dockerfile
     assert (
-        "COPY --from=prepare_control /bundle/control "
-        "/usr/local/lib/moviepilot/control" in dockerfile
+        "-exec cp -f -t /bundle/rootfs/usr/local/lib/moviepilot/control {} +"
+        in dockerfile
+    )
+    assert "bash -n /bundle/rootfs/entrypoint.sh" in dockerfile
+    assert (
+        "COPY --link --from=prepare_control /bundle/rootfs/ /" in dockerfile
     )
     assert 'ENTRYPOINT [ "/usr/bin/tini", "-g", "--", "/entrypoint.sh" ]' in dockerfile
     assert "CMD /usr/bin/curl -fsS" in dockerfile
     assert '"http://127.0.0.1:${PORT:-3001}/health/ready"' in dockerfile
     assert "system/global?token=moviepilot" not in dockerfile
     assert (
-        'for control_script in /bundle/control/*.sh; do bash -n "${control_script}" || exit 1; done'
+        "for control_script in "
+        '/bundle/rootfs/usr/local/lib/moviepilot/control/*.sh; do '
+        'bash -n "${control_script}" || exit 1; done'
         in dockerfile
     )
 

--- a/tests/test_docker_payload_contract.py
+++ b/tests/test_docker_payload_contract.py
@@ -75,7 +75,10 @@ def test_dockerfile_assigns_each_payload_to_an_independent_stage() -> None:
     assert positions == sorted(positions)
     for copy in copies:
         assert final.count(copy) == 1
-    assert "COPY --from=prepare_control /bundle/entrypoint.sh /entrypoint.sh" in final
+    assert "COPY --link --from=prepare_control /bundle/rootfs/ /" in final
+    assert final.count("--from=prepare_control ") == 1
+    assert "COPY --from=ffmpeg /ffmpeg /ffprobe /usr/local/bin/" in final
+    assert final.count("COPY --from=ffmpeg ") == 1
     assert "RUN rm -rf /app/frontend-dist" in dockerfile
 
 


### PR DESCRIPTION
## 说明

V3 镜像 final 阶段将体积很小、始终共同变化的控制面文件拆成了 6 个独立 `COPY` 层，同时 `ffmpeg` 与 `ffprobe` 也分别复制。这样的拆分没有带来有效缓存收益，反而增加了镜像层数。

## 调整

- 在 `prepare_control` 阶段组装控制面 rootfs，并通过一次 `COPY --link` 写入最终镜像。
- 将同版本更新的 `ffmpeg` 与 `ffprobe` 合并为一次多源 `COPY`。
- 更新 Docker 载荷合同测试，约束控制面和 ffmpeg 工具只各生成一个复制层。

本次不改变 `/app/docker`、核心后端载荷层或 Python 变体结构。

## 验证

- `python -m pytest tests/test_docker_bootstrap.py::test_dockerfile_control_bundle_build_checks_fail_closed tests/test_docker_payload_contract.py`：7 passed
- 标准 arm64 镜像完整构建通过，RootFS 从 24 层降至 18 层
- 标准及 free-threaded Dockerfile build check 无警告
- 容器内入口脚本、控制脚本、nginx 配置、`ffmpeg` 与 `ffprobe` 内容及权限探测通过
- `git diff --check`

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at c1851866269c853ea27d228c31f8244c0f6bfcef

- 合并控制面文件为单个 `COPY --link` 层
- 合并 `ffmpeg`、`ffprobe` 的复制层
- 保持镜像路径、权限与运行行为不变
- 更新 Docker 载荷层数合同测试
- 风险：依赖 BuildKit 的 `--link` 支持
<!-- pr-agent-summary:end -->
