### PR TITLE
fix(scraping): 补充豆瓣图片下载 Referer 避免触发 418 防盗链

### DIFF
--- a/app/startup/composition/network.py
+++ b/app/startup/composition/network.py
@@ -283,7 +283,14 @@ class _ScrapingHttpAdapter:
         timeout: int,
     ) -> Optional[ScrapingResponsePort]:
         """读取需要完整载荷的音乐封面响应。"""
-        options: dict[str, Any] = {"proxies": proxies, "ua": ua, "timeout": timeout}
+        options: dict[str, Any] = {
+            "proxies": proxies,
+            "ua": ua,
+            "timeout": timeout,
+            "referer": (
+                "https://movie.douban.com/" if "doubanio.com" in url else None
+            ),
+        }
         response = RequestUtils(**options).get_res(url)
         return cast(Optional[ScrapingResponsePort], response)
 
@@ -295,7 +302,13 @@ class _ScrapingHttpAdapter:
         ua: str,
     ) -> ScrapingStreamResponsePort:
         """打开由刮削链上下文关闭的流式图片响应。"""
-        options: dict[str, Any] = {"proxies": proxies, "ua": ua}
+        options: dict[str, Any] = {
+            "proxies": proxies,
+            "ua": ua,
+            "referer": (
+                "https://movie.douban.com/" if "doubanio.com" in url else None
+            ),
+        }
         response = RequestUtils(**options).get_stream(url=url)
         return cast(ScrapingStreamResponsePort, response)
 


### PR DESCRIPTION
### 问题描述

当媒体识别来源匹配到豆瓣（如部分华语电影、国漫或冷门剧集）时，图片来源为豆瓣 CDN（`img*.doubanio.com`）。
豆瓣 CDN 开启了防盗链校验，未携带 `Referer` 头部的 HTTP 请求会直接返回 `HTTP 418`，导致刮削图片下载中断，日志报：
`https://img*.doubanio.com/... 图片下载失败`

项目中 `app/application/image.py`（内部图片预览代理）已包含针对 `doubanio.com` 注入 `Referer: https://movie.douban.com/` 的逻辑，但刮削端口实现类 `_ScrapingHttpAdapter` 的 `get` 和 `stream` 未透传 `Referer`。

### 解决方案

在 `app/startup/composition/network.py` 中的 `_ScrapingHttpAdapter.get` 和 `_ScrapingHttpAdapter.stream` 中，针对包含 `doubanio.com` 的图片请求补充 `referer="https://movie.douban.com/"`，与 `app/application/image.py` 的防盗链处理逻辑保持一致。

### 测试验证

- 实测在携带 `Referer: https://movie.douban.com/` 后，豆瓣图片下载返回 `HTTP 200` 并成功保存落盘。
- 非豆瓣域名不受任何影响，保持原有行为。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 3ea745e058364017dc62e8f49331c0d9d750eeb2

- 为豆瓣 CDN 图片请求注入 Referer
- 覆盖完整读取与流式下载路径
- 非豆瓣 URL 保持原有请求行为
- 未新增自动化测试；依赖现有请求实现
<!-- pr-agent-summary:end -->
