### PR TITLE
fix(history): 请求级下载历史仓储补齐 async_count，修复下载历史接口 500

### DIFF
--- a/app/db/adapters/history/download.py
+++ b/app/db/adapters/history/download.py
@@ -287,6 +287,12 @@ class SessionDownloadHistoryRepository:
         )
         return [_project_history(record) for record in records]
 
+    async def async_count(self) -> int:
+        """在请求异步 Session 内统计下载历史总数。"""
+        if not isinstance(self._session, AsyncSession):
+            raise RuntimeError("下载历史异步统计需要 AsyncSession")
+        return await DownloadHistoryOper(self._session).async_count()
+
     def stage_delete_history(self, history_id: int) -> None:
         """在请求同步 Session 内暂存下载历史删除。"""
         if not isinstance(self._session, Session):

--- a/tests/test_transactional_download_history.py
+++ b/tests/test_transactional_download_history.py
@@ -205,3 +205,27 @@ def test_session_repository_obeys_caller_transaction(db) -> None:
         repository.stage_delete_history(history.id)
         session.commit()
     assert _repository().get_by_hash("request-history-hash") is None
+
+
+def test_session_repository_counts_history_in_caller_async_session(db) -> None:
+    """请求级 adapter 在调用方 AsyncSession 内统计总数，与分页读取口径一致。"""
+    repository = _repository()
+    baseline_count = asyncio.run(repository.async_count())
+    history_id = repository.add(_history_write(download_hash="request-async-count-hash"))
+
+    async def exercise() -> tuple[int, list[DownloadHistorySnapshot]]:
+        """在同一请求 AsyncSession 内先统计总数再分页读取。"""
+        async with async_session_scope() as session:
+            session_repository = SessionDownloadHistoryRepository(session)
+            total = await session_repository.async_count()
+            records = await session_repository.async_list_by_page(count=10)
+            return total, records
+
+    total, records = asyncio.run(exercise())
+
+    assert total == baseline_count + 1
+    assert any(record.id == history_id for record in records)
+
+    with SessionFactory() as session:
+        with pytest.raises(RuntimeError):
+            asyncio.run(SessionDownloadHistoryRepository(session).async_count())


### PR DESCRIPTION
## 问题

v3 Web 端「下载历史」页面始终加载失败，重试后提示「未知错误」。后端日志中 `GET /api/v1/history/download?page=1&count=30` 全部返回 500，堆栈如下：

```
File "/app/app/application/history.py", line 701, in count_download
    return await self._download_repository.async_count()
AttributeError: 'SessionDownloadHistoryRepository' object has no attribute 'async_count'
```

「整理历史」接口不受影响。

## 根因

`HistoryQueryService.count_download()` 依赖 `AsyncDownloadHistoryQueryRepository` 协议中的 `async_count()`，`download_history` 端点在写入分页总数响应头时会调用它。

`app/startup/composition/runtime.py` 给 `HistoryQueryService` 注入的是请求级适配器 `SessionDownloadHistoryRepository`，但该类只实现了 `async_list_by_page()`，没有实现协议要求的 `async_count()`；`async_count()` 目前只存在于 `TransactionalDownloadHistoryRepository`。于是列表查询成功后，统计总数这一步直接抛 `AttributeError`，整个请求以 500 结束。

## 修改

- `app/db/adapters/history/download.py`：为 `SessionDownloadHistoryRepository` 补齐 `async_count()`，在请求持有的 `AsyncSession` 内调用 `DownloadHistoryOper.async_count()`，Session 类型校验与同类的 `async_list_by_page()` 保持一致（非 `AsyncSession` 时抛 `RuntimeError`）。
- 最小改动，不涉及模型、迁移或其他调用方。

## 测试

- `tests/test_transactional_download_history.py` 新增 `test_session_repository_counts_history_in_caller_async_session`：在请求级 `AsyncSession` 内统计总数与分页读取口径一致，并覆盖同步 `Session` 传入时的 `RuntimeError` 保护。该用例在修复前会以同样的 `AttributeError` 失败。
- 本地 `uv run --locked --no-sync python tests/run.py` 全量 4 分片全部通过（0 failed，5 skipped）；`pylint` 改动的两个文件 10.00/10。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at fae87d68bff0face997612be8c003878e3e1ed73

- 补齐请求级下载历史异步计数
- 修复下载历史分页接口 500
- 增加 AsyncSession 计数回归测试
- 保持同步会话类型保护
<!-- pr-agent-summary:end -->
