### PR TITLE
fix(doctor): 解决 Windows Free-Threading环境下 诊断机制报 DLL 问题

### DIFF
--- a/app/doctor/dependencies.py
+++ b/app/doctor/dependencies.py
@@ -1,10 +1,17 @@
 """主程序运行依赖的轻量可用性探针。"""
 
 import argparse
+import os
+import shutil
 from importlib import import_module
 import sys
 import sysconfig
 import warnings
+
+if os.name == "nt":
+    psql_exe = shutil.which("psql")
+    if psql_exe:
+        getattr(os, "add_dll_directory")(os.path.dirname(psql_exe))
 
 
 CORE_MODULES = (


### PR DESCRIPTION
- 添加 os 和 shutil 模块导入
- 在 Windows 环境下查找并添加 PostgreSQL 可执行文件目录到 DLL 搜索路径
- 使用 add_dll_directory 确保 PostgreSQL 相关库正确加载

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at d263919045a6e29d197b3c35b16da3484342a335

- 修复 Windows 诊断加载 PostgreSQL DLL
- 自动加入 `psql` 所在 DLL 搜索路径
- 降低 Free-Threading 环境依赖探针失败风险
<!-- pr-agent-summary:end -->
