### PR TITLE
fix(plex): 跳过缺少季号或集号的条目

### DIFF
--- a/app/modules/plex/plex.py
+++ b/app/modules/plex/plex.py
@@ -353,6 +353,9 @@ class Plex:
         for episode in episodes:
             if season is not None and episode.seasonNumber != int(season):
                 continue
+            # Plex 空条目可能缺少季集号，不能传入后续季集模型校验。
+            if episode.seasonNumber is None or episode.index is None:
+                continue
             if episode.seasonNumber not in season_episodes:
                 season_episodes[episode.seasonNumber] = []
             season_episodes[episode.seasonNumber].append(episode.index)

--- a/tests/test_plex_episode_numbers.py
+++ b/tests/test_plex_episode_numbers.py
@@ -1,0 +1,48 @@
+from types import SimpleNamespace
+from typing import Optional
+from unittest.mock import Mock
+
+import pytest
+
+from app.modules.plex.plex import Plex
+from app.schemas.types import MediaSource
+
+
+@pytest.mark.parametrize(
+    ("numbers", "season", "expected"),
+    [
+        ([(None, 1), (1, None), (None, None), (1, 2)], None, {1: [2]}),
+        ([(None, 1), (1, None), (1, 2), (2, 1)], 1, {1: [2]}),
+        ([(None, 1), (1, None), (None, None)], None, {}),
+        ([(0, 1), (1, 0), (1, 2)], None, {0: [1], 1: [0, 2]}),
+        ([(0, 1), (1, 1)], 0, {0: [1]}),
+    ],
+    ids=["missing-numbers", "season-filter", "all-invalid", "preserve-zero", "specials"],
+)
+def test_plex_tv_episodes_skips_missing_numbers(
+    numbers: list[tuple[Optional[int], Optional[int]]],
+    season: Optional[int],
+    expected: dict[int, list[int]],
+) -> None:
+    """缺失季集号不能进入同步结果，合法的零值和季过滤应保持不变。"""
+    plex = Plex.__new__(Plex)
+    plex._plex = Mock()
+    show = Mock()
+    show.key = "/library/metadata/123"
+    show.guids = [{"id": "tmdb://12345"}]
+    show.episodes.return_value = [
+        SimpleNamespace(seasonNumber=season_number, index=episode_number)
+        for season_number, episode_number in numbers
+    ]
+    plex._plex.fetchItem.return_value = show
+
+    item_id, episodes = plex.get_tv_episodes(
+        item_id="123",
+        media_source=MediaSource.TMDB,
+        media_id="12345",
+        season=season,
+    )
+
+    assert item_id == show.key
+    assert episodes == expected
+    plex._plex.library.search.assert_not_called()


### PR DESCRIPTION
Plex 返回缺少 `seasonNumber` 或 `index` 的集条目时，`get_tv_episodes()` 会把 `None` 放入季集映射，导致后续季集模型校验失败。此修改跳过这类条目，保留有效剧集、季过滤以及合法的第 0 季/第 0 集。

新增参数化回归测试覆盖缺季号、缺集号、全部无效、季过滤和零值。未修改其他媒体服务器逻辑、配置或依赖。

验证：
- 在当前官方 v3 基线上，新测试复现 3 项失败、2 项通过；应用修复后，新增测试和现有 Plex 图片查询、媒体 ID 失效回退测试共 15 项通过。
- 两个改动文件通过项目配置的 Pylint 检查（10.00/10），`git diff --check` 通过。
- 测试运行于独立、断网的 Python 3.14.7 容器，使用项目 conftest 的临时数据库和网络守卫，无真实服务访问。
- 本地复用官方运行镜像依赖并额外安装 pytest/Pylint，未执行 `uv sync --locked` 或全量测试；因未安装 pytest-asyncio/pytest-timeout，出现 5 条对应配置项警告。全部受影响用例为同步测试；锁定环境和全量测试由 CI 继续验证。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 08b5e9d34c023f8f4dcdac5da70cb3e717802c91

- 跳过缺失季号或集号的 Plex 剧集
- 保留第 0 季、第 0 集与季筛选
- 新增参数化回归测试覆盖异常条目
- 兼容性影响：仅忽略无效 Plex 数据
<!-- pr-agent-summary:end -->
