### PR TITLE
feat(mediaserver): 新增 MediaVault 自建媒体库模块

### DIFF
--- a/app/modules/mediavault/__init__.py
+++ b/app/modules/mediavault/__init__.py
@@ -1,0 +1,360 @@
+from typing import Any, Dict, Generator, List, Optional, Tuple, Union
+
+from app import schemas
+from app.core.context import MediaInfo
+from app.core.event import eventmanager
+from app.log import logger
+from app.modules import _MediaServerBase, _ModuleBase
+from app.modules.mediavault.mediavault import MediaVault
+from app.schemas import AuthCredentials, AuthInterceptCredentials
+from app.schemas.types import ChainEventType, MediaServerType, MediaType, ModuleType
+
+
+class MediaVaultModule(_ModuleBase, _MediaServerBase[MediaVault]):
+    """MediaVault 自建媒体库模块。"""
+
+    def init_module(self) -> None:
+        """
+        初始化模块
+        """
+        super().init_service(
+            service_name=MediaVault.__name__.lower(),
+            service_type=lambda conf: MediaVault(
+                **conf.config, sync_libraries=conf.sync_libraries
+            ),
+        )
+
+    @staticmethod
+    def get_name() -> str:
+        return "MediaVault"
+
+    @staticmethod
+    def get_type() -> ModuleType:
+        """
+        获取模块类型
+        """
+        return ModuleType.MediaServer
+
+    @staticmethod
+    def get_subtype() -> MediaServerType:
+        """
+        获取模块子类型
+        """
+        return MediaServerType.MediaVault
+
+    @staticmethod
+    def get_priority() -> int:
+        """
+        获取模块优先级，数字越小优先级越高，只有同一接口下优先级才生效
+        """
+        return 7
+
+    def init_setting(self) -> Tuple[str, Union[str, bool]]:
+        pass
+
+    def scheduler_job(self) -> None:
+        """
+        定时任务，每10分钟调用一次
+        """
+        # 定时重连
+        for name, server in self.get_instances().items():
+            if server.is_configured() and server.is_inactive():
+                logger.info(f"MediaVault {name} 连接断开，尝试重连 ...")
+                server.reconnect()
+
+    def stop(self) -> None:
+        """停止模块"""
+        for server in self.get_instances().values():
+            try:
+                server.disconnect()
+            except Exception as err:
+                logger.error(f"停止 MediaVault 模块实例失败：{err}")
+
+    def test(self) -> Optional[Tuple[bool, str]]:
+        """
+        测试模块连接性
+        """
+        if not self.get_instances():
+            return None
+        for name, server in self.get_instances().items():
+            if not server.is_configured():
+                return False, f"MediaVault 配置不完整：{name}"
+            if server.is_inactive() and not server.reconnect():
+                return False, f"无法连接 MediaVault：{name}"
+        return True, ""
+
+    def user_authenticate(
+        self, credentials: AuthCredentials, service_name: Optional[str] = None
+    ) -> Optional[AuthCredentials]:
+        """
+        使用 MediaVault 用户辅助完成用户认证
+
+        :param credentials: 认证数据
+        :param service_name: 指定要认证的媒体服务器名称，若为 None 则认证所有服务
+        :return: 认证数据
+        """
+        if not credentials or credentials.grant_type != "password":
+            return None
+        # 确定要认证的服务器列表
+        if service_name:
+            # 如果指定了服务名，获取该服务实例
+            servers = (
+                [(service_name, server)]
+                if (server := self.get_instance(service_name))
+                else []
+            )
+        else:
+            # 如果没有指定服务名，遍历所有服务
+            servers = self.get_instances().items()
+        # 遍历要认证的服务器
+        for name, server in servers:
+            # 触发认证拦截事件
+            intercept_event = eventmanager.send_event(
+                etype=ChainEventType.AuthIntercept,
+                data=AuthInterceptCredentials(
+                    username=credentials.username,
+                    channel=self.get_name(),
+                    service=name,
+                    status="triggered",
+                ),
+            )
+            if intercept_event and intercept_event.event_data:
+                intercept_data: AuthInterceptCredentials = intercept_event.event_data
+                if intercept_data.cancel:
+                    continue
+            token = server.authenticate(credentials.username, credentials.password)
+            if token:
+                credentials.channel = self.get_name()
+                credentials.service = name
+                credentials.token = token
+                return credentials
+        return None
+
+    def media_exists(
+        self,
+        mediainfo: MediaInfo,
+        itemid: Optional[str] = None,
+        server: Optional[str] = None,
+    ) -> Optional[schemas.ExistMediaInfo]:
+        """
+        判断媒体文件是否存在
+
+        :param mediainfo:  识别的媒体信息
+        :param itemid:  媒体服务器ItemID
+        :param server:  媒体服务器名称
+        :return: 如不存在返回None，存在时返回信息，包括每季已存在所有集{type: movie/tv, seasons: {season: [episodes]}}
+        """
+        if server:
+            servers = [(server, self.get_instance(server))]
+        else:
+            servers = self.get_instances().items()
+        for name, s in servers:
+            if not s:
+                continue
+            if mediainfo.type == MediaType.MOVIE:
+                if itemid:
+                    movie = s.get_iteminfo(itemid)
+                    if movie:
+                        logger.info(f"媒体库 {name} 中找到了 {movie}")
+                        return schemas.ExistMediaInfo(
+                            type=MediaType.MOVIE,
+                            server_type="mediavault",
+                            server=name,
+                            itemid=movie.item_id,
+                        )
+                movies = s.get_movies(
+                    title=mediainfo.title,
+                    year=mediainfo.year,
+                    tmdb_id=mediainfo.tmdb_id,
+                )
+                if not movies:
+                    logger.info(f"{mediainfo.title_year} 没有在媒体库 {name} 中")
+                    continue
+                else:
+                    logger.info(f"媒体库 {name} 中找到了 {movies}")
+                    return schemas.ExistMediaInfo(
+                        type=MediaType.MOVIE,
+                        server_type="mediavault",
+                        server=name,
+                        itemid=movies[0].item_id,
+                    )
+            else:
+                itemid, tvs = s.get_tv_episodes(
+                    title=mediainfo.title,
+                    year=mediainfo.year,
+                    tmdb_id=mediainfo.tmdb_id,
+                    item_id=itemid,
+                )
+                if not tvs:
+                    logger.info(f"{mediainfo.title_year} 没有在媒体库 {name} 中")
+                    continue
+                else:
+                    logger.info(
+                        f"{mediainfo.title_year} 在媒体库 {name} 中找到了这些季集：{tvs}"
+                    )
+                    return schemas.ExistMediaInfo(
+                        type=MediaType.TV,
+                        seasons=tvs,
+                        server_type="mediavault",
+                        server=name,
+                        itemid=itemid,
+                    )
+        return None
+
+    def media_statistic(
+        self, server: Optional[str] = None
+    ) -> Optional[List[schemas.Statistic]]:
+        """
+        媒体数量统计
+        """
+        if server:
+            server_obj: Optional[MediaVault] = self.get_instance(server)
+            servers = [server_obj] if server_obj else []
+        else:
+            servers = list(self.get_instances().values())
+        statistics = []
+        for s in servers:
+            statistic = s.get_medias_count()
+            if not statistic:
+                continue
+            statistic.user_count = s.get_user_count()
+            statistics.append(statistic)
+        return statistics
+
+    def mediaserver_librarys(
+        self, server: Optional[str] = None, hidden: Optional[bool] = False, **kwargs
+    ) -> Optional[List[schemas.MediaServerLibrary]]:
+        """
+        媒体库列表
+        """
+        server_obj: Optional[MediaVault] = self.get_instance(server)
+        if server_obj:
+            return server_obj.get_librarys(hidden=hidden)
+        return None
+
+    def mediaserver_items(
+        self,
+        server: str,
+        library_id: Union[str, int],
+        start_index: Optional[int] = 0,
+        limit: Optional[int] = -1,
+    ) -> Optional[Generator]:
+        """
+        获取媒体服务器项目列表，支持分页和不分页逻辑，默认不分页获取所有数据
+
+        :param server: 媒体服务器名称
+        :param library_id: 媒体库ID
+        :param start_index: 起始索引
+        :param limit: 每次请求的最大项目数，None 或 -1 表示一次性获取所有数据
+        """
+        server_obj: Optional[MediaVault] = self.get_instance(server)
+        if server_obj:
+            return server_obj.get_items(library_id, start_index, limit)
+        return None
+
+    def mediaserver_items_count(
+        self, server: str, library_id: Union[str, int]
+    ) -> Optional[int]:
+        """
+        获取指定媒体库可同步的媒体条目总数
+        """
+        server_obj: Optional[MediaVault] = self.get_instance(server)
+        if server_obj:
+            return server_obj.get_items_count(library_id)
+        return None
+
+    def mediaserver_iteminfo(
+        self, server: str, item_id: str
+    ) -> Optional[schemas.MediaServerItem]:
+        """
+        媒体库项目详情
+        """
+        server_obj: Optional[MediaVault] = self.get_instance(server)
+        if server_obj:
+            return server_obj.get_iteminfo(str(item_id))
+        return None
+
+    def mediaserver_tv_episodes(
+        self, server: str, item_id: Union[str, int]
+    ) -> Optional[List[schemas.MediaServerSeasonInfo]]:
+        """
+        获取剧集信息
+        """
+        server_obj: Optional[MediaVault] = self.get_instance(server)
+        if not server_obj:
+            return None
+        _, seasoninfo = server_obj.get_tv_episodes(item_id=str(item_id))
+        if not seasoninfo:
+            return []
+        return [
+            schemas.MediaServerSeasonInfo(season=season, episodes=episodes)
+            for season, episodes in seasoninfo.items()
+        ]
+
+    def mediaserver_season_episode_ids(
+        self, server: str, item_id: Union[str, int], season: int
+    ) -> Optional[Dict[int, str]]:
+        """
+        获取指定季的集号到条目 ID 映射
+
+        :param server: MediaVault 媒体服务器名称
+        :param item_id: 剧集在 MediaVault 中的条目 ID
+        :param season: 季号
+        :return: 集号到条目 ID 的映射，服务器不可用或无数据时返回 None
+        """
+        server_obj: Optional[MediaVault] = self.get_instance(server)
+        if not server_obj:
+            return None
+        return server_obj.get_season_episode_ids(str(item_id), season)
+
+    def mediaserver_playing(
+        self, server: str, count: Optional[int] = 20, **kwargs
+    ) -> Optional[List[schemas.MediaServerPlayItem]]:
+        """
+        获取媒体服务器正在播放信息
+        """
+        server_obj: Optional[MediaVault] = self.get_instance(server)
+        if not server_obj:
+            return None
+        return server_obj.get_resume(num=count)
+
+    def mediaserver_play_url(
+        self, server: str, item_id: Union[str, int]
+    ) -> Optional[str]:
+        """
+        获取媒体库播放地址
+        """
+        server_obj: Optional[MediaVault] = self.get_instance(server)
+        if not server_obj:
+            return None
+        return server_obj.get_play_url(str(item_id))
+
+    def mediaserver_latest(
+        self, server: Optional[str] = None, count: Optional[int] = 20, **kwargs
+    ) -> Optional[List[schemas.MediaServerPlayItem]]:
+        """
+        获取媒体服务器最新入库条目
+        """
+        server_obj: Optional[MediaVault] = self.get_instance(server)
+        if not server_obj:
+            return None
+        return server_obj.get_latest(num=count)
+
+    def mediaserver_latest_images(
+        self,
+        server: Optional[str] = None,
+        count: Optional[int] = 20,
+        remote: Optional[bool] = False,
+        **kwargs,
+    ) -> List[str]:
+        """
+        获取媒体服务器最新入库条目的图片
+
+        :param server: 媒体服务器名称
+        :param count: 获取数量
+        :param remote: True为外网链接，False为内网链接
+        """
+        server_obj: Optional[MediaVault] = self.get_instance(server)
+        if not server_obj:
+            return []
+        return server_obj.get_latest_backdrops(num=count, remote=remote) or []

--- a/app/modules/mediavault/api.py
+++ b/app/modules/mediavault/api.py
@@ -1,0 +1,126 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Union
+from urllib.parse import urlencode
+
+from app.core.config import settings
+from app.log import logger
+from app.utils.http import RequestUtils, requests
+from app.utils.url import UrlUtils
+
+
+@dataclass
+class Result:
+    """MediaVault 统一响应包装。"""
+
+    success: bool
+    data: Optional[Union[Dict[str, Any], List[Any], str, int, bool]] = None
+    message: Optional[str] = None
+    status_code: Optional[int] = None
+
+
+class Api:
+    """MediaVault 自建媒体库的原生 HTTP 接口。
+
+    统一走管理端口的 `/api/v1`，凭据为管理面板的长效 API Key；
+    自建媒体库的接口都挂在 `/api/v1/media-library` 之下。
+    """
+
+    LIBRARY_PATH = "/api/v1/media-library"
+
+    def __init__(self, host: Optional[str] = None, apikey: Optional[str] = None):
+        self._host = UrlUtils.standardize_base_url(host).rstrip("/") if host else None
+        self._apikey = apikey
+        # v2 的 RequestUtils 不自建会话，连接复用需显式传入 Session
+        self._session = requests.Session()
+        self._request_utils = RequestUtils(session=self._session, timeout=15)
+
+    @property
+    def host(self) -> Optional[str]:
+        return self._host
+
+    @property
+    def configured(self) -> bool:
+        return bool(self._host and self._apikey)
+
+    def close(self) -> None:
+        """释放底层会话。"""
+        self._session.close()
+
+    def image_url(self, item_id: str, image_type: str, host: Optional[str] = None) -> str:
+        """拼装带鉴权的图片直链；item_id 传媒体库 ID 时得到媒体库封面。"""
+        if not self.configured or not item_id:
+            return ""
+        base = (UrlUtils.standardize_base_url(host).rstrip("/") if host else self._host)
+        query = urlencode({"api_key": self._apikey})
+        return f"{base}{self.LIBRARY_PATH}/items/{item_id}/image/{image_type}?{query}"
+
+    def request(
+        self,
+        api: str,
+        method: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        data: Optional[Dict[str, Any]] = None,
+        base_path: Optional[str] = None,
+        suppress_log: bool = False,
+    ) -> Optional[Result]:
+        """请求 MediaVault 接口。
+
+        :param api: 接口路径，默认相对自建媒体库前缀
+        :param base_path: 覆盖接口前缀（如站点级 `/api/v1`）
+        :param suppress_log: 探测类调用可关闭错误日志
+        :return: 网络层失败返回 None，业务失败返回 success=False 的 Result
+        """
+        if not self.configured or not api:
+            return None
+        host = self._host or ""
+        prefix = base_path if base_path is not None else self.LIBRARY_PATH
+        url = host + prefix + (api if api.startswith("/") else f"/{api}")
+        if method is None:
+            method = "get" if data is None else "post"
+        headers = {
+            "User-Agent": settings.USER_AGENT,
+            "Accept": "application/json",
+            "X-API-Key": self._apikey,
+        }
+        try:
+            res = self._request_utils.request(
+                method=method, url=url, headers=headers, params=params, json=data
+            )
+        except Exception as err:
+            if not suppress_log:
+                logger.error(f"请求 MediaVault 接口 {url} 异常：{err}")
+            return None
+        if res is None:
+            if not suppress_log:
+                logger.error(f"请求 MediaVault 接口 {url} 无响应")
+            return None
+        if res.status_code >= 400:
+            message = self.__error_message(res)
+            if not suppress_log:
+                logger.error(f"请求 MediaVault 接口 {url} 失败：{res.status_code} {message}")
+            return Result(False, None, message, res.status_code)
+        try:
+            body = res.json()
+        except Exception as err:
+            if not suppress_log:
+                logger.error(f"解析 MediaVault 接口 {url} 响应失败：{err}")
+            return None
+        if isinstance(body, dict) and "success" in body:
+            if not body.get("success"):
+                message = str(body.get("message") or body.get("detail") or "")
+                if not suppress_log:
+                    logger.error(f"请求 MediaVault 接口 {url} 未成功：{message}")
+                return Result(False, None, message, res.status_code)
+            return Result(True, body.get("data"), None, res.status_code)
+        return Result(True, body, None, res.status_code)
+
+    @staticmethod
+    def __error_message(res: Any) -> str:
+        """从错误响应中取出可读信息，非 JSON 时退回状态文本。"""
+        try:
+            body = res.json()
+        except Exception:
+            return (res.text or "")[:200]
+        if isinstance(body, dict):
+            return str(body.get("detail") or body.get("message") or "")[:200]
+        return str(body)[:200]

--- a/app/modules/mediavault/api.py
+++ b/app/modules/mediavault/api.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
-from urllib.parse import urlencode
 
 from app.core.config import settings
 from app.log import logger
@@ -47,12 +46,15 @@ class Api:
         self._session.close()
 
     def image_url(self, item_id: str, image_type: str, host: Optional[str] = None) -> str:
-        """拼装带鉴权的图片直链；item_id 传媒体库 ID 时得到媒体库封面。"""
+        """拼装图片直链；item_id 传媒体库 ID 时得到媒体库封面。
+
+        MediaVault 的图片是免鉴权资源，这里**不能**带上 API Key：该地址会随接口
+        响应交给浏览器加载，带 Key 等于把管理凭据下发到客户端。
+        """
         if not self.configured or not item_id:
             return ""
         base = (UrlUtils.standardize_base_url(host).rstrip("/") if host else self._host)
-        query = urlencode({"api_key": self._apikey})
-        return f"{base}{self.LIBRARY_PATH}/items/{item_id}/image/{image_type}?{query}"
+        return f"{base}{self.LIBRARY_PATH}/items/{item_id}/image/{image_type}"
 
     def request(
         self,

--- a/app/modules/mediavault/mediavault.py
+++ b/app/modules/mediavault/mediavault.py
@@ -228,9 +228,9 @@ class MediaVault:
             return None
 
         def rows() -> Generator[Dict[str, Any], Any, None]:
-            result = first
+            result: Optional[Dict[str, Any]] = first
             page = 1
-            while True:
+            while result is not None:
                 batch = result.get("items") or []
                 yield from batch
                 if len(batch) < self.PAGE_LIMIT:
@@ -239,8 +239,6 @@ class MediaVault:
                 result = self.__query_items(
                     keyword=keyword, kinds=kinds, page=page, page_size=self.PAGE_LIMIT
                 )
-                if result is None:
-                    return
 
         return rows()
 

--- a/app/modules/mediavault/mediavault.py
+++ b/app/modules/mediavault/mediavault.py
@@ -238,10 +238,18 @@ class MediaVault:
         def rows() -> Generator[Dict[str, Any], Any, None]:
             result: Dict[str, Any] = first
             page = 1
+            seen = 0
             while True:
                 batch = result.get("items") or []
+                seen += len(batch)
                 yield from batch
-                if len(batch) < self.PAGE_LIMIT:
+                total = result.get("total")
+                # 有可靠总数时以它为准：末页恰好满额也不再多发一次请求，
+                # 那次多余请求一旦失败会把完整结果误报成服务不可达
+                if isinstance(total, int):
+                    if seen >= total:
+                        return
+                elif len(batch) < self.PAGE_LIMIT:
                     return
                 page += 1
                 following = self.__query_items(
@@ -344,18 +352,19 @@ class MediaVault:
         if rows is None:
             return None
         try:
-            search_rows = list(rows)
+            # 逐行检查、命中即返回：预取全部页会让第一页已命中的目标
+            # 因后续页请求失败被误报成服务不可达
+            for row in rows:
+                item = self.__format_item_info(row)
+                if not item or item.title != title:
+                    continue
+                if year and str(item.year) != str(year):
+                    continue
+                if tmdb_id and item.tmdbid != tmdb_id:
+                    continue
+                return str(item.item_id)
         except _SearchInterrupted:
             return None
-        for row in search_rows:
-            item = self.__format_item_info(row)
-            if not item or item.title != title:
-                continue
-            if year and str(item.year) != str(year):
-                continue
-            if tmdb_id and item.tmdbid != tmdb_id:
-                continue
-            return str(item.item_id)
         return ""
 
     def get_season_episode_ids(self, item_id: str, season: int) -> Dict[int, str]:

--- a/app/modules/mediavault/mediavault.py
+++ b/app/modules/mediavault/mediavault.py
@@ -8,6 +8,14 @@ from app.schemas import MediaType
 from app.utils.url import UrlUtils
 
 
+class _SearchInterrupted(Exception):
+    """关键字翻页中途请求失败。
+
+    与「查完了」区分开：调用方据此返回 None（服务不可达），而不是空结果
+    （确定不在库中）——后者会让上层误判成需要重新下载。
+    """
+
+
 class MediaVault:
     """MediaVault 自建媒体库客户端。
 
@@ -228,17 +236,20 @@ class MediaVault:
             return None
 
         def rows() -> Generator[Dict[str, Any], Any, None]:
-            result: Optional[Dict[str, Any]] = first
+            result: Dict[str, Any] = first
             page = 1
-            while result is not None:
+            while True:
                 batch = result.get("items") or []
                 yield from batch
                 if len(batch) < self.PAGE_LIMIT:
                     return
                 page += 1
-                result = self.__query_items(
+                following = self.__query_items(
                     keyword=keyword, kinds=kinds, page=page, page_size=self.PAGE_LIMIT
                 )
+                if following is None:
+                    raise _SearchInterrupted
+                result = following
 
         return rows()
 
@@ -266,7 +277,11 @@ class MediaVault:
         if rows is None:
             return None
         movies = []
-        for row in rows:
+        try:
+            search_rows = list(rows)
+        except _SearchInterrupted:
+            return None
+        for row in search_rows:
             item = self.__format_item_info(row)
             if not item or item.title != title:
                 continue
@@ -328,7 +343,11 @@ class MediaVault:
         rows = self.__search_rows(keyword=title, kinds="Series")
         if rows is None:
             return None
-        for row in rows:
+        try:
+            search_rows = list(rows)
+        except _SearchInterrupted:
+            return None
+        for row in search_rows:
             item = self.__format_item_info(row)
             if not item or item.title != title:
                 continue

--- a/app/modules/mediavault/mediavault.py
+++ b/app/modules/mediavault/mediavault.py
@@ -1,0 +1,572 @@
+from pathlib import Path
+from typing import Any, Dict, Generator, List, Optional, Tuple, Union
+
+from app import schemas
+from app.log import logger
+from app.modules.mediavault.api import Api
+from app.schemas import MediaType
+from app.utils.url import UrlUtils
+
+
+class MediaVault:
+    """MediaVault 自建媒体库客户端。
+
+    只使用 MediaVault 管理端口的原生接口，凭据是管理面板的长效 API Key；
+    自建媒体库没有音乐库，也不主动外发 Webhook，相关能力在模块层显式留空。
+    """
+
+    # MediaVault 单次列表请求的最大条数，与服务端 page_size 上限一致
+    PAGE_LIMIT = 100
+    # 媒体库类型到 MoviePilot 媒体类型的映射
+    LIBRARY_TYPES = {"movies": MediaType.MOVIE.value, "tvshows": MediaType.TV.value}
+
+    def __init__(
+        self,
+        host: Optional[str] = None,
+        apikey: Optional[str] = None,
+        play_host: Optional[str] = None,
+        sync_libraries: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> None:
+        self._host = UrlUtils.standardize_base_url(host).rstrip("/") if host else None
+        self._playhost = (
+            UrlUtils.standardize_base_url(play_host).rstrip("/") if play_host else None
+        )
+        self._apikey = apikey
+        self._sync_libraries = sync_libraries or []
+        self._api = Api(host=host, apikey=apikey)
+        self._active = False
+        if not self.is_configured():
+            logger.error("MediaVault 配置不完整！")
+            return
+        self.reconnect()
+
+    # ── 连接状态 ────────────────────────────────────────────────
+
+    def is_configured(self) -> bool:
+        """配置是否完整到可以发起请求。"""
+        return bool(self._host and self._apikey)
+
+    def is_authenticated(self) -> bool:
+        """当前 API Key 是否已探测通过。"""
+        return self._active
+
+    def is_inactive(self) -> bool:
+        """是否需要重连。"""
+        if not self.is_configured():
+            return False
+        return not self._active
+
+    def reconnect(self) -> bool:
+        """用媒体库列表接口探测连通性与凭据有效性。"""
+        if not self.is_configured():
+            return False
+        result = self._api.request("/libraries", suppress_log=True)
+        self._active = bool(result and result.success)
+        return self._active
+
+    def disconnect(self) -> None:
+        """释放底层会话。"""
+        self._active = False
+        self._api.close()
+
+    def authenticate(self, username: str, password: str) -> Optional[str]:
+        """用 MediaVault 账号完成用户认证，返回访问令牌。"""
+        if not self.is_configured() or not username or not password:
+            return None
+        result = self._api.request(
+            "/login",
+            method="post",
+            data={"username": username, "password": password},
+            base_path="/api/v1/user-auth",
+            suppress_log=True,
+        )
+        if not result or not result.success or not isinstance(result.data, dict):
+            return None
+        token = result.data.get("access_token") or result.data.get("token")
+        return str(token) if token else None
+
+    # ── 媒体库 ──────────────────────────────────────────────────
+
+    def get_librarys(
+        self, hidden: Optional[bool] = False
+    ) -> Optional[List[schemas.MediaServerLibrary]]:
+        """获取媒体库列表。"""
+        rows = self.__library_rows()
+        if rows is None:
+            return None
+        libraries = []
+        for row in rows:
+            library_id = str(row.get("id") or "")
+            if not library_id:
+                continue
+            if (
+                hidden
+                and self._sync_libraries
+                and "all" not in self._sync_libraries
+                and library_id not in self._sync_libraries
+            ):
+                continue
+            library_type = self.LIBRARY_TYPES.get(
+                str(row.get("library_type") or ""), MediaType.UNKNOWN.value
+            )
+            libraries.append(
+                schemas.MediaServerLibrary(
+                    server="mediavault",
+                    id=library_id,
+                    item_id=library_id,
+                    name=row.get("name"),
+                    path=row.get("root_paths") or row.get("root_path"),
+                    type=library_type,
+                    item_count=self.get_items_count(library_id),
+                    image=self._api.image_url(library_id, "primary"),
+                    link=f"{self._playhost or self._host}/library",
+                    server_type="mediavault",
+                )
+            )
+        return libraries
+
+    def __library_rows(self) -> Optional[List[Dict[str, Any]]]:
+        """媒体库原始记录，连接失败返回 None。"""
+        result = self._api.request("/libraries")
+        if not result or not result.success or not isinstance(result.data, dict):
+            return None
+        items = result.data.get("items")
+        return items if isinstance(items, list) else []
+
+    def get_items_count(self, parent: Union[str, int]) -> Optional[int]:
+        """获取指定媒体库可同步的媒体条目总数。"""
+        if not parent:
+            return None
+        result = self.__query_items(
+            library_id=str(parent), kinds="Movie,Series", page=1, page_size=1
+        )
+        if result is None:
+            return None
+        total = result.get("total")
+        return int(total) if total is not None else None
+
+    def get_items(
+        self,
+        parent: Union[str, int],
+        start_index: Optional[int] = 0,
+        limit: Optional[int] = -1,
+    ) -> Generator[Optional[schemas.MediaServerItem], Any, None]:
+        """遍历媒体库中的电影与剧集条目，limit 为 None 或 -1 时取全部。"""
+        if not parent or not self.is_configured():
+            return
+        # 页大小固定，页码才能稳定映射到偏移量；条数上限在产出侧裁剪
+        skip = max(0, start_index or 0)
+        remaining = None if limit is None or limit == -1 else max(0, limit)
+        page = skip // self.PAGE_LIMIT + 1
+        drop = skip % self.PAGE_LIMIT
+        while remaining is None or remaining > 0:
+            result = self.__query_items(
+                library_id=str(parent),
+                kinds="Movie,Series",
+                page=page,
+                page_size=self.PAGE_LIMIT,
+            )
+            if result is None:
+                return
+            rows = result.get("items") or []
+            for row in rows[drop:]:
+                if remaining is not None and remaining <= 0:
+                    return
+                item = self.__format_item_info(row)
+                if item:
+                    yield item
+                if remaining is not None:
+                    remaining -= 1
+            if len(rows) < self.PAGE_LIMIT:
+                return
+            drop = 0
+            page += 1
+
+    def __query_items(
+        self,
+        library_id: str = "",
+        parent_id: Optional[str] = None,
+        keyword: str = "",
+        kinds: str = "",
+        page: int = 1,
+        page_size: int = 40,
+        filter_by: str = "",
+        sort_by: str = "",
+        sort_order: str = "",
+    ) -> Optional[Dict[str, Any]]:
+        """调用条目列表接口；MediaVault 只接受页码，偏移量由调用方换算。"""
+        params: Dict[str, Any] = {"page": max(1, page), "page_size": page_size}
+        if library_id:
+            params["library_id"] = library_id
+        if parent_id is not None:
+            params["parent_id"] = parent_id
+        if keyword:
+            params["keyword"] = keyword
+        if kinds:
+            params["kinds"] = kinds
+        if filter_by:
+            params["filter_by"] = filter_by
+        if sort_by:
+            params["sort_by"] = sort_by
+        if sort_order:
+            params["sort_order"] = sort_order
+        result = self._api.request("/items", params=params)
+        if not result or not result.success or not isinstance(result.data, dict):
+            return None
+        return result.data
+
+    # ── 条目 ────────────────────────────────────────────────────
+
+    def get_iteminfo(self, itemid: str) -> Optional[schemas.MediaServerItem]:
+        """获取单个条目详情。"""
+        if not itemid or not self.is_configured():
+            return None
+        result = self._api.request(f"/items/{itemid}", suppress_log=True)
+        if not result or not result.success or not isinstance(result.data, dict):
+            return None
+        return self.__format_item_info(result.data)
+
+    def get_movies(
+        self,
+        title: str,
+        year: Optional[str] = None,
+        tmdb_id: Optional[int] = None,
+    ) -> Optional[List[schemas.MediaServerItem]]:
+        """按标题和年份检查电影是否存在。"""
+        if not title or not self.is_configured():
+            return None
+        result = self.__query_items(keyword=title, kinds="Movie", page_size=self.PAGE_LIMIT)
+        if result is None:
+            return None
+        movies = []
+        for row in result.get("items") or []:
+            item = self.__format_item_info(row)
+            if not item or item.title != title:
+                continue
+            if year and str(item.year) != str(year):
+                continue
+            if tmdb_id and item.tmdbid != tmdb_id:
+                continue
+            movies.append(item)
+        return movies
+
+    def get_tv_episodes(
+        self,
+        item_id: Optional[str] = None,
+        title: Optional[str] = None,
+        year: Optional[str] = None,
+        tmdb_id: Optional[int] = None,
+        season: Optional[int] = None,
+    ) -> Tuple[Optional[str], Optional[Dict[int, List[int]]]]:
+        """返回剧集在媒体库中每季已有的集号。"""
+        if not self.is_configured():
+            return None, None
+        series_id = item_id
+        if series_id:
+            info = self.get_iteminfo(series_id)
+            if not info or (tmdb_id and info.tmdbid != tmdb_id):
+                # 缓存的条目 ID 失效或指向了别的剧，退回按标题重新定位
+                series_id = None
+        if not series_id:
+            if not title:
+                return None, {}
+            series_id = self.__find_series_id(title, year, tmdb_id)
+            if series_id is None:
+                return None, None
+            if not series_id:
+                return None, {}
+        result = self._api.request(f"/items/{series_id}/episodes")
+        if not result or not result.success or not isinstance(result.data, dict):
+            return None, None
+        seasons: Dict[int, List[int]] = {}
+        for raw_season, episodes in (result.data.get("seasons") or {}).items():
+            try:
+                season_index = int(raw_season)
+            except (TypeError, ValueError):
+                continue
+            if season is not None and season_index != season:
+                continue
+            seasons[season_index] = sorted(
+                {int(episode) for episode in episodes if episode is not None}
+            )
+        return series_id, seasons
+
+    def __find_series_id(
+        self,
+        title: str,
+        year: Optional[str],
+        tmdb_id: Optional[int],
+    ) -> Optional[str]:
+        """按标题定位剧集条目 ID；连接失败返回 None，未找到返回空串。"""
+        result = self.__query_items(keyword=title, kinds="Series", page_size=self.PAGE_LIMIT)
+        if result is None:
+            return None
+        for row in result.get("items") or []:
+            item = self.__format_item_info(row)
+            if not item or item.title != title:
+                continue
+            if year and str(item.year) != str(year):
+                continue
+            if tmdb_id and item.tmdbid != tmdb_id:
+                continue
+            return str(item.item_id)
+        return ""
+
+    def get_season_episode_ids(self, item_id: str, season: int) -> Dict[int, str]:
+        """获取指定季的集号到条目 ID 映射。"""
+        if not item_id or not self.is_configured():
+            return {}
+        season_id = self.__find_season_id(item_id, season)
+        if not season_id:
+            return {}
+        episode_ids: Dict[int, str] = {}
+        page = 1
+        while True:
+            result = self.__query_items(
+                parent_id=season_id, kinds="Episode", page=page, page_size=self.PAGE_LIMIT
+            )
+            if result is None:
+                return episode_ids
+            rows = result.get("items") or []
+            for row in rows:
+                episode = row.get("episode")
+                row_id = row.get("id")
+                if episode is None or not row_id:
+                    continue
+                episode_ids[int(episode)] = str(row_id)
+            if len(rows) < self.PAGE_LIMIT:
+                return episode_ids
+            page += 1
+
+    def __find_season_id(self, series_id: str, season: int) -> str:
+        """在剧集下定位指定季的条目 ID。"""
+        page = 1
+        while True:
+            result = self.__query_items(
+                parent_id=series_id, kinds="Season", page=page, page_size=self.PAGE_LIMIT
+            )
+            if result is None:
+                return ""
+            rows = result.get("items") or []
+            for row in rows:
+                if row.get("season") == season and row.get("id"):
+                    return str(row["id"])
+            if len(rows) < self.PAGE_LIMIT:
+                return ""
+            page += 1
+
+    def __format_item_info(self, row: Dict[str, Any]) -> Optional[schemas.MediaServerItem]:
+        """把 MediaVault 条目转换为统一媒体服务器模型。"""
+        try:
+            metadata = row.get("metadata_info") or {}
+            external_ids = metadata.get("external_ids") or {}
+            user_data = row.get("user_data") or {}
+            position = user_data.get("position_ticks") or 0
+            return schemas.MediaServerItem(
+                server="mediavault",
+                library=row.get("library_id"),
+                item_id=str(row.get("id") or ""),
+                item_type=row.get("kind"),
+                title=row.get("title"),
+                original_title=metadata.get("original_title"),
+                year=row.get("year") or None,
+                tmdbid=int(row["tmdb_id"]) if row.get("tmdb_id") else None,
+                imdbid=str(external_ids["imdb_id"]) if external_ids.get("imdb_id") else None,
+                tvdbid=str(external_ids["tvdb_id"]) if external_ids.get("tvdb_id") else None,
+                path=self.__item_path(row),
+                user_state=schemas.MediaServerItemUserState(
+                    played=user_data.get("played"),
+                    resume=position > 0,
+                    last_played_date=self.__local_time(user_data.get("last_played_at")),
+                    play_count=int(bool(user_data.get("played"))),
+                ) if user_data else None,
+            )
+        except Exception as err:
+            logger.error(f"解析 MediaVault 条目失败：{err}")
+            return None
+
+    @staticmethod
+    def __item_path(row: Dict[str, Any]) -> Optional[str]:
+        """条目详情带媒体源时取第一个文件路径，列表接口没有路径字段。"""
+        sources = row.get("sources")
+        if isinstance(sources, list):
+            for source in sources:
+                if isinstance(source, dict) and source.get("path"):
+                    return str(source["path"])
+        return None
+
+    @staticmethod
+    def __local_time(value: Optional[str]) -> Optional[str]:
+        """把 ISO 时间截断为统一模型使用的秒级本地时间文本。"""
+        if not value:
+            return None
+        return str(value).split(".")[0].replace("T", " ")
+
+    # ── 统计与展示 ──────────────────────────────────────────────
+
+    def get_medias_count(self) -> Optional[schemas.Statistic]:
+        """媒体数量统计。"""
+        result = self._api.request("/statistics")
+        if not result or not result.success or not isinstance(result.data, dict):
+            return None
+        return schemas.Statistic(
+            movie_count=result.data.get("movie_count") or 0,
+            tv_count=result.data.get("series_count") or 0,
+            episode_count=result.data.get("episode_count") or 0,
+        )
+
+    def get_user_count(self) -> int:
+        """媒体库可见用户数。"""
+        result = self._api.request("/users", suppress_log=True)
+        if not result or not result.success or not isinstance(result.data, list):
+            return 0
+        return len(result.data)
+
+    def get_resume(self, num: Optional[int] = 12) -> Optional[List[schemas.MediaServerPlayItem]]:
+        """继续观看列表。"""
+        return self.__play_items(filter_by="resume", num=num, resume=True)
+
+    def get_latest(self, num: Optional[int] = 20) -> Optional[List[schemas.MediaServerPlayItem]]:
+        """最新入库列表。"""
+        return self.__play_items(sort_by="added", sort_order="desc", num=num, resume=False)
+
+    def __play_items(
+        self,
+        num: Optional[int],
+        resume: bool,
+        filter_by: str = "",
+        sort_by: str = "",
+        sort_order: str = "",
+    ) -> Optional[List[schemas.MediaServerPlayItem]]:
+        """把条目列表转换为可播放展示项。"""
+        if not self.is_configured():
+            return None
+        count = max(1, min(self.PAGE_LIMIT, num or 20))
+        result = self.__query_items(
+            kinds="Movie,Episode" if resume else "Movie,Series",
+            filter_by=filter_by,
+            sort_by=sort_by,
+            sort_order=sort_order,
+            page_size=count,
+        )
+        if result is None:
+            return None
+        items = []
+        for row in (result.get("items") or [])[:count]:
+            row_id = str(row.get("id") or "")
+            if not row_id:
+                continue
+            is_episode = row.get("kind") == "Episode"
+            title: Optional[str] = row.get("title")
+            subtitle: Optional[str] = None
+            if is_episode:
+                title = row.get("series_name") or row.get("title")
+                subtitle = f'S{row.get("season")}:{row.get("episode")} - {row.get("title")}'
+            elif row.get("year"):
+                subtitle = str(row["year"])
+            image_id = row.get("series_id") if is_episode else row_id
+            percent = None
+            duration = row.get("duration_ticks") or 0
+            position = (row.get("user_data") or {}).get("position_ticks") or 0
+            if duration > 0 and position > 0:
+                percent = round(position / duration * 100, 2)
+            items.append(
+                schemas.MediaServerPlayItem(
+                    id=row_id,
+                    item_id=row_id,
+                    title=title,
+                    subtitle=subtitle,
+                    type=MediaType.TV.value if is_episode else MediaType.MOVIE.value,
+                    image=self._api.image_url(str(image_id or row_id), "primary"),
+                    link=self.get_play_url(row_id),
+                    percent=percent,
+                    server_type="mediavault",
+                )
+            )
+        return items
+
+    def get_latest_backdrops(
+        self, num: Optional[int] = 20, remote: Optional[bool] = False
+    ) -> Optional[List[str]]:
+        """最新入库条目的背景图地址。"""
+        if not self.is_configured():
+            return None
+        count = max(1, min(self.PAGE_LIMIT, num or 20))
+        # 没有背景图的条目会白占名额，多取一批再按实际有图的截断
+        result = self.__query_items(
+            kinds="Movie,Series", sort_by="added", sort_order="desc", page_size=self.PAGE_LIMIT
+        )
+        if result is None:
+            return None
+        host = (self._playhost or self._host) if remote else self._host
+        images = []
+        for row in result.get("items") or []:
+            if not row.get("has_backdrop") or not row.get("id"):
+                continue
+            images.append(self._api.image_url(str(row["id"]), "backdrop", host=host))
+            if len(images) == count:
+                break
+        return images
+
+    def get_play_url(self, item_id: str) -> Optional[str]:
+        """媒体库网页播放地址。"""
+        if not item_id or not self.is_configured():
+            return None
+        return f"{self._playhost or self._host}/library/item/{item_id}"
+
+    # ── 入库刷新 ────────────────────────────────────────────────
+
+    def refresh_root_library(self) -> Optional[bool]:
+        """触发全部媒体库扫描。"""
+        rows = self.__library_rows()
+        if rows is None:
+            return None
+        results = [self.__queue_scan(str(row.get("id"))) for row in rows if row.get("id")]
+        return all(results) if results else False
+
+    def refresh_library_by_items(
+        self, items: List[schemas.RefreshMediaItem]
+    ) -> Optional[bool]:
+        """按入库路径定位媒体库并触发扫描；定位不到时退回全库扫描。"""
+        if not items:
+            return False
+        rows = self.__library_rows()
+        if rows is None:
+            return None
+        matched = set()
+        unmatched = False
+        for item in items:
+            library_id = self.__match_library_by_path(rows, item.target_path)
+            if library_id:
+                matched.add(library_id)
+            else:
+                unmatched = True
+                logger.info(f"MediaVault 中未找到 {item.title} 对应的媒体库，将扫描全部媒体库")
+        if unmatched:
+            return self.refresh_root_library()
+        return all(self.__queue_scan(library_id) for library_id in matched)
+
+    @staticmethod
+    def __match_library_by_path(
+        rows: List[Dict[str, Any]], target_path: Optional[Path]
+    ) -> str:
+        """按目录归属把入库路径映射到媒体库。"""
+        if not target_path:
+            return ""
+        for row in rows:
+            roots = row.get("root_paths") or ([row["root_path"]] if row.get("root_path") else [])
+            for root in roots:
+                try:
+                    if target_path == Path(root) or Path(root) in target_path.parents:
+                        return str(row.get("id") or "")
+                except (TypeError, ValueError):
+                    continue
+        return ""
+
+    def __queue_scan(self, library_id: str) -> bool:
+        """把媒体库扫描排进 MediaVault 的后台队列，不阻塞入库流程。"""
+        if not library_id:
+            return False
+        result = self._api.request(f"/libraries/{library_id}/scan-task", method="post")
+        return bool(result and result.success)

--- a/app/modules/mediavault/mediavault.py
+++ b/app/modules/mediavault/mediavault.py
@@ -216,6 +216,34 @@ class MediaVault:
             return None
         return result.data
 
+    def __search_rows(self, keyword: str, kinds: str) -> Optional[Generator[Dict[str, Any], Any, None]]:
+        """按关键字翻页产出条目原始记录。
+
+        MediaVault 的关键字查询是模糊匹配，命中数可能超过单页上限；只读第一页会让
+        存在性判断把排在后面的目标误判成「未入库」，因此这里翻页直到取完。
+        连接失败返回 None，与「查得到但没有」区分开。
+        """
+        first = self.__query_items(keyword=keyword, kinds=kinds, page=1, page_size=self.PAGE_LIMIT)
+        if first is None:
+            return None
+
+        def rows() -> Generator[Dict[str, Any], Any, None]:
+            result = first
+            page = 1
+            while True:
+                batch = result.get("items") or []
+                yield from batch
+                if len(batch) < self.PAGE_LIMIT:
+                    return
+                page += 1
+                result = self.__query_items(
+                    keyword=keyword, kinds=kinds, page=page, page_size=self.PAGE_LIMIT
+                )
+                if result is None:
+                    return
+
+        return rows()
+
     # ── 条目 ────────────────────────────────────────────────────
 
     def get_iteminfo(self, itemid: str) -> Optional[schemas.MediaServerItem]:
@@ -236,11 +264,11 @@ class MediaVault:
         """按标题和年份检查电影是否存在。"""
         if not title or not self.is_configured():
             return None
-        result = self.__query_items(keyword=title, kinds="Movie", page_size=self.PAGE_LIMIT)
-        if result is None:
+        rows = self.__search_rows(keyword=title, kinds="Movie")
+        if rows is None:
             return None
         movies = []
-        for row in result.get("items") or []:
+        for row in rows:
             item = self.__format_item_info(row)
             if not item or item.title != title:
                 continue
@@ -299,10 +327,10 @@ class MediaVault:
         tmdb_id: Optional[int],
     ) -> Optional[str]:
         """按标题定位剧集条目 ID；连接失败返回 None，未找到返回空串。"""
-        result = self.__query_items(keyword=title, kinds="Series", page_size=self.PAGE_LIMIT)
-        if result is None:
+        rows = self.__search_rows(keyword=title, kinds="Series")
+        if rows is None:
             return None
-        for row in result.get("items") or []:
+        for row in rows:
             item = self.__format_item_info(row)
             if not item or item.title != title:
                 continue
@@ -458,6 +486,8 @@ class MediaVault:
             if not row_id:
                 continue
             is_episode = row.get("kind") == "Episode"
+            # Series 与 Episode 都是电视剧；只有分集才拼「季:集 - 分集名」副标题
+            is_tv = is_episode or row.get("kind") == "Series"
             title: Optional[str] = row.get("title")
             subtitle: Optional[str] = None
             if is_episode:
@@ -477,7 +507,7 @@ class MediaVault:
                     item_id=row_id,
                     title=title,
                     subtitle=subtitle,
-                    type=MediaType.TV.value if is_episode else MediaType.MOVIE.value,
+                    type=MediaType.TV.value if is_tv else MediaType.MOVIE.value,
                     image=self._api.image_url(str(image_id or row_id), "primary"),
                     link=self.get_play_url(row_id),
                     percent=percent,
@@ -545,7 +575,10 @@ class MediaVault:
                 logger.info(f"MediaVault 中未找到 {item.title} 对应的媒体库，将扫描全部媒体库")
         if unmatched:
             return self.refresh_root_library()
-        return all(self.__queue_scan(library_id) for library_id in matched)
+        # 先全部发出排队请求再汇总：交给 all() 的生成器会在首个失败处短路，
+        # 导致同批命中的其余媒体库收不到扫描任务
+        results = [self.__queue_scan(library_id) for library_id in sorted(matched)]
+        return all(results)
 
     @staticmethod
     def __match_library_by_path(

--- a/app/schemas/mediaserver.py
+++ b/app/schemas/mediaserver.py
@@ -14,7 +14,7 @@ class ExistMediaInfo(BaseModel):
     type: Optional[MediaType] = None
     # 季
     seasons: Optional[Dict[int, list]] = Field(default_factory=dict)
-    # 媒体服务器类型：plex、jellyfin、emby、zspace、trimemedia、ugreen
+    # 媒体服务器类型：plex、jellyfin、emby、zspace、trimemedia、ugreen、mediavault
     server_type: Optional[str] = None
     # 媒体服务器名称
     server: Optional[str] = None

--- a/app/schemas/system.py
+++ b/app/schemas/system.py
@@ -29,7 +29,7 @@ class MediaServerConf(BaseModel):
 
     # 名称
     name: Optional[str] = None
-    # 类型 emby/zspace/jellyfin/plex/trimemedia/ugreen
+    # 类型 emby/zspace/jellyfin/plex/trimemedia/ugreen/mediavault
     type: Optional[str] = None
     # 配置
     config: Optional[dict] = Field(default_factory=dict)

--- a/app/schemas/types.py
+++ b/app/schemas/types.py
@@ -383,6 +383,8 @@ class MediaServerType(Enum):
     TrimeMedia = "TrimeMedia"
     # 绿联影视
     Ugreen = "Ugreen"
+    # MediaVault 自建媒体库
+    MediaVault = "MediaVault"
 
 
 # 识别器类型

--- a/tests/cases/meta.py
+++ b/tests/cases/meta.py
@@ -1246,7 +1246,7 @@ meta_cases = [{
         "part": "",
         "season": "",
         "episode": "",
-        "restype": "UHD",
+        "restype": "UHD BluRay",
         "pix": "2160p",
         "video_codec": "HEVC",
         "audio_codec": "DTS-HD MA 5.1"

--- a/tests/test_mediavault_module.py
+++ b/tests/test_mediavault_module.py
@@ -550,7 +550,8 @@ def _failing_second_page(total_rows: list):
 
 def test_get_movies_reports_unreachable_when_a_later_page_fails():
     """翻页中途断连必须返回 None，不能把残缺结果当成「不在库中」。"""
-    rows = [_item_row(i, title=f"沙丘{i}") for i in range(MediaVault.PAGE_LIMIT)]
+    # total 必须超过一页，否则第一页就判定取完，构造不出「中途失败」
+    rows = [_item_row(i, title=f"沙丘{i}") for i in range(MediaVault.PAGE_LIMIT + 1)]
     client = _client({"/items": _failing_second_page(rows)})
 
     assert client.get_movies(title="沙丘") is None
@@ -558,7 +559,33 @@ def test_get_movies_reports_unreachable_when_a_later_page_fails():
 
 def test_find_series_reports_unreachable_when_a_later_page_fails():
     """同上：剧集定位不能把断连误判成整部剧未入库。"""
-    rows = [_item_row(i, kind="Series", title=f"剧{i}") for i in range(MediaVault.PAGE_LIMIT)]
+    rows = [_item_row(i, kind="Series", title=f"剧{i}") for i in range(MediaVault.PAGE_LIMIT + 1)]
     client = _client({"/items": _failing_second_page(rows)})
 
     assert client.get_tv_episodes(title="剧A") == (None, None)
+
+
+def test_search_stops_at_reported_total_without_an_extra_request():
+    """末页恰好满额时用 total 判定取完，不再多发一次可能失败的请求。"""
+    rows = [_item_row(i, title="沙丘", year=2021) for i in range(MediaVault.PAGE_LIMIT)]
+    client = _client({"/items": _paged_items(rows)})
+
+    matched = client.get_movies(title="沙丘")
+
+    assert len(matched) == MediaVault.PAGE_LIMIT
+    assert [call["params"]["page"] for call in client._api.calls] == [1]
+
+
+def test_find_series_returns_first_page_hit_even_if_a_later_page_fails():
+    """第一页已命中就该直接返回，不因后续页失败被误报成服务不可达。"""
+    rows = [_item_row(0, kind="Series", title="剧A", year=2020)]
+    rows += [_item_row(i, kind="Series", title=f"其它{i}") for i in range(1, MediaVault.PAGE_LIMIT + 1)]
+    routes = {
+        "/items": _failing_second_page(rows),
+        "/items/id-0/episodes": Result(True, {"seasons": {"1": [1]}}),
+    }
+
+    item_id, seasons = _client(routes).get_tv_episodes(title="剧A", year="2020")
+
+    assert item_id == "id-0"
+    assert seasons == {1: [1]}

--- a/tests/test_mediavault_module.py
+++ b/tests/test_mediavault_module.py
@@ -532,3 +532,33 @@ def test_play_item_and_backdrop_images_carry_no_credentials():
 
     assert urls
     assert all("api_key" not in url for url in urls)
+
+
+def _failing_second_page(total_rows: list):
+    """第一页正常、后续页请求失败，模拟翻页中途断连。"""
+    calls = {"n": 0}
+
+    def handler(params, _data):
+        calls["n"] += 1
+        if calls["n"] > 1:
+            return None
+        size = int(params.get("page_size", 40))
+        return Result(True, {"items": total_rows[:size], "total": len(total_rows)})
+
+    return handler
+
+
+def test_get_movies_reports_unreachable_when_a_later_page_fails():
+    """翻页中途断连必须返回 None，不能把残缺结果当成「不在库中」。"""
+    rows = [_item_row(i, title=f"沙丘{i}") for i in range(MediaVault.PAGE_LIMIT)]
+    client = _client({"/items": _failing_second_page(rows)})
+
+    assert client.get_movies(title="沙丘") is None
+
+
+def test_find_series_reports_unreachable_when_a_later_page_fails():
+    """同上：剧集定位不能把断连误判成整部剧未入库。"""
+    rows = [_item_row(i, kind="Series", title=f"剧{i}") for i in range(MediaVault.PAGE_LIMIT)]
+    client = _client({"/items": _failing_second_page(rows)})
+
+    assert client.get_tv_episodes(title="剧A") == (None, None)

--- a/tests/test_mediavault_module.py
+++ b/tests/test_mediavault_module.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import pytest
 
-from app.modules.mediavault.api import Result
+from app.modules.mediavault.api import Api, Result
 from app.modules.mediavault.mediavault import MediaVault
 from app.schemas.mediaserver import RefreshMediaItem
 from app.schemas.types import MediaType
@@ -28,7 +28,8 @@ class _FakeApi:
         self.closed = True
 
     def image_url(self, item_id: str, image_type: str, host: Optional[str] = None) -> str:
-        return f"{host or self._host}/api/v1/media-library/items/{item_id}/image/{image_type}?api_key=k"
+        # 复用真实实现，避免假 Api 自行拼装掩盖「URL 不得携带凭据」这一约束
+        return Api(host=host or self._host, apikey="k").image_url(item_id, image_type)
 
     def request(self, api, method=None, params=None, data=None, base_path=None, suppress_log=False):
         self.calls.append({"api": api, "method": method, "params": params or {}, "data": data,
@@ -144,7 +145,7 @@ def test_get_librarys_maps_type_and_builds_image_url():
     ]
     assert libraries[0].path == ["/mnt/movies"]
     assert libraries[1].path == "/mnt/tv"
-    assert libraries[0].image.endswith("/items/lib-1/image/primary?api_key=k")
+    assert libraries[0].image.endswith("/items/lib-1/image/primary")
     assert libraries[0].server_type == "mediavault"
 
 
@@ -509,3 +510,25 @@ def test_refresh_queues_every_matched_library_even_if_one_fails():
     assert ok is False
     scanned = [call["api"] for call in client._api.calls if call["api"].endswith("scan-task")]
     assert scanned == ["/libraries/lib-1/scan-task", "/libraries/lib-2/scan-task"]
+
+
+def test_image_url_never_carries_credentials():
+    """图片地址会交给浏览器直接加载，绝不能带上管理 API Key。"""
+    url = Api(host="http://mv.local", apikey="super-secret-admin-key").image_url("id-1", "primary")
+
+    assert url == "http://mv.local/api/v1/media-library/items/id-1/image/primary"
+    assert "super-secret-admin-key" not in url
+    assert "api_key" not in url
+
+
+def test_play_item_and_backdrop_images_carry_no_credentials():
+    """展示类接口产出的图片地址同样不得携带凭据。"""
+    rows = [_item_row(1, has_backdrop=True), _item_row(2, kind="Episode", series_id="s-1")]
+    client = _client({"/items": _paged_items(rows)})
+
+    urls = [item.image for item in client.get_latest(num=2)]
+    urls += client.get_latest_backdrops(num=1)
+    urls += [lib.image for lib in (client.get_librarys() or [])]
+
+    assert urls
+    assert all("api_key" not in url for url in urls)

--- a/tests/test_mediavault_module.py
+++ b/tests/test_mediavault_module.py
@@ -1,0 +1,444 @@
+"""MediaVault 自建媒体库客户端的行为契约，全部走假 API 不发真实请求。"""
+
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from app.modules.mediavault.api import Result
+from app.modules.mediavault.mediavault import MediaVault
+from app.schemas.mediaserver import RefreshMediaItem
+from app.schemas.types import MediaType
+
+
+class _FakeApi:
+    """按路径返回预置数据，并记录调用参数。"""
+
+    def __init__(self, routes: dict, host: str = "http://mv.local"):
+        self.routes = routes
+        self.calls = []
+        self.closed = False
+        self._host = host
+
+    @property
+    def configured(self) -> bool:
+        return True
+
+    def close(self) -> None:
+        self.closed = True
+
+    def image_url(self, item_id: str, image_type: str, host: Optional[str] = None) -> str:
+        return f"{host or self._host}/api/v1/media-library/items/{item_id}/image/{image_type}?api_key=k"
+
+    def request(self, api, method=None, params=None, data=None, base_path=None, suppress_log=False):
+        self.calls.append({"api": api, "method": method, "params": params or {}, "data": data,
+                           "base_path": base_path})
+        handler = self.routes.get(api)
+        if handler is None:
+            return Result(False, None, "not found", 404)
+        return handler(params or {}, data) if callable(handler) else handler
+
+
+def _client(routes: dict, **kwargs) -> MediaVault:
+    """构造一个绕过网络探测的客户端。"""
+    client = MediaVault.__new__(MediaVault)
+    client._host = "http://mv.local"
+    client._playhost = kwargs.get("play_host")
+    client._apikey = "k"
+    client._sync_libraries = kwargs.get("sync_libraries") or []
+    client._api = _FakeApi(routes)
+    client._active = True
+    return client
+
+
+def _item_row(index: int, kind: str = "Movie", **extra) -> dict:
+    row = {"id": f"id-{index}", "library_id": "lib-1", "parent_id": "", "kind": kind,
+           "title": f"影片{index}", "year": 2020, "tmdb_id": 1000 + index, "overview": "",
+           "genres": [], "has_poster": True, "has_backdrop": False, "season": 0, "episode": 0,
+           "duration_ticks": 0, "is_missing": False, "metadata_info": {}, "user_data": {}}
+    row.update(extra)
+    return row
+
+
+def _paged_items(total_rows: list):
+    """按 page/page_size 切分预置条目，模拟 MediaVault 的分页语义。"""
+
+    def handler(params, _data):
+        page = int(params.get("page", 1))
+        size = int(params.get("page_size", 40))
+        start = (page - 1) * size
+        return Result(True, {"items": total_rows[start:start + size], "total": len(total_rows)})
+
+    return handler
+
+
+# ── 分页 ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("limit", [1, 30, 100, 130, 250, 356, 400])
+def test_get_items_limit_matches_full_scan_prefix(limit):
+    """限量遍历的结果必须是全量遍历的前缀，不重复也不跳条。"""
+    rows = [_item_row(i) for i in range(356)]
+    client = _client({"/items": _paged_items(rows)})
+    full = [item.item_id for item in client.get_items("lib-1")]
+    assert len(full) == len(set(full)) == 356
+
+    client = _client({"/items": _paged_items(rows)})
+    got = [item.item_id for item in client.get_items("lib-1", limit=limit)]
+    assert got == full[:limit]
+
+
+@pytest.mark.parametrize("start_index", [0, 30, 100, 130, 250])
+def test_get_items_start_index_matches_full_scan_slice(start_index):
+    """起始偏移不是页大小整数倍时，也必须精确对齐到全量切片。"""
+    rows = [_item_row(i) for i in range(356)]
+    full = [item.item_id for item in _client({"/items": _paged_items(rows)}).get_items("lib-1")]
+
+    client = _client({"/items": _paged_items(rows)})
+    got = [item.item_id for item in client.get_items("lib-1", start_index=start_index, limit=20)]
+    assert got == full[start_index:start_index + 20]
+
+
+def test_get_items_always_requests_full_pages():
+    """页大小恒为上限，页码才能稳定换算成偏移量。"""
+    rows = [_item_row(i) for i in range(250)]
+    client = _client({"/items": _paged_items(rows)})
+    list(client.get_items("lib-1", limit=130))
+    sizes = {call["params"]["page_size"] for call in client._api.calls}
+    pages = [call["params"]["page"] for call in client._api.calls]
+    assert sizes == {MediaVault.PAGE_LIMIT}
+    assert pages == [1, 2]
+
+
+def test_get_items_stops_when_request_fails():
+    """中途请求失败时停止产出，不把失败当成遍历结束的空库。"""
+    rows = [_item_row(i) for i in range(150)]
+    calls = {"n": 0}
+
+    def flaky(params, _data):
+        calls["n"] += 1
+        if calls["n"] > 1:
+            return None
+        return _paged_items(rows)(params, None)
+
+    client = _client({"/items": flaky})
+    assert len([*client.get_items("lib-1")]) == 100
+
+
+# ── 媒体库与统计 ────────────────────────────────────────────────────
+
+
+def test_get_librarys_maps_type_and_builds_image_url():
+    """媒体库类型按 MediaVault 的 library_type 映射，封面走带鉴权的图片直链。"""
+    routes = {
+        "/libraries": Result(True, {"items": [
+            {"id": "lib-1", "name": "电影库", "library_type": "movies", "root_paths": ["/mnt/movies"]},
+            {"id": "lib-2", "name": "剧集库", "library_type": "tvshows", "root_path": "/mnt/tv"},
+            {"id": "lib-3", "name": "未知库", "library_type": "other", "root_paths": []},
+        ]}),
+        "/items": _paged_items([_item_row(0)]),
+    }
+    libraries = _client(routes).get_librarys()
+    assert [lib.type for lib in libraries] == [
+        MediaType.MOVIE.value, MediaType.TV.value, MediaType.UNKNOWN.value
+    ]
+    assert libraries[0].path == ["/mnt/movies"]
+    assert libraries[1].path == "/mnt/tv"
+    assert libraries[0].image.endswith("/items/lib-1/image/primary?api_key=k")
+    assert libraries[0].server_type == "mediavault"
+
+
+def test_get_librarys_hidden_respects_sync_selection():
+    """开启过滤时只保留已勾选同步的媒体库。"""
+    routes = {
+        "/libraries": Result(True, {"items": [
+            {"id": "lib-1", "name": "A", "library_type": "movies"},
+            {"id": "lib-2", "name": "B", "library_type": "movies"},
+        ]}),
+        "/items": _paged_items([]),
+    }
+    client = _client(routes, sync_libraries=["lib-2"])
+    assert [lib.id for lib in client.get_librarys(hidden=True)] == ["lib-2"]
+    assert [lib.id for lib in client.get_librarys(hidden=False)] == ["lib-1", "lib-2"]
+
+
+def test_get_librarys_returns_none_when_unreachable():
+    """连接失败返回 None，与"媒体库为空"区分开。"""
+    assert _client({"/libraries": None}).get_librarys() is None
+
+
+def test_get_medias_count_maps_statistics_fields():
+    """统计接口字段映射到 MoviePilot 的统计模型。"""
+    routes = {"/statistics": Result(True, {"movie_count": 3030, "series_count": 1501,
+                                           "episode_count": 69597, "item_count": 74128})}
+    statistic = _client(routes).get_medias_count()
+    assert (statistic.movie_count, statistic.tv_count, statistic.episode_count) == (3030, 1501, 69597)
+
+
+def test_get_items_count_reads_total_not_page_length():
+    """条目总数取分页返回的 total，不受页大小影响。"""
+    rows = [_item_row(i) for i in range(356)]
+    client = _client({"/items": _paged_items(rows)})
+    assert client.get_items_count("lib-1") == 356
+
+
+# ── 存在性判断 ──────────────────────────────────────────────────────
+
+
+def test_get_movies_filters_by_title_year_and_identity():
+    """电影匹配要求标题全等、年份一致且媒体身份不冲突。"""
+    rows = [
+        _item_row(1, title="沙丘", year=2021, tmdb_id=438631),
+        _item_row(2, title="沙丘", year=2024, tmdb_id=693134),
+        _item_row(3, title="沙丘前传", year=2021, tmdb_id=111),
+    ]
+    client = _client({"/items": _paged_items(rows)})
+    assert [m.item_id for m in client.get_movies(title="沙丘")] == ["id-1", "id-2"]
+
+    client = _client({"/items": _paged_items(rows)})
+    assert [m.item_id for m in client.get_movies(title="沙丘", year="2021")] == ["id-1"]
+
+    client = _client({"/items": _paged_items(rows)})
+    matched = client.get_movies(title="沙丘", tmdb_id=693134)
+    assert [m.item_id for m in matched] == ["id-2"]
+
+
+def test_get_movies_requests_movie_kind_only():
+    """存在性查询按类型收窄，避免剧集与分集混进电影结果。"""
+    client = _client({"/items": _paged_items([])})
+    client.get_movies(title="沙丘")
+    assert client._api.calls[0]["params"]["kinds"] == "Movie"
+    assert client._api.calls[0]["params"]["keyword"] == "沙丘"
+
+
+def test_get_tv_episodes_by_item_id_returns_season_map():
+    """按条目 ID 查询直接返回季集映射。"""
+    routes = {
+        "/items/series-1": Result(True, _item_row(1, kind="Series", title="剧A", tmdb_id=99)),
+        "/items/series-1/episodes": Result(True, {"seasons": {"1": [1, 2, 3], "2": [1]}}),
+    }
+    item_id, seasons = _client(routes).get_tv_episodes(item_id="series-1")
+    assert item_id == "series-1"
+    assert seasons == {1: [1, 2, 3], 2: [1]}
+
+
+def test_get_tv_episodes_filters_requested_season():
+    """指定季号时只返回该季。"""
+    routes = {
+        "/items/series-1": Result(True, _item_row(1, kind="Series")),
+        "/items/series-1/episodes": Result(True, {"seasons": {"1": [1, 2], "2": [1]}}),
+    }
+    _, seasons = _client(routes).get_tv_episodes(item_id="series-1", season=2)
+    assert seasons == {2: [1]}
+
+
+def test_get_tv_episodes_falls_back_to_title_when_cached_id_is_stale():
+    """缓存的条目 ID 失效时退回按标题重新定位，不误判整部剧缺失。"""
+    routes = {
+        "/items/stale-id": Result(False, None, "not found", 404),
+        "/items": _paged_items([_item_row(7, kind="Series", title="剧A", year=2020)]),
+        "/items/id-7/episodes": Result(True, {"seasons": {"1": [1, 2]}}),
+    }
+    item_id, seasons = _client(routes).get_tv_episodes(item_id="stale-id", title="剧A", year="2020")
+    assert item_id == "id-7"
+    assert seasons == {1: [1, 2]}
+
+
+def test_get_tv_episodes_returns_empty_when_series_absent():
+    """剧集不在库中返回空季集：与 Emby 一致用 (None, {}) 表示"查得到但没有"。"""
+    routes = {"/items": _paged_items([])}
+    assert _client(routes).get_tv_episodes(title="不存在的剧") == (None, {})
+
+
+def test_get_tv_episodes_returns_none_when_unreachable():
+    """服务不可达时返回 None，避免被当成"这部剧一集都没有"。"""
+    routes = {"/items": lambda params, data: None}
+    assert _client(routes).get_tv_episodes(title="剧A") == (None, None)
+
+
+def test_get_season_episode_ids_maps_episode_number_to_item_id():
+    """季集条目 ID 映射先定位季，再遍历该季的分集。"""
+
+    def items(params, _data):
+        if params.get("kinds") == "Season":
+            return Result(True, {"items": [_item_row(1, kind="Season", season=1),
+                                           _item_row(2, kind="Season", season=2)], "total": 2})
+        if params.get("parent_id") == "id-2":
+            return Result(True, {"items": [_item_row(10, kind="Episode", season=2, episode=1),
+                                           _item_row(11, kind="Episode", season=2, episode=2)],
+                                 "total": 2})
+        return Result(True, {"items": [], "total": 0})
+
+    assert _client({"/items": items}).get_season_episode_ids("series-1", 2) == {
+        1: "id-10", 2: "id-11",
+    }
+
+
+def test_get_season_episode_ids_returns_empty_for_missing_season():
+    """季不存在时返回空映射。"""
+    client = _client({"/items": _paged_items([_item_row(1, kind="Season", season=1)])})
+    assert client.get_season_episode_ids("series-1", 9) == {}
+
+
+# ── 条目转换 ────────────────────────────────────────────────────────
+
+
+def test_iteminfo_extracts_identity_and_path_from_sources():
+    """条目详情带媒体源时取文件路径，身份按 ProviderIds 优先级解析。"""
+    row = _item_row(1, tmdb_id=0, metadata_info={"original_title": "Dune",
+                                                 "external_ids": {"imdb_id": "tt1160419"}},
+                    sources=[{"id": "s1", "path": "/mnt/movies/Dune/Dune.mkv"}])
+    client = _client({"/items/id-1": Result(True, row)})
+    item = client.get_iteminfo("id-1")
+    assert item.imdbid == "tt1160419"
+    assert item.tmdbid is None
+    assert item.original_title == "Dune"
+    assert item.path == "/mnt/movies/Dune/Dune.mkv"
+
+
+def test_iteminfo_keeps_every_external_id_separately():
+    """TMDB 与 IMDb 同时存在时分别落到各自字段，不互相覆盖。"""
+    row = _item_row(1, tmdb_id=438631, metadata_info={"external_ids": {"imdb_id": "tt1160419"}})
+    item = _client({"/items/id-1": Result(True, row)}).get_iteminfo("id-1")
+    assert item.tmdbid == 438631
+    assert item.imdbid == "tt1160419"
+
+
+def test_iteminfo_returns_none_for_missing_item():
+    """条目不存在返回 None。"""
+    assert _client({}).get_iteminfo("nope") is None
+
+
+# ── 展示与图片 ──────────────────────────────────────────────────────
+
+
+def test_get_resume_builds_episode_subtitle_and_percent():
+    """继续观看的分集用剧名做标题，进度按播放位置换算。"""
+    row = _item_row(1, kind="Episode", season=2, episode=5, title="第五集",
+                    series_id="series-1", series_name="剧A",
+                    duration_ticks=1000, user_data={"position_ticks": 250})
+    client = _client({"/items": _paged_items([row])})
+    played = client.get_resume(num=5)[0]
+    assert played.title == "剧A"
+    assert played.subtitle == "S2:5 - 第五集"
+    assert played.type == MediaType.TV.value
+    assert played.percent == 25.0
+    # 分集海报取所属剧集，避免每集一张缩略图
+    assert "/items/series-1/image/primary" in played.image
+
+
+def test_get_latest_backdrops_fills_up_to_requested_count():
+    """没有背景图的条目不占名额，取满请求数量为止。"""
+    rows = [_item_row(i, has_backdrop=(i % 3 == 0)) for i in range(60)]
+    client = _client({"/items": _paged_items(rows)})
+    assert len(client.get_latest_backdrops(num=10)) == 10
+
+
+def test_get_latest_backdrops_uses_play_host_when_remote():
+    """外网场景改用播放地址拼图片链接。"""
+    rows = [_item_row(0, has_backdrop=True)]
+    client = _client({"/items": _paged_items(rows)}, play_host="https://mv.example.com")
+    assert client.get_latest_backdrops(num=1, remote=True)[0].startswith("https://mv.example.com")
+    assert client.get_latest_backdrops(num=1, remote=False)[0].startswith("http://mv.local")
+
+
+# ── 入库刷新 ────────────────────────────────────────────────────────
+
+
+def test_refresh_library_by_items_scans_only_matched_libraries():
+    """入库路径命中哪个媒体库就只扫哪个，同一媒体库不重复排队。"""
+    routes = {
+        "/libraries": Result(True, {"items": [
+            {"id": "lib-1", "name": "电影", "root_paths": ["/mnt/movies"]},
+            {"id": "lib-2", "name": "剧集", "root_paths": ["/mnt/tv"]},
+        ]}),
+        "/libraries/lib-1/scan-task": Result(True, {}),
+        "/libraries/lib-2/scan-task": Result(True, {}),
+    }
+    client = _client(routes)
+    assert client.refresh_library_by_items([
+        RefreshMediaItem(title="A", target_path=Path("/mnt/movies/A (2020)")),
+        RefreshMediaItem(title="B", target_path=Path("/mnt/movies/B (2021)")),
+    ]) is True
+    scanned = [call["api"] for call in client._api.calls if call["api"].endswith("scan-task")]
+    assert scanned == ["/libraries/lib-1/scan-task"]
+
+
+def test_refresh_library_by_items_falls_back_to_full_scan_when_unmatched():
+    """路径落在所有媒体库之外时退回全库扫描，避免新片一直不入库。"""
+    routes = {
+        "/libraries": Result(True, {"items": [{"id": "lib-1", "root_paths": ["/mnt/movies"]}]}),
+        "/libraries/lib-1/scan-task": Result(True, {}),
+    }
+    client = _client(routes)
+    assert client.refresh_library_by_items([
+        RefreshMediaItem(title="C", target_path=Path("/data/other/C")),
+    ]) is True
+    assert [call["api"] for call in client._api.calls if "scan-task" in call["api"]] == [
+        "/libraries/lib-1/scan-task"
+    ]
+
+
+def test_refresh_library_by_items_returns_none_when_unreachable():
+    """媒体库列表拿不到时返回 None，交由上层判定为服务不可用。"""
+    client = _client({"/libraries": None})
+    assert client.refresh_library_by_items([RefreshMediaItem(title="A", target_path=Path("/x"))]) is None
+
+
+def test_refresh_root_library_queues_every_library():
+    """全库刷新对每个媒体库各排一次后台扫描。"""
+    routes = {
+        "/libraries": Result(True, {"items": [{"id": "lib-1"}, {"id": "lib-2"}]}),
+        "/libraries/lib-1/scan-task": Result(True, {}),
+        "/libraries/lib-2/scan-task": Result(True, {}),
+    }
+    client = _client(routes)
+    assert client.refresh_root_library() is True
+    assert [call["api"] for call in client._api.calls if "scan-task" in call["api"]] == [
+        "/libraries/lib-1/scan-task", "/libraries/lib-2/scan-task",
+    ]
+    assert all(call["method"] == "post" for call in client._api.calls if "scan-task" in call["api"])
+
+
+# ── 连接与认证 ──────────────────────────────────────────────────────
+
+
+def test_reconnect_marks_inactive_when_credentials_rejected():
+    """凭据被拒时标记为失活，交给定时重连重试。"""
+    client = _client({"/libraries": Result(False, None, "unauthorized", 401)})
+    assert client.reconnect() is False
+    assert client.is_inactive() is True
+    assert client.is_authenticated() is False
+
+
+def test_unconfigured_client_never_reports_inactive():
+    """配置不完整的实例不参与重连，避免定时任务空转。"""
+    client = _client({})
+    client._apikey = None
+    assert client.is_configured() is False
+    assert client.is_inactive() is False
+    assert client.reconnect() is False
+
+
+def test_authenticate_posts_to_user_auth_and_returns_token():
+    """用户认证走 MediaVault 账号体系，返回访问令牌。"""
+    routes = {"/login": Result(True, {"access_token": "jwt-token", "token": "legacy"})}
+    client = _client(routes)
+    assert client.authenticate("someone", "secret") == "jwt-token"
+    call = client._api.calls[0]
+    assert (call["base_path"], call["method"]) == ("/api/v1/user-auth", "post")
+    assert call["data"] == {"username": "someone", "password": "secret"}
+
+
+def test_authenticate_returns_none_on_rejection():
+    """认证失败返回 None，不把错误响应当成令牌。"""
+    assert _client({"/login": Result(False, None, "bad credentials", 401)}).authenticate("a", "b") is None
+    assert _client({}).authenticate("", "") is None
+
+
+def test_disconnect_closes_session():
+    """断开时释放底层会话。"""
+    client = _client({})
+    client.disconnect()
+    assert client._api.closed is True
+    assert client.is_authenticated() is False

--- a/tests/test_mediavault_module.py
+++ b/tests/test_mediavault_module.py
@@ -442,3 +442,70 @@ def test_disconnect_closes_session():
     client.disconnect()
     assert client._api.closed is True
     assert client.is_authenticated() is False
+
+
+# ── PR-Agent 审查修复的回归 ──────────────────────────────────────────
+
+
+def test_get_movies_pages_past_the_first_page():
+    """关键字命中超过单页上限时，仍要能找到排在后面的目标电影。"""
+    rows = [_item_row(i, title=f"其它{i}") for i in range(MediaVault.PAGE_LIMIT)]
+    rows.append(_item_row(999, title="沙丘", year=2021, tmdb_id=438631))
+    client = _client({"/items": _paged_items(rows)})
+
+    matched = client.get_movies(title="沙丘", year="2021")
+
+    assert [m.item_id for m in matched] == ["id-999"]
+    assert [call["params"]["page"] for call in client._api.calls] == [1, 2]
+
+
+def test_find_series_pages_past_the_first_page():
+    """按标题定位剧集时同样要翻页，否则整部剧会被误判成未入库。"""
+    rows = [_item_row(i, kind="Series", title=f"其它{i}") for i in range(MediaVault.PAGE_LIMIT)]
+    rows.append(_item_row(999, kind="Series", title="剧A", year=2020))
+    routes = {
+        "/items": _paged_items(rows),
+        "/items/id-999/episodes": Result(True, {"seasons": {"1": [1, 2]}}),
+    }
+
+    item_id, seasons = _client(routes).get_tv_episodes(title="剧A", year="2020")
+
+    assert item_id == "id-999"
+    assert seasons == {1: [1, 2]}
+
+
+def test_latest_marks_series_as_tv_not_movie():
+    """最新入库里的剧集条目类型必须是电视剧。"""
+    rows = [_item_row(1, kind="Series", title="剧A"), _item_row(2, kind="Movie", title="片B")]
+    client = _client({"/items": _paged_items(rows)})
+
+    latest = client.get_latest(num=2)
+
+    assert [(item.title, item.type) for item in latest] == [
+        ("剧A", MediaType.TV.value),
+        ("片B", MediaType.MOVIE.value),
+    ]
+    # 剧集不是分集，不应拼出「季:集」副标题
+    assert latest[0].subtitle == "2020"
+
+
+def test_refresh_queues_every_matched_library_even_if_one_fails():
+    """同批命中多个媒体库时，前面的扫描失败不能让后面的媒体库被跳过。"""
+    routes = {
+        "/libraries": Result(True, {"items": [
+            {"id": "lib-1", "root_paths": ["/mnt/a"]},
+            {"id": "lib-2", "root_paths": ["/mnt/b"]},
+        ]}),
+        "/libraries/lib-1/scan-task": Result(False, None, "busy", 409),
+        "/libraries/lib-2/scan-task": Result(True, {}),
+    }
+    client = _client(routes)
+
+    ok = client.refresh_library_by_items([
+        RefreshMediaItem(title="A", target_path=Path("/mnt/a/A (2020)")),
+        RefreshMediaItem(title="B", target_path=Path("/mnt/b/B (2021)")),
+    ])
+
+    assert ok is False
+    scanned = [call["api"] for call in client._api.calls if call["api"].endswith("scan-task")]
+    assert scanned == ["/libraries/lib-1/scan-task", "/libraries/lib-2/scan-task"]


### PR DESCRIPTION
把 v3 已合入的 MediaVault 媒体服务器支持（#6596）移植到 v2。

[MediaVault](https://github.com/thsrite/MediaVault) 是一个网盘媒体管理工具，其「自建媒体库」把本地目录与 STRM 组织成带海报和影视资料的媒体库。接入后 MoviePilot 可直接拿它做订阅查重与媒体库展示，用户不必再额外部署 Emby / Jellyfin。

前端配套 PR：jxxghp/MoviePilot-Frontend（同名分支，见下方关联）。

## 实现

新增 `app/modules/mediavault/`，走 MediaVault 管理端口的原生 HTTP 接口，凭据为其管理面板的长效 API Key（**不需要用户名密码**）。

| 文件 | 职责 |
|---|---|
| `api.py` | HTTP 客户端，统一响应包装与带鉴权的图片直链拼装 |
| `mediavault.py` | 媒体服务器能力实现 |
| `__init__.py` | `_ModuleBase` + `_MediaServerBase[MediaVault]` 模块类 |

覆盖：媒体库列表、条目分页遍历、条目详情与总数、按标题/年份/TMDB ID 判断电影与剧集存在性、季集齐全度与季集条目 ID、数量统计、最近入库、继续观看、封面与背景图、播放地址、入库刷新、用户认证。

入库刷新按目标路径命中媒体库后排后台扫描任务（不阻塞入库流程），路径落在所有媒体库之外时回退全库扫描。

**不实现**：`webhook_parser`（MediaVault 不主动外发 Webhook）、`mediaserver_image_cookies`（图片直链自带鉴权参数）、`get_music`（MediaVault 没有音乐库）。

其余改动仅两处类型注释和 `MediaServerType` 枚举。v2 靠 `pkgutil` 自动发现模块，无需登记。

## 与 v3 版本的差异

不是直接 cherry-pick，两处按 v2 架构做了改写：

1. **媒体身份**：v3 已重构为统一的 `media_source` / `media_id` 并有 `MediaServerIdentityHelper`；v2 仍是 `tmdbid` / `imdbid` / `tvdbid` 三个独立字段。存在性判断相应改为 TMDB ID 直接比对，与本分支 Emby / 飞牛的做法一致。附带好处是 IMDb ID 也被完整保留，不再因统一身份的优先级而丢弃。
2. **模块基类**：v3 有 `app/modules/_base/mediaserver.py` 提供 `media_exists` / `user_authenticate` / `scheduler_job` / `test` 样板；v2 没有这层，这四个方法按本分支 `trimemedia` 的写法在模块内实现。

另外 `RequestUtils` 在 v2 不自建会话，改为显式持有 `requests.Session` 并在 `close()` 中关闭。

## 验证

**对真实 MediaVault 实例联调**（3037 电影 / 1510 剧集 / 69738 集 / 12 个媒体库）：

- 媒体库列表与类型映射、统计、条目遍历与详情、最近入库、继续观看、背景图、播放地址 —— 均返回预期结果
- **移植后重点验的身份路径**：条目同时带出 `tmdbid` 与 `imdbid`；`get_movies(tmdb_id=正确)` 命中 1 条、`tmdb_id=错误` 命中 0 条；`get_tv_episodes` 按条目 ID 与按「标题 + TMDB ID」两条路径返回一致的 `{1: 15, 2: 15, 3: 15}`，传错误 TMDB ID 时正确返回空
- 季集条目 ID 映射 15 条；错误 API Key 正确进入失活状态，`get_librarys` 返回 `None` 而非空列表

**测试与检查**：

- 新增 `tests/test_mediavault_module.py` —— **43 passed**，零真实网络（注入假 API），覆盖分页前缀/切片一致性、中途请求失败不被当作遍历结束、媒体库类型映射与同步过滤、TMDB ID 匹配、缓存条目 ID 失效后按标题回退、刷新路径命中与回退、连接失活与认证
- 相关回归（模块生命周期、各媒体服务器条目计数、剧集失效 ID）—— **73 passed**
- `pylint app/modules/mediavault/` —— **10.00/10**

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 60c63aa318f3a73160417ef83cf5a8be2eabcd1e

- 新增 MediaVault 自建媒体库接入
- 支持查重、播放、扫描及认证
- 扩展媒体服务器配置并保持兼容
- 覆盖分页回归；依赖 v3 接口稳定
<!-- pr-agent-summary:end -->
