### PR TITLE
fix: preserve selected music metadata in manual downloads

### DIFF
--- a/app/api/endpoints/download.py
+++ b/app/api/endpoints/download.py
@@ -25,6 +25,7 @@ from app.chain.media import MediaChain
 from app.domain.context import Context, MediaInfo, MusicInfo, SubtitleInfo, TorrentInfo
 from app.domain.media import is_music_media_source, normalize_music_type
 from app.domain.meta.metabase import MetaBase
+from app.domain.meta.metamusic import MetaMusic
 from app.domain.metainfo import MetaInfo
 from app.schemas.common import ServiceClientInfo as _SchemaServiceClientInfo
 from app.schemas.download import DownloadAddedData as _SchemaDownloadAddedData
@@ -116,6 +117,44 @@ def _build_unrecognized_media_info(
         title=metainfo.name or torrent.title,
         year=metainfo.year,
     )
+
+
+def _merge_selected_music_meta(
+    metainfo: MetaBase,
+    mediainfo: MusicInfo,
+    torrent_title: str,
+) -> MetaBase:
+    """保留种子解析证据，并补齐已选音乐实体中缺失的高可信字段。"""
+    if not isinstance(metainfo, MetaMusic):
+        return metainfo
+
+    # MetaInfo 可能已经从种子标题解析出曲名、艺人和音质；这些资源证据优先保留。
+    # 但资源标题常省略所属专辑，整理历史随后又依赖 MetaMusic，因此把目标实体中
+    # 尚未解析出的身份字段补回。媒体来源和 ID 仍只放在 media_info，避免重复身份。
+    for field_name in (
+        "title",
+        "artists",
+        "album",
+        "album_artist",
+        "year",
+        "disc_number",
+        "track_number",
+        "total_discs",
+        "total_tracks",
+        "version",
+        "isrc",
+    ):
+        current_value = getattr(metainfo, field_name, None)
+        selected_value = getattr(mediainfo, field_name, None)
+        if current_value in (None, "", []) and selected_value not in (None, "", []):
+            setattr(
+                metainfo,
+                field_name,
+                list(selected_value) if isinstance(selected_value, list) else selected_value,
+            )
+    # org_string 应保留用户实际选择的种子标题，而不是识别词处理后的副本。
+    metainfo.org_string = torrent_title
+    return metainfo
 
 
 def _resolve_add_media(
@@ -232,6 +271,8 @@ def download(
         mediainfo = MediaInfo()
         mediainfo.from_dict(media_in.model_dump())
     metainfo = MetaInfo(title=torrent_in.title, subtitle=torrent_in.description, mtype=mediainfo.type)
+    if isinstance(mediainfo, MusicInfo):
+        metainfo = _merge_selected_music_meta(metainfo, mediainfo, torrent_in.title)
     # 种子信息
     torrentinfo = TorrentInfo()
     torrentinfo.from_dict(torrent_in.model_dump())

--- a/tests/test_music_download.py
+++ b/tests/test_music_download.py
@@ -171,6 +171,33 @@ def test_download_endpoint_builds_music_context():
     assert context.meta_info.type == MediaType.MUSIC
     assert context.meta_info.org_string == "周杰伦 - 叶惠美 FLAC"
     assert context.meta_info.title == "叶惠美"
+    assert context.meta_info.album == "叶惠美"
+    assert context.meta_info.media_id is None
+
+
+def test_download_endpoint_preserves_selected_music_album_when_resource_omits_it():
+    """单曲种子标题省略专辑时，下载上下文仍应保留已选媒体的专辑身份。"""
+    chain = Mock()
+    chain.download_single.return_value = "hash-1"
+
+    with patch("app.api.endpoints.download.DownloadChain", return_value=chain):
+        response = download(
+            media_in=MusicInfoSchema(**_music_info().to_dict()),
+            torrent_in=TorrentInfo(
+                title="周杰伦 - 晴天 FLAC",
+                enclosure="https://example.com/download?id=2",
+                category="音乐",
+            ),
+            downloader="qb",
+            save_path=None,
+            current_user=Mock(name="admin"),
+        )
+
+    assert response.success is True
+    context = chain.download_single.call_args.kwargs["context"]
+    assert context.meta_info.title == "晴天"
+    assert context.meta_info.album == "叶惠美"
+    assert context.meta_info.org_string == "周杰伦 - 晴天 FLAC"
     assert context.meta_info.media_id is None
 
 


### PR DESCRIPTION
## Problem
The manual download endpoint rebuilt `MetaMusic` only from the torrent title after the recent refactor. When a recording torrent omits its album name, the selected `MusicInfo.album` and related target metadata were lost. Transfer-history restoration relies on the saved `MetaMusic`, so tagless audio could no longer retain the selected album context.

## Fix
Keep parsed torrent evidence first, then fill only missing music metadata from the selected `MusicInfo`. Keep the source ID exclusively in `media_info` and preserve the original torrent title in `org_string`.

## Verification
- `python3 -m py_compile app/api/endpoints/download.py tests/test_music_download.py`
- `git diff --check`
- Added regression coverage for a single-track torrent whose title omits the album.
- The configured environments do not have `pytest` installed, so the targeted pytest command could not run.

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 38c2a841cafaed30e7cbbee1b0b2cf542277079b

- 保留手动音乐下载的已选元数据
- 种子解析字段优先，补齐缺失专辑
- 保持原始种子标题及来源 ID 边界
- 新增缺失专辑的回归覆盖
<!-- pr-agent-summary:end -->
