### PR TITLE
fix(plugin): preserve binary files in fallback downloads

### DIFF
--- a/app/adapters/system/plugin/package.py
+++ b/app/adapters/system/plugin/package.py
@@ -1232,10 +1232,10 @@ class PluginPackageManager:
                     elif res.status_code != 200:
                         return False, f"下载文件 {item.get('path')} 失败：{res.status_code}"
 
-                    # 创建插件文件夹并写入文件
+                    # GitHub 文件列表同时承载 Python 源码和 wheel 等二进制制品，统一按原始字节写入
                     file_path.parent.mkdir(parents=True, exist_ok=True)
-                    with open(file_path, "w", encoding="utf-8") as f:
-                        f.write(res.text)
+                    with open(file_path, "wb") as f:
+                        f.write(res.content)
                     logger.debug(f"文件 {item.get('path')} 下载成功，保存路径：{file_path}")
                 else:
                     # 如果是子目录，则将子目录内容加入栈中继续处理
@@ -1674,11 +1674,11 @@ class PluginPackageManager:
                     elif res.status_code != 200:
                         return False, f"下载文件 {item.get('path')} 失败：{res.status_code}"
 
-                    # 创建插件文件夹并写入文件
+                    # GitHub 文件列表同时承载 Python 源码和 wheel 等二进制制品，统一按原始字节写入
                     file_path = AsyncPath(resolved_path)
                     await file_path.parent.mkdir(parents=True, exist_ok=True)
-                    async with aiofiles.open(file_path, "w", encoding="utf-8") as f:
-                        await f.write(res.text)
+                    async with aiofiles.open(file_path, "wb") as f:
+                        await f.write(res.content)
                     logger.debug(f"文件 {item.get('path')} 下载成功，保存路径：{file_path}")
                 else:
                     # 如果是子目录，则将子目录内容加入栈中继续处理

--- a/tests/test_plugin_package_manager.py
+++ b/tests/test_plugin_package_manager.py
@@ -182,13 +182,14 @@ async def test_file_list_download_rejects_traversal_directory_names(
 
 
 @pytest.mark.asyncio
-async def test_file_list_download_maps_valid_paths_into_injected_plugin_root(
+async def test_file_list_download_preserves_binary_payload_in_injected_plugin_root(
     monkeypatch,
     tmp_path,
 ):
-    """同步与异步文件列表都只写入显式装配的插件根目录。"""
+    """同步与异步文件列表都应在受控根目录内保留原始文件字节。"""
     plugin_root = tmp_path / "plugins"
-    response = SimpleNamespace(status_code=200, text="payload")
+    payload = b"\x00\xffwheel-payload"
+    response = SimpleNamespace(status_code=200, content=payload, text="wrong-text")
     manager = PluginPackageManager(source=Mock(), plugin_root=plugin_root)
     monkeypatch.setattr(
         manager,
@@ -211,9 +212,7 @@ async def test_file_list_download_maps_valid_paths_into_injected_plugin_root(
     assert await manager._PluginPackageManager__async_download_files(
         "DemoPlugin", [item], "owner/repo", "v2"
     ) == (True, "")
-    assert (plugin_root / "demoplugin" / "nested" / "file.py").read_text(
-        encoding="utf-8"
-    ) == "payload"
+    assert (plugin_root / "demoplugin" / "nested" / "file.py").read_bytes() == payload
 
 
 def test_checkpoint_does_not_scan_native_dependencies(monkeypatch, tmp_path):


### PR DESCRIPTION
## 问题

插件 Release 下载失败后，文件列表回退路径使用 response.text 读取所有文件，再以文本模式写入。对于 .whl 等二进制制品，这会改变原始字节，导致后续 uv 报 Failed to read from zip file，插件依赖安装失败。

## 修复

- 同步文件列表下载改为使用 response.content 和二进制模式写入
- 异步文件列表下载采用相同的原始字节路径
- 增加回归测试，确认二进制 payload 在同步和异步路径中保持不变

## 验证

- python3 -m py_compile app/adapters/system/plugin/package.py tests/test_plugin_package_manager.py
- git diff --check

本机缺少可用的 uv/pytest 环境，完整测试由 CI 执行。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 69d4a15571fe17c38219049d240f7c7b9708687f

- 回退下载按原始字节保存文件
- 同步与异步路径统一二进制写入
- 防止 wheel 制品下载后损坏
- 增加二进制 payload 回归覆盖
<!-- pr-agent-summary:end -->
