### PR TITLE
fix: 支持目录配置匹配多个媒体类别

### DIFF
--- a/app/helper/directory.py
+++ b/app/helper/directory.py
@@ -74,7 +74,8 @@ class DirectoryHelper:
                 return dir_info
             if dir_info.media_type == media_type and not dir_info.media_category:
                 return dir_info
-            if dir_info.media_type == media_type and dir_info.media_category == media.category:
+            if dir_info.media_type == media_type and _match_media_category(
+                    dir_info.media_category, media.category):
                 return dir_info
         return None
 
@@ -136,8 +137,8 @@ class DirectoryHelper:
             if d.media_type == media_type and not d.media_category:
                 matched_dirs.append(d)
                 continue
-            # 目录类型相等，目录类别相等，符合条件
-            if d.media_type == media_type and d.media_category == media.category:
+            # 目录类型相等，目录类别命中配置，符合条件
+            if d.media_type == media_type and _match_media_category(d.media_category, media.category):
                 matched_dirs.append(d)
                 continue
         if matched_dirs:
@@ -208,6 +209,20 @@ class DirectoryHelper:
         # 媒体根路径
         media_root = rename_path.parents[rename_format_level - 1]
         return media_root
+
+
+def _match_media_category(configured_category: Optional[str], media_category: Optional[str]) -> bool:
+    """
+    判断媒体类别是否命中目录配置，支持逗号分隔的多个类别。
+    """
+    if not configured_category or not media_category:
+        return False
+    categories = {
+        category.strip()
+        for category in re.split(r"[,，]", configured_category)
+        if category.strip()
+    }
+    return media_category.strip() in categories
 
 
 def _split_file_uri(value: str) -> Tuple[str, str]:

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.helper.directory import DirectoryHelper
+from app.schemas import TransferDirectoryConf
+
+
+def _media(category: str):
+    """构造目录匹配测试所需的媒体信息。"""
+    return SimpleNamespace(
+        type=SimpleNamespace(value="电视剧"),
+        category=category,
+    )
+
+
+def _directory(media_category: str) -> TransferDirectoryConf:
+    """构造启用自动整理的动漫目录配置。"""
+    return TransferDirectoryConf(
+        name="动漫",
+        priority=1,
+        storage="local",
+        download_path="/media/anime",
+        media_type="电视剧",
+        media_category=media_category,
+        monitor_type="monitor",
+        library_path="/media/link/anime",
+        library_storage="local",
+    )
+
+
+@pytest.mark.parametrize("configured_category", ["日番", "日番,日韩剧", "日番，日韩剧", " 日番 , 日韩剧 "])
+def test_get_dir_matches_media_category_list(monkeypatch, configured_category):
+    """自动整理应匹配目录配置中逗号分隔的任一媒体类别。"""
+    directory = _directory(configured_category)
+    monkeypatch.setattr(DirectoryHelper, "get_dirs", staticmethod(lambda: [directory]))
+
+    matched = DirectoryHelper().get_dir(
+        media=_media("日番"),
+        storage="local",
+        src_path=Path("/media/anime/demo.mkv"),
+    )
+
+    assert matched == directory
+
+
+def test_get_dir_rejects_unconfigured_media_category(monkeypatch):
+    """自动整理不应匹配目录配置中不存在的媒体类别。"""
+    directory = _directory("日番,日韩剧")
+    monkeypatch.setattr(DirectoryHelper, "get_dirs", staticmethod(lambda: [directory]))
+
+    matched = DirectoryHelper().get_dir(
+        media=_media("欧美剧"),
+        storage="local",
+        src_path=Path("/media/anime/demo.mkv"),
+    )
+
+    assert matched is None
+
+
+def test_get_download_dir_by_save_path_matches_media_category_list(monkeypatch):
+    """精确保存根路径应继承逗号分隔的媒体类别规则。"""
+    directory = _directory("日番,日韩剧")
+    monkeypatch.setattr(DirectoryHelper, "get_download_dirs", lambda _self: [directory])
+
+    matched = DirectoryHelper().get_download_dir_by_save_path(
+        media=_media("日韩剧"),
+        save_path="/media/anime",
+    )
+
+    assert matched == directory


### PR DESCRIPTION
## 问题

目录设置允许同时选择多个媒体类别，并以逗号分隔字符串保存，例如 `日番,日韩剧`。当前 `DirectoryHelper` 使用严格字符串相等判断目录类别，自动整理识别出的单一类别 `日番` 无法匹配该配置，最终提示“未找到有效的媒体库目录”；手动指定目标目录则可以绕过该判断。

## 修复

- 新增私有类别匹配函数，将配置值按半角/全角逗号拆分并去除两侧空格
- `get_dir()` 与 `get_download_dir_by_save_path()` 统一使用成员匹配
- 保持单类别配置与类别不匹配时的原有行为

## 测试

- `pytest -v tests/test_directory.py`：6 passed
- `pylint app/helper/directory.py`：10.00/10
- 变异验证：临时恢复严格相等逻辑后，4 个多类别用例按预期失败
- `python tests/run.py`（Windows / Python 3.12）：2413 passed, 1 skipped, 55 failed。55 个失败集中在 Windows/Linux 平台差异及既有无关模块；本 PR 新增的目录测试全部通过。CI 的 Linux 环境可进一步验证全量结果。

## 实际环境验证

在 MoviePilot v2.15.6 容器中使用真实配置 `media_category=日番,日韩剧` 验证：

- `日番` → 自动匹配“动漫”目录
- `日韩剧` → 自动匹配“动漫”目录
- 目标目录均为 `/media/link/anime`

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 54cad2a38ec0c7afe8d7e9a4c84cf9145e23cca2

- 支持目录配置匹配多个媒体类别
- 兼容中英文逗号及空格
- 下载与整理流程复用匹配逻辑
- 新增多类别匹配回归测试
<!-- pr-agent-summary:end -->
