### PR TITLE
feat(agent): add loop detection middleware to interrupt repeated tool calls/outputs

### DIFF
--- a/app/agent/middleware/loop_detection.py
+++ b/app/agent/middleware/loop_detection.py
@@ -1,0 +1,216 @@
+"""MoviePilot 智能体循环检测中间件。
+
+用于识别并中断模型陷入的重复循环，避免"循环输出相同内容"或"反复调用
+同一工具"导致的无意义执行。
+
+检测两类循环：
+1. 重复工具调用：同一工具名 + 相同参数在短时间内被连续调用多次。
+2. 重复输出：模型连续多次生成相同或高度相似的回复文本。
+
+达到阈值时抛出 `AgentLoopDetectedError`，由 orchestrator 专门捕获并终止
+本轮 Agent 执行，同时向用户返回友好提示。
+"""
+
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from langchain.agents.middleware import AgentMiddleware, ToolCallRequest
+from langchain.agents.middleware.types import (
+    AgentState,
+    ContextT,
+    ModelRequest,
+    ModelResponse,
+    ResponseT,
+)
+from langchain_core.messages import AIMessage
+
+from app.runtime.log import logger
+
+
+class AgentLoopDetectedError(Exception):
+    """检测到模型陷入重复循环时抛出的异常。"""
+
+    def __init__(self, message: str, *, loop_type: str = "unknown") -> None:
+        super().__init__(message)
+        self.loop_type = loop_type
+
+
+# 连续重复多少次判定为循环
+DEFAULT_MAX_REPEATED_TOOL_CALLS = 3
+DEFAULT_MAX_REPEATED_OUTPUTS = 3
+# 输出文本相似度阈值（0~1），用于判断两条文本是否"高度相似"
+DEFAULT_OUTPUT_SIMILARITY_THRESHOLD = 0.95
+
+
+class LoopDetectionMiddleware(AgentMiddleware):
+    """检测并中断模型重复循环的中间件。
+
+    状态保存在中间件实例上，并在每次 Agent 执行开始时（``abefore_agent``）
+    重置，避免跨用户请求残留。
+    """
+
+    def __init__(
+        self,
+        *,
+        max_repeated_tool_calls: int = DEFAULT_MAX_REPEATED_TOOL_CALLS,
+        max_repeated_outputs: int = DEFAULT_MAX_REPEATED_OUTPUTS,
+        output_similarity_threshold: float = DEFAULT_OUTPUT_SIMILARITY_THRESHOLD,
+    ) -> None:
+        self._max_repeated_tool_calls = max_repeated_tool_calls
+        self._max_repeated_outputs = max_repeated_outputs
+        self._output_similarity_threshold = output_similarity_threshold
+        self._tool_call_history: list[str] = []
+        self._output_history: list[str] = []
+
+    # ------------------------------------------------------------------
+    # 状态重置
+    # ------------------------------------------------------------------
+    async def abefore_agent(
+        self,
+        state: AgentState,
+        runtime: Any,  # noqa: ARG002
+    ) -> None:
+        """每次 Agent 执行开始时重置循环检测状态。"""
+        self._tool_call_history = []
+        self._output_history = []
+        return None
+
+    # ------------------------------------------------------------------
+    # 工具调用签名规范化
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalize_tool_call_signature(tool_name: str, args: Any) -> str:
+        """把工具名和参数规范化为可比较的签名串。"""
+        try:
+            args_json = json.dumps(args, sort_keys=True, ensure_ascii=False, default=str)
+        except (TypeError, ValueError):
+            args_json = str(args)
+        return f"{tool_name}::{args_json}"
+
+    @staticmethod
+    def _is_repeating(history: list[str], max_repeats: int) -> bool:
+        """判断最近 ``max_repeats`` 条记录是否完全相同。"""
+        if len(history) < max_repeats:
+            return False
+        recent = history[-max_repeats:]
+        return len(set(recent)) == 1
+
+    # ------------------------------------------------------------------
+    # 重复工具调用检测
+    # ------------------------------------------------------------------
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[Any]],
+    ) -> Any:
+        """在工具执行前检测重复调用，命中循环则中断。"""
+        tool_call = request.tool_call or {}
+        tool_name = str(tool_call.get("name") or getattr(request.tool, "name", None) or "unknown")
+        args = tool_call.get("args") or {}
+        signature = self._normalize_tool_call_signature(tool_name, args)
+
+        self._tool_call_history.append(signature)
+        if self._is_repeating(self._tool_call_history, self._max_repeated_tool_calls):
+            logger.warning(
+                f"检测到重复工具调用循环: tool={tool_name}, "
+                f"连续 {self._max_repeated_tool_calls} 次相同调用"
+            )
+            raise AgentLoopDetectedError(
+                f"检测到重复工具调用循环（工具 {tool_name} 连续 "
+                f"{self._max_repeated_tool_calls} 次相同调用），已中断。",
+                loop_type="repeated_tool_call",
+            )
+
+        return await handler(request)
+
+    # ------------------------------------------------------------------
+    # 重复输出检测
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _extract_output_text(response: ModelResponse[Any]) -> str:
+        """从模型响应中提取纯文本输出。"""
+        for msg in reversed(response.result):
+            if isinstance(msg, AIMessage) and msg.content:
+                content = msg.content
+                if isinstance(content, list):
+                    parts = []
+                    for item in content:
+                        if isinstance(item, dict) and item.get("type") == "text":
+                            parts.append(str(item.get("text", "")))
+                    return "".join(parts)
+                return str(content)
+        return ""
+
+    @staticmethod
+    def _similarity(a: str, b: str) -> float:
+        """计算两条文本的相似度（0~1），基于字符集合与长度差异的简单近似。"""
+        if not a and not b:
+            return 1.0
+        if not a or not b:
+            return 0.0
+        if a == b:
+            return 1.0
+        # 使用最长公共子序列长度 / 较长串长度作为相似度近似
+        shorter, longer = (a, b) if len(a) <= len(b) else (b, a)
+        if not longer:
+            return 0.0
+        # 简单字符级 LCS（限制长度避免极端开销）
+        if len(shorter) > 2000:
+            shorter = shorter[:2000]
+            longer = longer[:2000]
+        prev = [0] * (len(shorter) + 1)
+        for ch in longer:
+            curr = [0] * (len(shorter) + 1)
+            for i, s_ch in enumerate(shorter, 1):
+                if ch == s_ch:
+                    curr[i] = prev[i - 1] + 1
+                else:
+                    curr[i] = max(prev[i], curr[i - 1])
+            prev = curr
+        lcs = prev[-1]
+        return lcs / max(len(longer), 1)
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[
+            [ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]
+        ],
+    ) -> ModelResponse[ResponseT]:
+        """在模型输出后检测重复文本，命中循环则中断。"""
+        response = await handler(request)
+        text = self._extract_output_text(response)
+        if not text:
+            return response
+
+        self._output_history.append(text)
+        if len(self._output_history) >= self._max_repeated_outputs:
+            recent = self._output_history[-self._max_repeated_outputs:]
+            # 全部完全相同
+            if len(set(recent)) == 1:
+                logger.warning(
+                    f"检测到重复输出循环: 连续 {self._max_repeated_outputs} 次相同文本"
+                )
+                raise AgentLoopDetectedError(
+                    f"检测到重复输出循环（连续 {self._max_repeated_outputs} 次相同内容），"
+                    "已中断。",
+                    loop_type="repeated_output",
+                )
+            # 高度相似（相邻两两相似度均超过阈值）
+            all_similar = all(
+                self._similarity(recent[i], recent[i + 1])
+                >= self._output_similarity_threshold
+                for i in range(len(recent) - 1)
+            )
+            if all_similar:
+                logger.warning(
+                    f"检测到高度相似的重复输出循环: 连续 {self._max_repeated_outputs} 次"
+                )
+                raise AgentLoopDetectedError(
+                    f"检测到高度相似的重复输出循环（连续 {self._max_repeated_outputs} 次"
+                    "内容高度相似），已中断。",
+                    loop_type="repeated_output",
+                )
+
+        return response

--- a/app/agent/middleware/loop_detection.py
+++ b/app/agent/middleware/loop_detection.py
@@ -136,7 +136,9 @@ class LoopDetectionMiddleware(AgentMiddleware):
                 if isinstance(content, list):
                     parts = []
                     for item in content:
-                        if isinstance(item, dict) and item.get("type") == "text":
+                        if isinstance(item, str):
+                            parts.append(item)
+                        elif isinstance(item, dict) and item.get("type") == "text":
                             parts.append(str(item.get("text", "")))
                     return "".join(parts)
                 return str(content)
@@ -144,32 +146,36 @@ class LoopDetectionMiddleware(AgentMiddleware):
 
     @staticmethod
     def _similarity(a: str, b: str) -> float:
-        """计算两条文本的相似度（0~1），基于字符集合与长度差异的简单近似。"""
+        """计算两条文本的相似度（0~1）。
+
+        使用字符 bigram 集合的 Jaccard 相似度，并叠加长度差异惩罚。
+        bigram 覆盖完整文本内容，能区分"相同前缀但后续不同"的文本，
+        同时计算开销为 O(n)，避免 LCS 在长文本上的 O(n*m) 开销。
+        """
         if not a and not b:
             return 1.0
         if not a or not b:
             return 0.0
         if a == b:
             return 1.0
-        # 使用最长公共子序列长度 / 较长串长度作为相似度近似
-        shorter, longer = (a, b) if len(a) <= len(b) else (b, a)
-        if not longer:
+
+        def _bigrams(s: str) -> set:
+            if len(s) <= 1:
+                return {s}
+            return {s[i:i + 2] for i in range(len(s) - 1)}
+
+        bigrams_a = _bigrams(a)
+        bigrams_b = _bigrams(b)
+        if not bigrams_a or not bigrams_b:
             return 0.0
-        # 简单字符级 LCS（限制长度避免极端开销）
-        if len(shorter) > 2000:
-            shorter = shorter[:2000]
-            longer = longer[:2000]
-        prev = [0] * (len(shorter) + 1)
-        for ch in longer:
-            curr = [0] * (len(shorter) + 1)
-            for i, s_ch in enumerate(shorter, 1):
-                if ch == s_ch:
-                    curr[i] = prev[i - 1] + 1
-                else:
-                    curr[i] = max(prev[i], curr[i - 1])
-            prev = curr
-        lcs = prev[-1]
-        return lcs / max(len(longer), 1)
+
+        intersection = len(bigrams_a & bigrams_b)
+        union = len(bigrams_a | bigrams_b)
+        jaccard = intersection / union if union else 0.0
+
+        # 长度差异惩罚：长度差异越大，相似度越低
+        len_ratio = min(len(a), len(b)) / max(len(a), len(b))
+        return jaccard * len_ratio
 
     async def awrap_model_call(
         self,

--- a/app/agent/middleware/loop_detection.py
+++ b/app/agent/middleware/loop_detection.py
@@ -9,11 +9,14 @@
 
 达到阈值时抛出 `AgentLoopDetectedError`，由 orchestrator 专门捕获并终止
 本轮 Agent 执行，同时向用户返回友好提示。
+
+循环检测状态保存在每次 Agent 执行的独立状态（``request.state``）中，而非
+中间件实例字段，避免共享同一已编译 Agent 的并发执行互相串扰。
 """
 
 import json
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Annotated, Any, NotRequired
 
 from langchain.agents.middleware import AgentMiddleware, ToolCallRequest
 from langchain.agents.middleware.types import (
@@ -21,6 +24,7 @@ from langchain.agents.middleware.types import (
     ContextT,
     ModelRequest,
     ModelResponse,
+    PrivateStateAttr,
     ResponseT,
 )
 from langchain_core.messages import AIMessage
@@ -43,12 +47,25 @@ DEFAULT_MAX_REPEATED_OUTPUTS = 3
 DEFAULT_OUTPUT_SIMILARITY_THRESHOLD = 0.95
 
 
+class LoopDetectionState(AgentState):
+    """循环检测中间件私有状态。"""
+
+    tool_call_history: NotRequired[Annotated[list[str], PrivateStateAttr]]
+    """当前这条 Agent 执行的工具调用签名历史。"""
+
+    output_history: NotRequired[Annotated[list[str], PrivateStateAttr]]
+    """当前这条 Agent 执行的模型输出文本历史。"""
+
+
 class LoopDetectionMiddleware(AgentMiddleware):
     """检测并中断模型重复循环的中间件。
 
-    状态保存在中间件实例上，并在每次 Agent 执行开始时（``abefore_agent``）
-    重置，避免跨用户请求残留。
+    循环检测状态保存在 ``request.state`` 中，并在每次 Agent 执行开始时
+    （``abefore_agent``）初始化，避免共享同一已编译 Agent 的并发执行互相
+    串扰。
     """
+
+    state_schema = LoopDetectionState
 
     def __init__(
         self,
@@ -60,21 +77,20 @@ class LoopDetectionMiddleware(AgentMiddleware):
         self._max_repeated_tool_calls = max_repeated_tool_calls
         self._max_repeated_outputs = max_repeated_outputs
         self._output_similarity_threshold = output_similarity_threshold
-        self._tool_call_history: list[str] = []
-        self._output_history: list[str] = []
 
     # ------------------------------------------------------------------
-    # 状态重置
+    # 状态初始化
     # ------------------------------------------------------------------
     async def abefore_agent(
         self,
         state: AgentState,
         runtime: Any,  # noqa: ARG002
-    ) -> None:
-        """每次 Agent 执行开始时重置循环检测状态。"""
-        self._tool_call_history = []
-        self._output_history = []
-        return None
+    ) -> dict[str, Any] | None:
+        """每次 Agent 执行开始时初始化循环检测状态。"""
+        return {
+            "tool_call_history": [],
+            "output_history": [],
+        }
 
     # ------------------------------------------------------------------
     # 工具调用签名规范化
@@ -110,8 +126,10 @@ class LoopDetectionMiddleware(AgentMiddleware):
         args = tool_call.get("args") or {}
         signature = self._normalize_tool_call_signature(tool_name, args)
 
-        self._tool_call_history.append(signature)
-        if self._is_repeating(self._tool_call_history, self._max_repeated_tool_calls):
+        history = list(request.state.get("tool_call_history") or [])
+        history.append(signature)
+        request.state["tool_call_history"] = history
+        if self._is_repeating(history, self._max_repeated_tool_calls):
             logger.warning(
                 f"检测到重复工具调用循环: tool={tool_name}, "
                 f"连续 {self._max_repeated_tool_calls} 次相同调用"
@@ -143,6 +161,14 @@ class LoopDetectionMiddleware(AgentMiddleware):
                     return "".join(parts)
                 return str(content)
         return ""
+
+    @staticmethod
+    def _has_tool_calls(response: ModelResponse[Any]) -> bool:
+        """判断模型响应是否包含工具调用（即是否还会继续执行）。"""
+        for msg in reversed(response.result):
+            if isinstance(msg, AIMessage):
+                return bool(msg.tool_calls)
+        return False
 
     @staticmethod
     def _similarity(a: str, b: str) -> float:
@@ -184,15 +210,24 @@ class LoopDetectionMiddleware(AgentMiddleware):
             [ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]
         ],
     ) -> ModelResponse[ResponseT]:
-        """在模型输出后检测重复文本，命中循环则中断。"""
+        """在模型输出后检测重复文本，命中循环则中断。
+
+        仅当模型响应仍包含工具调用（即 Agent 还会继续执行）时才检测，
+        避免把已正常结束的最终回复误判为循环。
+        """
         response = await handler(request)
+        if not self._has_tool_calls(response):
+            return response
+
         text = self._extract_output_text(response)
         if not text:
             return response
 
-        self._output_history.append(text)
-        if len(self._output_history) >= self._max_repeated_outputs:
-            recent = self._output_history[-self._max_repeated_outputs:]
+        history = list(request.state.get("output_history") or [])
+        history.append(text)
+        request.state["output_history"] = history
+        if len(history) >= self._max_repeated_outputs:
+            recent = history[-self._max_repeated_outputs:]
             # 全部完全相同
             if len(set(recent)) == 1:
                 logger.warning(

--- a/app/agent/orchestrator.py
+++ b/app/agent/orchestrator.py
@@ -33,6 +33,10 @@ from app.agent.middleware.config import RuntimeConfigMiddleware
 from app.agent.middleware.jobs import (
     JobsMiddleware,
 )
+from app.agent.middleware.loop_detection import (
+    AgentLoopDetectedError,
+    LoopDetectionMiddleware,
+)
 from app.agent.middleware.memory import MemoryMiddleware
 from app.agent.middleware.patching import PatchToolCallsMiddleware
 from app.agent.middleware.policy import AgentPolicyMiddleware
@@ -1950,6 +1954,8 @@ class MoviePilotAgent:
                 *([activity_log_middleware] if activity_log_middleware else []),
                 # 错误工具调用修复
                 PatchToolCallsMiddleware(),
+                # 循环检测：识别重复工具调用/重复输出并中断
+                LoopDetectionMiddleware(),
                 # 子代理委派
                 *subagent_middlewares,
             ]
@@ -2336,6 +2342,19 @@ class MoviePilotAgent:
             await self._invalidate_cached_agent()
             execution_error = "任务已取消"
             raise
+        except AgentLoopDetectedError as e:
+            await self._invalidate_cached_agent()
+            execution_error = str(e)
+            logger.warning(
+                f"检测到Agent循环已中断: session_id={self.session_id}, "
+                f"loop_type={e.loop_type}, detail={e}"
+            )
+            friendly_message = (
+                "检测到智能体陷入重复循环，已自动中断以避免无意义执行。"
+                "请尝试换一种更明确的描述，或缩小任务范围后重试。"
+            )
+            await self._dispatch_execution_notice(friendly_message)
+            return friendly_message, {}
         except Exception as e:
             await self._invalidate_cached_agent()
             execution_error = str(e)


### PR DESCRIPTION
## 问题

智能助手（Agent）在复杂排查任务中容易陷入重复循环：反复调用同一工具或反复输出相同内容，导致无意义执行。根因是 Agent 中间件体系缺少循环检测机制，只能依赖 LangGraph 的 recursion_limit 兜底，而该机制只限制工具调用次数、不限制重复输出，且默认上限（512）过高。

## 修改

1. 新增 ：实现 
   - 检测重复工具调用：同一工具名 + 相同参数连续 3 次相同调用时中断
   - 检测重复输出：模型连续 3 次输出相同或高度相似文本时中断
   - 命中循环时抛出 
2. 修改 ：
   - 注册  到中间件链
   - 专门捕获 ，返回友好提示并终止本轮执行

## 效果

循环达到阈值时自动中断，避免无意义执行，并向用户返回明确提示。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 5e75e13edd9b52aad1a23658d10f15841823f5f6

- 新增 Agent 循环检测中间件
  - 连续三次相同工具调用即中断
  - 检测携带工具调用的重复或高相似输出
- 状态按单次执行隔离，避免并发串扰
- 编排器捕获循环异常并返回友好提示
- 最终无工具调用回复不参与检测
- 未新增自动化测试；阈值可能误判
<!-- pr-agent-summary:end -->
