### PR TITLE
修复宿主模块配置变更未触发生命周期协调

### DIFF
--- a/app/runtime/extensions/module/manager.py
+++ b/app/runtime/extensions/module/manager.py
@@ -135,7 +135,12 @@ class ModuleManager(metaclass=Singleton):
         self,
         owner_class: type,
     ) -> Optional[EventHandlerBinding]:
-        """按 canonical class identity 绑定当前 generation，停止态阻断 fallback 构造。"""
+        """按类型身份绑定管理器自身或运行模块，停止态阻断 fallback 构造。"""
+        if owner_class is type(self):
+            return EventHandlerBinding(
+                instance=self,
+                owner_name=type(self).__name__,
+            )
         for spec in self._specs:
             with self._lock:
                 implementation = self._modules.get(spec.id)

--- a/tests/test_module_manager_capability_adapter.py
+++ b/tests/test_module_manager_capability_adapter.py
@@ -499,6 +499,31 @@ def test_config_event_reloads_same_instance_and_tracks_selector_changes(
     assert running.events == ["create", "start", "stop", "start", "stop"]
 
 
+def test_registered_config_event_activates_newly_enabled_module(
+    module_manager_harness,
+) -> None:
+    """事件总线必须把配置变更绑定回当前 ModuleManager 实例。"""
+    manager = module_manager_harness.manager
+    handler = next(
+        listener
+        for listener in _config_changed_listeners().values()
+        if getattr(listener, "__self__", None) is manager
+    )
+    _enable_sample(module_manager_harness.config_values)
+
+    eventmanager._EventManager__invoke_handler_by_type_sync(
+        handler,
+        Event(
+            EventType.ConfigChanged,
+            ConfigChangeEventData(key="Notifications"),
+        ),
+    )
+
+    running = manager.get_running_module("SampleModule")
+    assert running is not None
+    assert running.events == ["create", "start"]
+
+
 def test_shutdown_is_irreversible(module_manager_harness, monkeypatch) -> None:
     """shutdown 撤销全部可见实例，并拒绝通过 load_modules 再次启动。"""
     manager = module_manager_harness.manager


### PR DESCRIPTION
## 问题

运行期间修改 Host Module 配置后，`ModuleManager` 注册的 `ConfigChanged` 处理器无法被显式 resolver 解析回当前管理器实例，事件会被跳过。配置虽然已经保存，但对应 Host Module 不会按新配置启动、停止或重载。

## 处理

- 让 modules resolver 同时绑定当前 `ModuleManager` 实例和运行中的 Host Module 实例。
- 增加事件总线级回归测试，验证新启用的 Host Module 能通过真实配置事件完成激活。

## 验证

- 关键配置生命周期回归：2 项通过。
- 模块生命周期、事件绑定与调度相关测试：41 项通过。
- 后端完整测试分片：1709 项通过，3 项跳过。
- `pylint app/runtime/extensions/module/manager.py`：10.00/10。
- `git diff --check upstream/v3...HEAD`：通过。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 7874a3c08c57d42e2ac70469dd6c47bcee325ca3

- 修复配置事件无法解析模块管理器
- 支持配置变更启停宿主模块
- 新增真实事件总线激活回归测试
- 兼容性影响：恢复既有配置生命周期行为
<!-- pr-agent-summary:end -->
