### PR TITLE
fix(agent): inject context into custom agent factories

### DIFF
--- a/app/agent/session.py
+++ b/app/agent/session.py
@@ -563,6 +563,12 @@ class AgentSessionOwner:
                     "output_callback": task.output_callback,
                     "protected_output_callback": task.protected_output_callback,
                 }
+                if isinstance(task.agent_factory, type) and issubclass(
+                    task.agent_factory,
+                    MoviePilotAgent,
+                ):
+                    agent_kwargs["data"] = self._data
+                    agent_kwargs["memory"] = self._memory
                 if task.message_callback is not None:
                     agent_kwargs["message_callback"] = task.message_callback
                 agent = task.agent_factory(**agent_kwargs)

--- a/tests/test_agent_lifecycle.py
+++ b/tests/test_agent_lifecycle.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import app.agent.orchestrator as agent_module
+import app.agent.session as agent_session
 from app.agent.memory import MemoryManager
 from app.agent.orchestrator import (
     AGENT_SESSION_QUEUE_MAX_SIZE,
@@ -20,6 +21,32 @@ from app.application.messaging.agent import (
 from app.sdk import queries as query_sdk
 from app.startup.initializers import agent as agent_initializer
 from app.startup.initializers import modules as modules_initializer
+
+
+@pytest.mark.anyio
+async def test_custom_moviepilot_agent_factory_receives_runtime_context() -> None:
+    """Web/OpenAI Agent 子类必须复用 manager 装配的数据与记忆上下文。"""
+    data = MagicMock()
+    memory = MagicMock()
+    manager = AgentManager(data=data, memory=memory)
+
+    class CustomMoviePilotAgent(agent_module.MoviePilotAgent):
+        async def process(self, message: str, **kwargs: object) -> str:
+            return message
+
+    result = await manager._process_message_internal(
+        agent_session._MessageTask(
+            session_id="custom-context",
+            user_id="1",
+            message="ok",
+            agent_factory=CustomMoviePilotAgent,
+        )
+    )
+
+    agent = manager.active_agents["custom-context"]
+    assert result == "ok"
+    assert agent._data is data
+    assert agent._memory is memory
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## 问题

WebAgent 和 OpenAI 兼容入口通过 `agent_factory` 创建 `MoviePilotAgent` 子类，但自定义工厂分支未传入 AgentManager 已装配的 `data` 与 `memory`。因此 Web 聊天中的 `agent_task` 等数据工具会稳定报错：`Agent 工具数据上下文尚未注入`。

## 修改

- 当自定义工厂是 `MoviePilotAgent` 子类时，注入 manager 的同一份 `data` 和 `memory`
- 保持非 MoviePilotAgent 自定义工厂的现有构造合同不变
- 增加回归测试，覆盖自定义 Agent 工厂的数据与记忆上下文传递

## 验证

- 在最新 `moviepilot-v3t` Python 3.14 运行环境中完成构造级回归验证
- `scripts/architecture/complexity.py` 通过
- `git diff --check` 通过

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at dc59e08e08d7a7faf753fc7a157956c647c8d491

- 为 `MoviePilotAgent` 自定义工厂注入上下文
- 保持其他工厂构造参数兼容
- 新增数据与记忆传递回归测试
- 风险：仅覆盖 Agent 子类工厂路径
<!-- pr-agent-summary:end -->
